### PR TITLE
space-after-if-condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "prettier plugin for solidity",
   "main": "src",
   "scripts": {

--- a/src/printer.js
+++ b/src/printer.js
@@ -44,6 +44,7 @@ function genericPrint(path, options, print) {
         ]);
       }
       return concat([
+        line,
         doc,
         ' {',
         indent(line),
@@ -281,7 +282,7 @@ function genericPrint(path, options, print) {
       doc = concat([
         'if (',
         path.call(print, 'condition'),
-        ')',
+        ') ',
         path.call(print, 'trueBody')
       ]);
       if (node.falseBody) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -68,7 +68,11 @@ function genericPrint(path, options, print) {
       return concat(['using ', node.libraryName, ' for *;']);
     case 'FunctionDefinition':
       if (node.isConstructor) {
-        doc = 'constructor';
+        if (node.name) {
+          doc = `function ${node.name}`;
+        } else {
+          doc = 'constructor';
+        }
       } else if (node.name === '') {
         doc = 'function';
       } else {

--- a/tests/BasicIterator/BasicIterator.sol
+++ b/tests/BasicIterator/BasicIterator.sol
@@ -1,0 +1,44 @@
+/*
+	This is a very simple demonstration of a while loops. Same as JS/c.
+*/
+
+contract BasicIterator {
+
+    address creator;                  // reserve one "address"-type spot
+    uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
+
+    function BasicIterator() 
+    {
+        creator = msg.sender;         // set the creator address
+        uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero
+        while(x < integers.length)    // the variable integers was initialized to length 10
+        {
+        	integers[x] = x;      // set integers to [0,1,2,3,4,5,6,7,8,9] over ten iterations
+        	x++;
+        }
+    }
+    
+    function getSum() constant returns (uint)  // "constant" just means this function returns something to the caller
+    {                                          // which is immediately followed by what type gets returned, in this case a full uint256
+    	uint8 sum = 0;
+    	uint8 x = 0;
+    	while(x < integers.length)
+        {
+        	sum = sum + integers[x];
+        	x++;
+        }
+    	return sum;
+    }
+    
+    /**********
+     Standard kill() function to recover funds 
+     **********/
+    
+    function kill()
+    { 
+        if (msg.sender == creator)
+        {
+            suicide(creator);  // kills this contract and sends remaining funds back to creator
+        }
+    }
+}

--- a/tests/BasicIterator/BasicIterator.sol
+++ b/tests/BasicIterator/BasicIterator.sol
@@ -7,7 +7,7 @@ contract BasicIterator {
     address creator;                  // reserve one "address"-type spot
     uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
 
-    constructor() 
+    function BasicIterator() 
     {
         creator = msg.sender;         // set the creator address
         uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero

--- a/tests/BasicIterator/BasicIterator.sol
+++ b/tests/BasicIterator/BasicIterator.sol
@@ -7,7 +7,7 @@ contract BasicIterator {
     address creator;                  // reserve one "address"-type spot
     uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
 
-    function BasicIterator() 
+    constructor() 
     {
         creator = msg.sender;         // set the creator address
         uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ contract BasicIterator {
     address creator;                  // reserve one "address"-type spot
     uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
 
-    constructor() 
+    function BasicIterator() 
     {
         creator = msg.sender;         // set the creator address
         uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero
@@ -51,7 +51,7 @@ contract BasicIterator {
   address creator;
   uint8[10] integers;
 
-  constructor() {
+  function BasicIterator() {
     creator = msg.sender;
     uint8 x = 0;
     while (x < integers.length) {

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ contract BasicIterator {
     address creator;                  // reserve one "address"-type spot
     uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
 
-    function BasicIterator() 
+    constructor() 
     {
         creator = msg.sender;         // set the creator address
         uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BasicIterator.sol 1`] = `
+/*
+	This is a very simple demonstration of a while loops. Same as JS/c.
+*/
+
+contract BasicIterator {
+
+    address creator;                  // reserve one "address"-type spot
+    uint8[10] integers;               // reserve a chunk of storage for 10 8-bit unsigned integers in an array
+
+    function BasicIterator() 
+    {
+        creator = msg.sender;         // set the creator address
+        uint8 x = 0;                  // initialize an 8-bit, unsigned integer to zero
+        while(x < integers.length)    // the variable integers was initialized to length 10
+        {
+        	integers[x] = x;      // set integers to [0,1,2,3,4,5,6,7,8,9] over ten iterations
+        	x++;
+        }
+    }
+    
+    function getSum() constant returns (uint)  // "constant" just means this function returns something to the caller
+    {                                          // which is immediately followed by what type gets returned, in this case a full uint256
+    	uint8 sum = 0;
+    	uint8 x = 0;
+    	while(x < integers.length)
+        {
+        	sum = sum + integers[x];
+        	x++;
+        }
+    	return sum;
+    }
+    
+    /**********
+     Standard kill() function to recover funds 
+     **********/
+    
+    function kill()
+    { 
+        if (msg.sender == creator)
+        {
+            suicide(creator);  // kills this contract and sends remaining funds back to creator
+        }
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+contract BasicIterator {
+  address creator;
+  uint8[10] integers;
+
+  constructor() {
+    creator = msg.sender;
+    uint8 x = 0;
+    while (x < integers.length) {
+      integers[x] = x;
+      x++;
+    }
+  }
+
+  function getSum() constant returns(uint) {
+    uint8 sum = 0;
+    uint8 x = 0;
+    while (x < integers.length) {
+      sum = sum + integers[x];
+      x++;
+    }
+    return sum;
+  }
+
+  function kill() {
+    if (msg.sender == creator) {
+      suicide(creator);
+    }
+  }
+}
+
+`;

--- a/tests/BasicIterator/jsfmt.spec.js
+++ b/tests/BasicIterator/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/SimpleAuction/SimpleAuction.sol
+++ b/tests/SimpleAuction/SimpleAuction.sol
@@ -1,0 +1,123 @@
+pragma solidity ^0.4.22;
+
+contract SimpleAuction {
+    // Parameters of the auction. Times are either
+    // absolute unix timestamps (seconds since 1970-01-01)
+    // or time periods in seconds.
+    address public beneficiary;
+    uint public auctionEnd;
+
+    // Current state of the auction.
+    address public highestBidder;
+    uint public highestBid;
+
+    // Allowed withdrawals of previous bids
+    mapping(address => uint) pendingReturns;
+
+    // Set to true at the end, disallows any change
+    bool ended;
+
+    // Events that will be fired on changes.
+    event HighestBidIncreased(address bidder, uint amount);
+    event AuctionEnded(address winner, uint amount);
+
+    // The following is a so-called natspec comment,
+    // recognizable by the three slashes.
+    // It will be shown when the user is asked to
+    // confirm a transaction.
+
+    /// Create a simple auction with `_biddingTime`
+    /// seconds bidding time on behalf of the
+    /// beneficiary address `_beneficiary`.
+    constructor(
+        uint _biddingTime,
+        address _beneficiary
+    ) public {
+        beneficiary = _beneficiary;
+        auctionEnd = now + _biddingTime;
+    }
+
+    /// Bid on the auction with the value sent
+    /// together with this transaction.
+    /// The value will only be refunded if the
+    /// auction is not won.
+    function bid() public payable {
+        // No arguments are necessary, all
+        // information is already part of
+        // the transaction. The keyword payable
+        // is required for the function to
+        // be able to receive Ether.
+
+        // Revert the call if the bidding
+        // period is over.
+        require(
+            now <= auctionEnd,
+            "Auction already ended."
+        );
+
+        // If the bid is not higher, send the
+        // money back.
+        require(
+            msg.value > highestBid,
+            "There already is a higher bid."
+        );
+
+        if (highestBid != 0) {
+            // Sending back the money by simply using
+            // highestBidder.send(highestBid) is a security risk
+            // because it could execute an untrusted contract.
+            // It is always safer to let the recipients
+            // withdraw their money themselves.
+            pendingReturns[highestBidder] += highestBid;
+        }
+        highestBidder = msg.sender;
+        highestBid = msg.value;
+        emit HighestBidIncreased(msg.sender, msg.value);
+    }
+
+    /// Withdraw a bid that was overbid.
+    function withdraw() public returns (bool) {
+        uint amount = pendingReturns[msg.sender];
+        if (amount > 0) {
+            // It is important to set this to zero because the recipient
+            // can call this function again as part of the receiving call
+            // before `send` returns.
+            pendingReturns[msg.sender] = 0;
+
+            if (!msg.sender.send(amount)) {
+                // No need to call throw here, just reset the amount owing
+                pendingReturns[msg.sender] = amount;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// End the auction and send the highest bid
+    /// to the beneficiary.
+    function auctionEnd() public {
+        // It is a good guideline to structure functions that interact
+        // with other contracts (i.e. they call functions or send Ether)
+        // into three phases:
+        // 1. checking conditions
+        // 2. performing actions (potentially changing conditions)
+        // 3. interacting with other contracts
+        // If these phases are mixed up, the other contract could call
+        // back into the current contract and modify the state or cause
+        // effects (ether payout) to be performed multiple times.
+        // If functions called internally include interaction with external
+        // contracts, they also have to be considered interaction with
+        // external contracts.
+
+        // 1. Conditions
+        require(now >= auctionEnd, "Auction not yet ended.");
+        require(!ended, "auctionEnd has already been called.");
+
+        // 2. Effects
+        ended = true;
+        emit AuctionEnded(highestBidder, highestBid);
+
+        // 3. Interaction
+        beneficiary.transfer(highestBid);
+    }
+}

--- a/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SimpleAuction.sol 1`] = `
+pragma solidity ^0.4.22;
+
+contract SimpleAuction {
+    // Parameters of the auction. Times are either
+    // absolute unix timestamps (seconds since 1970-01-01)
+    // or time periods in seconds.
+    address public beneficiary;
+    uint public auctionEnd;
+
+    // Current state of the auction.
+    address public highestBidder;
+    uint public highestBid;
+
+    // Allowed withdrawals of previous bids
+    mapping(address => uint) pendingReturns;
+
+    // Set to true at the end, disallows any change
+    bool ended;
+
+    // Events that will be fired on changes.
+    event HighestBidIncreased(address bidder, uint amount);
+    event AuctionEnded(address winner, uint amount);
+
+    // The following is a so-called natspec comment,
+    // recognizable by the three slashes.
+    // It will be shown when the user is asked to
+    // confirm a transaction.
+
+    /// Create a simple auction with \`_biddingTime\`
+    /// seconds bidding time on behalf of the
+    /// beneficiary address \`_beneficiary\`.
+    constructor(
+        uint _biddingTime,
+        address _beneficiary
+    ) public {
+        beneficiary = _beneficiary;
+        auctionEnd = now + _biddingTime;
+    }
+
+    /// Bid on the auction with the value sent
+    /// together with this transaction.
+    /// The value will only be refunded if the
+    /// auction is not won.
+    function bid() public payable {
+        // No arguments are necessary, all
+        // information is already part of
+        // the transaction. The keyword payable
+        // is required for the function to
+        // be able to receive Ether.
+
+        // Revert the call if the bidding
+        // period is over.
+        require(
+            now <= auctionEnd,
+            "Auction already ended."
+        );
+
+        // If the bid is not higher, send the
+        // money back.
+        require(
+            msg.value > highestBid,
+            "There already is a higher bid."
+        );
+
+        if (highestBid != 0) {
+            // Sending back the money by simply using
+            // highestBidder.send(highestBid) is a security risk
+            // because it could execute an untrusted contract.
+            // It is always safer to let the recipients
+            // withdraw their money themselves.
+            pendingReturns[highestBidder] += highestBid;
+        }
+        highestBidder = msg.sender;
+        highestBid = msg.value;
+        emit HighestBidIncreased(msg.sender, msg.value);
+    }
+
+    /// Withdraw a bid that was overbid.
+    function withdraw() public returns (bool) {
+        uint amount = pendingReturns[msg.sender];
+        if (amount > 0) {
+            // It is important to set this to zero because the recipient
+            // can call this function again as part of the receiving call
+            // before \`send\` returns.
+            pendingReturns[msg.sender] = 0;
+
+            if (!msg.sender.send(amount)) {
+                // No need to call throw here, just reset the amount owing
+                pendingReturns[msg.sender] = amount;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// End the auction and send the highest bid
+    /// to the beneficiary.
+    function auctionEnd() public {
+        // It is a good guideline to structure functions that interact
+        // with other contracts (i.e. they call functions or send Ether)
+        // into three phases:
+        // 1. checking conditions
+        // 2. performing actions (potentially changing conditions)
+        // 3. interacting with other contracts
+        // If these phases are mixed up, the other contract could call
+        // back into the current contract and modify the state or cause
+        // effects (ether payout) to be performed multiple times.
+        // If functions called internally include interaction with external
+        // contracts, they also have to be considered interaction with
+        // external contracts.
+
+        // 1. Conditions
+        require(now >= auctionEnd, "Auction not yet ended.");
+        require(!ended, "auctionEnd has already been called.");
+
+        // 2. Effects
+        ended = true;
+        emit AuctionEnded(highestBidder, highestBid);
+
+        // 3. Interaction
+        beneficiary.transfer(highestBid);
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.4.22;
+
+contract SimpleAuction {
+  address public beneficiary;
+  uint public auctionEnd;
+  address public highestBidder;
+  uint public highestBid;
+  mapping(address => uint) pendingReturns;
+  bool ended;
+  event HighestBidIncreased(address bidder, uint amount);
+  event AuctionEnded(address winner, uint amount);
+
+  constructor(uint _biddingTime, address _beneficiary) public {
+    beneficiary = _beneficiary;
+    auctionEnd = now + _biddingTime;
+  }
+
+  function bid() public payable {
+    require(now <= auctionEnd, "Auction already ended.");
+    require(msg.value > highestBid, "There already is a higher bid.");
+    if (highestBid != 0) {
+      pendingReturns[highestBidder] += highestBid;
+    }
+    highestBidder = msg.sender;
+    highestBid = msg.value;
+    emit HighestBidIncreased(msg.sender, msg.value);
+  }
+
+  function withdraw() public returns(bool) {
+    uint amount = pendingReturns[msg.sender];
+    if (amount > 0) {
+      pendingReturns[msg.sender] = 0;
+      if (!msg.sender.send(amount)) {
+        pendingReturns[msg.sender] = amount;
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function auctionEnd() public {
+    require(now >= auctionEnd, "Auction not yet ended.");
+    require(!ended, "auctionEnd has already been called.");
+    ended = true;
+    emit AuctionEnded(highestBidder, highestBid);
+    beneficiary.transfer(highestBid);
+  }
+}
+
+`;

--- a/tests/SimpleAuction/jsfmt.spec.js
+++ b/tests/SimpleAuction/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/__snapshots__/jsfmt.spec.js.snap
@@ -26,6 +26,7 @@ contract Inbox {
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.23;
+
 contract Inbox {
   string public message;
 
@@ -118,6 +119,7 @@ contract Ownable {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.24;
+
 contract Ownable {
   address private _owner;
   event OwnershipRenounced(address indexed previousOwner);
@@ -177,6 +179,7 @@ contract SimpleStorage {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.0;
+
 contract SimpleStorage {
   string public name = "SimpleStorage";
   uint storedData;


### PR DESCRIPTION
# Description

- add a line before `ContractDefinition` 

- add space after the condition for `IfStatement`

- fix #37 

- fix #38 
