### PR TITLE
Preserve empty lines

### DIFF
--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -83,7 +83,5 @@ contract BasicIterator {
       suicide(creator); // kills this contract and sends remaining funds back to creator
     }
   }
-
 }
-
 `;

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,6 @@ contract BasicIterator {
 	This is a very simple demonstration of a while loops. Same as JS/c.
 */
 
-
 contract BasicIterator {
   address creator; // reserve one "address"-type spot
   uint8[10] integers; // reserve a chunk of storage for 10 8-bit unsigned integers in an array
@@ -74,16 +73,17 @@ contract BasicIterator {
     }
     return sum;
   }
+
   /**********
      Standard kill() function to recover funds 
      **********/
-
 
   function kill() {
     if (msg.sender == creator) {
       suicide(creator); // kills this contract and sends remaining funds back to creator
     }
   }
+
 }
 
 `;

--- a/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
@@ -36,7 +36,6 @@ lines.
 */
 
 pragma solidity ^0.4.23;
-
 contract Inbox {
   string public message;
 
@@ -47,6 +46,7 @@ contract Inbox {
   function setMessage(string newMessage) public {
     message = newMessage;
   }
+
 }
 
 `;

--- a/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
@@ -46,7 +46,6 @@ contract Inbox {
   function setMessage(string newMessage) public {
     message = newMessage;
   }
-
 }
 
 `;

--- a/tests/Ownable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Ownable/__snapshots__/jsfmt.spec.js.snap
@@ -151,7 +151,5 @@ contract Ownable {
     emit OwnershipTransferred(_owner, newOwner);
     _owner = newOwner;
   }
-
 }
-
 `;

--- a/tests/Ownable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Ownable/__snapshots__/jsfmt.spec.js.snap
@@ -78,34 +78,36 @@ contract Ownable {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.24;
+
 /**
  * @title Ownable
  * @dev The Ownable contract has an owner address, and provides basic authorization control
  * functions, this simplifies the implementation of "user permissions".
  */
-
 contract Ownable {
   address private _owner;
+
   event OwnershipRenounced(address indexed previousOwner);
   event OwnershipTransferred(
     address indexed previousOwner,
     address indexed newOwner
   );
+
   /**
    * @dev The Ownable constructor sets the original \`owner\` of the contract to the sender
    * account.
    */
-
   constructor() public {
     _owner = msg.sender;
   }
+
   /**
    * @return the address of the owner.
    */
-
   function owner() public view returns(address) {
     return _owner;
   }
+
   /**
    * @dev Throws if called by any account other than the owner.
    */
@@ -113,42 +115,43 @@ contract Ownable {
     require(isOwner());
     _;
   }
+
   /**
    * @return true if \`msg.sender\` is the owner of the contract.
    */
-
   function isOwner() public view returns(bool) {
     return msg.sender == _owner;
   }
+
   /**
    * @dev Allows the current owner to relinquish control of the contract.
    * @notice Renouncing to ownership will leave the contract without an owner.
    * It will not be possible to call the functions with the \`onlyOwner\`
    * modifier anymore.
    */
-
   function renounceOwnership() public onlyOwner {
     emit OwnershipRenounced(_owner);
     _owner = address(0);
   }
+
   /**
    * @dev Allows the current owner to transfer control of the contract to a newOwner.
    * @param newOwner The address to transfer ownership to.
    */
-
   function transferOwnership(address newOwner) public onlyOwner {
     _transferOwnership(newOwner);
   }
+
   /**
    * @dev Transfers control of the contract to a newOwner.
    * @param newOwner The address to transfer ownership to.
    */
-
   function _transferOwnership(address newOwner) internal {
     require(newOwner != address(0));
     emit OwnershipTransferred(_owner, newOwner);
     _owner = newOwner;
   }
+
 }
 
 `;

--- a/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
@@ -133,16 +133,21 @@ contract SimpleAuction {
   // or time periods in seconds.
   address public beneficiary;
   uint public auctionEnd;
+
   // Current state of the auction.
   address public highestBidder;
   uint public highestBid;
+
   // Allowed withdrawals of previous bids
   mapping(address => uint) pendingReturns;
+
   // Set to true at the end, disallows any change
   bool ended;
+
   // Events that will be fired on changes.
   event HighestBidIncreased(address bidder, uint amount);
   event AuctionEnded(address winner, uint amount);
+
   // The following is a so-called natspec comment,
   // recognizable by the three slashes.
   // It will be shown when the user is asked to
@@ -151,16 +156,15 @@ contract SimpleAuction {
   /// Create a simple auction with \`_biddingTime\`
   /// seconds bidding time on behalf of the
   /// beneficiary address \`_beneficiary\`.
-
   constructor(uint _biddingTime, address _beneficiary) public {
     beneficiary = _beneficiary;
     auctionEnd = now + _biddingTime;
   }
+
   /// Bid on the auction with the value sent
   /// together with this transaction.
   /// The value will only be refunded if the
   /// auction is not won.
-
   function bid() public payable {
     // No arguments are necessary, all
     // information is already part of
@@ -186,8 +190,8 @@ contract SimpleAuction {
     highestBid = msg.value;
     emit HighestBidIncreased(msg.sender, msg.value);
   }
-  /// Withdraw a bid that was overbid.
 
+  /// Withdraw a bid that was overbid.
   function withdraw() public returns(bool) {
     uint amount = pendingReturns[msg.sender];
     if (amount > 0) {
@@ -203,9 +207,9 @@ contract SimpleAuction {
     }
     return true;
   }
+
   /// End the auction and send the highest bid
   /// to the beneficiary.
-
   function auctionEnd() public {
     // It is a good guideline to structure functions that interact
     // with other contracts (i.e. they call functions or send Ether)
@@ -229,6 +233,7 @@ contract SimpleAuction {
     // 3. Interaction
     beneficiary.transfer(highestBid);
   }
+
 }
 
 `;

--- a/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
@@ -233,7 +233,5 @@ contract SimpleAuction {
     // 3. Interaction
     beneficiary.transfer(highestBid);
   }
-
 }
-
 `;

--- a/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
@@ -29,7 +29,5 @@ contract SimpleStorage {
   function get() public view returns(uint) {
     return storedData;
   }
-
 }
-
 `;

--- a/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,7 @@ contract SimpleStorage {
   function get() public view returns(uint) {
     return storedData;
   }
+
 }
 
 `;


### PR DESCRIPTION
This is an alternative to #43.

I think this approach is promising: I created a function that is similar to doing `concat(join(hardline, path.map(print, 'children')))`, but that also handles the preservation of empty lines. Notice that I have to do the `locEnd + 1` trick (see [comments](https://github.com/prettier-solidity/prettier-plugin-solidity/pull/43#issuecomment-425550585)).

There are several things left to do:

1. I couldn't get rid of the empty line before the contract closing brace. If I just remove it from the code, the indentations is broken. I committed the snapshots without that line, so the tests are failing now (as they should).
2. In the same vein, there is an empty line after the closing brace. I also removed it from the snapshots.
3. I did it only at the source and contract levels. This means that inside functions, empty lines are not being preserved. It should be easy to add it, though.