### PR TITLE
Fixed checking for the existence of parameters for a modifier

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -376,7 +376,7 @@ function genericPrint(path, options, print) {
       }
       return concat([doc, ';']);
     case 'ModifierDefinition':
-      if (node.parameters && node.parameters.length > 0) {
+      if (node.parameters && node.parameters.parameters.length > 0) {
         doc = path.call(print, 'parameters');
       } else {
         doc = '';

--- a/src/printer.js
+++ b/src/printer.js
@@ -376,7 +376,11 @@ function genericPrint(path, options, print) {
       }
       return concat([doc, ';']);
     case 'ModifierDefinition':
-      if (node.parameters && node.parameters.parameters.length > 0) {
+      if (
+        node.parameters &&
+        node.parameters.parameters &&
+        node.parameters.parameters.length > 0
+      ) {
         doc = path.call(print, 'parameters');
       } else {
         doc = '';

--- a/tests/Etc/Etc.sol
+++ b/tests/Etc/Etc.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+// line comment
+
+/*
+	Block comment
+*/
+
+contract Contract {
+  modifier modifierWithoutParams() {
+    require(msg.sender != address(0));
+    _;
+  }
+
+  modifier modifierWithParams(address x) {
+    require(msg.sender != x);
+    _;
+  }
+}

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Etc.sol 1`] = `
+pragma solidity ^0.4.24;
+
+// line comment
+
+/*
+	Block comment
+*/
+
+contract Contract {
+  modifier modifierWithoutParams() {
+    require(msg.sender != address(0));
+    _;
+  }
+
+  modifier modifierWithParams(address x) {
+    require(msg.sender != x);
+    _;
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.4.24;
+
+// line comment
+
+/*
+	Block comment
+*/
+
+contract Contract {
+  modifier modifierWithoutParams() {
+    require(msg.sender != address(0));
+    _;
+  }
+
+  modifier modifierWithParams(address x) {
+    require(msg.sender != x);
+    _;
+  }
+}
+
+`;

--- a/tests/Etc/jsfmt.spec.js
+++ b/tests/Etc/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
There was a bug that would delete all the parameters from a modifier because of the way this plugin was handling checking if the modifier had any parameters. This change fixes the check, which prevents the deletion of parameters.