### PR TITLE
use memory/storage memoryLocation when printing

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -290,9 +290,13 @@ function genericPrint(path, options, print) {
       }
       return join(
         ' ',
-        [doc, node.visibility, constantKeyword, node.name].filter(
-          element => element
-        )
+        [
+          doc,
+          node.visibility,
+          constantKeyword,
+          node.storageLocation,
+          node.name
+        ].filter(element => element)
       );
     }
     case 'ArrayTypeName':


### PR DESCRIPTION
First of all, thank you and hello!

This commit fixes a pretty print issue which was removing `memoryLocation` from the reprint.

Example prior to pretty:
```solidity
 CommodityLib.Commodity memory _commodity = CommodityLib.Commodity({
      category: uint64(1),
      timeRegistered: uint64(now), // solium-disable-line
      parentId: _tokenId,
      value: _amount,
      locked: false,
      misc: commodities[_tokenId].misc
    });
```

after:
```solidity
CommodityLib.Commodity _commodity = CommodityLib.Commodity({
      category: uint64(1),
      timeRegistered: uint64(now), // solium-disable-line
      parentId: _tokenId,
      value: _amount,
      locked: false,
      misc: commodities[_tokenId].misc
    });
```

note it moved the `memory` specification from CommodityLib.commodity

With this change, it will reprint as:
```solidity
CommodityLib.Commodity memory _commodity = CommodityLib.Commodity({
      category: uint64(1),
      timeRegistered: uint64(now), // solium-disable-line
      parentId: _tokenId,
      value: _amount,
      locked: false,
      misc: commodities[_tokenId].misc
    });
```
^^ correct