### PR TITLE
Omit semicolon in for statements init and loop expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "description": "prettier plugin for solidity",
   "main": "src",
   "scripts": {

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,6 +5,18 @@ const parser = require('solidity-parser-antlr');
 const parse = text => {
   const parsed = parser.parse(text, { loc: true, range: true });
   parsed.comments = extract(text);
+
+  parser.visit(parsed, {
+    ForStatement(ctx) {
+      if (ctx.initExpression) {
+        ctx.initExpression.omitSemicolon = true;
+      }
+      if (ctx.loopExpression) {
+        ctx.loopExpression.omitSemicolon = true;
+      }
+    }
+  });
+
   return parsed;
 };
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -162,10 +162,9 @@ function genericPrint(path, options, print) {
       ]);
 
     case 'ExpressionStatement': {
-      const addSemicolon = path.getParentNode().type !== 'ForStatement';
       return concat([
         node.expression ? path.call(print, 'expression') : '',
-        addSemicolon ? ';' : ''
+        node.omitSemicolon ? '' : ';'
       ]);
     }
     case 'FunctionCall':

--- a/src/printer.js
+++ b/src/printer.js
@@ -244,8 +244,7 @@ function genericPrint(path, options, print) {
       if (node.initialValue) {
         doc = concat([doc, ' = ', path.call(print, 'initialValue')]);
       }
-      const addSemicolon = path.getParentNode().type !== 'ForStatement';
-      return concat([doc, addSemicolon ? ';' : '']);
+      return concat([doc, node.omitSemicolon ? '' : ';']);
     }
     case 'StateVariableDeclaration':
       doc = concat(

--- a/tests/Etc/Etc.sol
+++ b/tests/Etc/Etc.sol
@@ -22,4 +22,10 @@ contract Contract {
     require(msg.sender != x);
     _;
   }
+
+  function forWithoutBlock() {
+    uint i;
+    uint sum;
+    for ( i = 0; i < 10; i++ ) sum   +=  i;
+  }
 }

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -25,8 +25,16 @@ contract Contract {
     require(msg.sender != x);
     _;
   }
-  
-  // FIXME
+
+  function ifBlockInOneLine(uint a) returns (uint b) {
+    if (a < 0) b = 0x67; else if (a == 0) b = 0x12; else b = 0x78;
+  }
+
+  function forWithoutBlock() {
+    uint i;
+    uint sum;
+    for ( i = 0; i < 10; i++ ) sum   +=  i;
+  }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.24;
@@ -54,7 +62,17 @@ contract Contract {
     _;
   }
 
-  // FIXME
+  function ifBlockInOneLine(uint a) returns(uint b) {
+    if (a < 0) b = 0x67;
+    else if (a == 0) b = 0x12;
+    else b = 0x78;
+  }
+
+  function forWithoutBlock() {
+    uint i;
+    uint sum;
+    for (i = 0; i < 10; i++) sum += i;
+  }
 }
 
 `;

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,12 @@ contract Contract {
     require(msg.sender != x);
     _;
   }
+
+  function forWithoutBlock() {
+    uint i;
+    uint sum;
+    for ( i = 0; i < 10; i++ ) sum   +=  i;
+  }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.4.24;
@@ -50,6 +56,12 @@ contract Contract {
   modifier modifierWithParams(address x) {
     require(msg.sender != x);
     _;
+  }
+
+  function forWithoutBlock() {
+    uint i;
+    uint sum;
+    for (i = 0; i < 10; i++) sum += i;
   }
 }
 


### PR DESCRIPTION
Closes #64.

I ended up mutating the nodes anyway, but I did it in the parser, which make it a little less ugly (or so I tell myself). The problem is that we don't have a better `type` to assign to this nodes; at least I didn't see one that could work.

Maybe later we can do it in a cleaner way. For now, tests pass and I don't think it's a huge technical debt.