### PR TITLE
Fix prettier removing payable from address payable

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -291,7 +291,12 @@ function genericPrint(path, options, print) {
       if (node.visibility === 'default') {
         return join(
           ' ',
-          [doc, node.typeName.stateMutability, constantKeyword, node.name].filter(element => element)
+          [
+            doc,
+            node.typeName.stateMutability,
+            constantKeyword,
+            node.name
+          ].filter(element => element)
         );
       }
       return join(

--- a/src/printer.js
+++ b/src/printer.js
@@ -135,7 +135,12 @@ function genericPrint(path, options, print) {
       doc = path.call(print, 'typeName');
       doc = join(
         ' ',
-        [doc, node.storageLocation, node.name].filter(element => element)
+        [
+          doc,
+          node.storageLocation,
+          node.typeName.stateMutability,
+          node.name
+        ].filter(element => element)
       );
       return doc;
     case 'ModifierInvocation':
@@ -286,13 +291,14 @@ function genericPrint(path, options, print) {
       if (node.visibility === 'default') {
         return join(
           ' ',
-          [doc, constantKeyword, node.name].filter(element => element)
+          [doc, node.typeName.stateMutability, constantKeyword, node.name].filter(element => element)
         );
       }
       return join(
         ' ',
         [
           doc,
+          node.typeName.stateMutability,
           node.visibility,
           constantKeyword,
           node.storageLocation,

--- a/tests/AddressPayable/AddressPayable.sol
+++ b/tests/AddressPayable/AddressPayable.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.2;
+
+contract AddressPayable {
+  function sendSomeEth(address payable to) public payable {
+    address payable target = to;
+    target.transfer(msg.value);
+  }
+}

--- a/tests/AddressPayable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AddressPayable/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddressPayable.sol 1`] = `
+pragma solidity ^0.5.2;
+
+contract AddressPayable {
+  function sendSomeEth(address payable to) public payable {
+    address payable target = to;
+    target.transfer(msg.value);
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.2;
+
+contract AddressPayable {
+  function sendSomeEth(address payable to) public payable {
+    address payable target = to;
+    target.transfer(msg.value);
+  }
+}
+
+`;

--- a/tests/AddressPayable/jsfmt.spec.js
+++ b/tests/AddressPayable/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
So I noticed an issue with the new address payable type.
At first the plugin would fail because the published version of solidity-parser-antlr had a bug and didn't recognize the payable keyword.
After using the most recent version from git I noticed that the printer would just remove the payable keyword.

So this PR fixes this.
I have absolutley no idea if what I did here is the correct way to fix it but it seems to work for me.
Also I have no idea what's the best way to include the most recent version of solidity-parser-antlr, maybe best to ask the maintainer to publish the newest version?