### PR TITLE
Print comments in empty blocks

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -144,14 +144,35 @@ function genericPrint(path, options, print) {
         doc = concat([doc, '(', join(', ', path.map(print, 'arguments')), ')']);
       }
       return doc;
-    case 'Block':
-      return concat([
+    case 'Block': {
+      const parts = [
         '{',
         indent(line),
-        indent(printPreservingEmptyLines(path, 'statements', options, print)),
-        line,
-        '}'
-      ]);
+        indent(printPreservingEmptyLines(path, 'statements', options, print))
+      ];
+
+      if (node.comments) {
+        let first = true;
+        path.each(commentPath => {
+          if (first) {
+            first = false;
+          } else {
+            parts.push(indent(line));
+          }
+          const comment = commentPath.getValue();
+          if (comment.trailing || comment.leading) {
+            return;
+          }
+          comment.printed = true;
+          parts.push(options.printer.printComment(commentPath));
+        }, 'comments');
+      }
+
+      parts.push(line);
+      parts.push('}');
+
+      return concat(parts);
+    }
     case 'EventDefinition':
       return concat([
         'event ',

--- a/tests/Inbox/Inbox.sol
+++ b/tests/Inbox/Inbox.sol
@@ -23,5 +23,11 @@ contract Inbox {
   function nothingHere() public {
     // to be defined
   }
+
+  function nothingHereMultipleComments() public {
+    // to be defined
+    // to be defined 2
+    /* to be defined 3 */
+  }
 }
 

--- a/tests/Inbox/Inbox.sol
+++ b/tests/Inbox/Inbox.sol
@@ -19,5 +19,9 @@ contract Inbox {
   function setMessage(string newMessage) public {
     message = newMessage;
   }
+
+  function nothingHere() public {
+    // to be defined
+  }
 }
 

--- a/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Inbox/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,16 @@ contract Inbox {
   function setMessage(string newMessage) public {
     message = newMessage;
   }
+
+  function nothingHere() public {
+    // to be defined
+  }
+
+  function nothingHereMultipleComments() public {
+    // to be defined
+    // to be defined 2
+    /* to be defined 3 */
+  }
 }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,6 +55,16 @@ contract Inbox {
 
   function setMessage(string newMessage) public {
     message = newMessage;
+  }
+
+  function nothingHere() public {
+    // to be defined
+  }
+
+  function nothingHereMultipleComments() public {
+    // to be defined
+    // to be defined 2
+    /* to be defined 3 */
   }
 }
 


### PR DESCRIPTION
Closes #45 (I hope).

From what I understood in Prettier's code, the printer should handle this kind of situations. At least that's what I did here. The block printer will handle all comments that are neither leading nor trailing (why? I'm not sure; I think this means they are on their own line).

A lot of this comes from guesswork. Also, the code is ugly: I'm sure there is a much more idiomatic way of doing what I did. But, well, at least tests pass.