### PR TITLE
Group and break modifiers

### DIFF
--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -566,9 +566,9 @@ library IntegerSet {
   function iterate_valid(data storage self, uint index) returns (bool) {
     return index < self.items.length;
   }
-  function iterate_advance(data storage self, uint index) returns (
-    uint r_index
-  ) {
+  function iterate_advance(data storage self, uint index)
+    returns (uint r_index)
+  {
     index++;
     while (iterate_valid(
       self,
@@ -827,16 +827,15 @@ contract Ballot {
     return false;
   }
 
-  function foobar() payable owner(myPrice) returns (
-    uint[],
-    address myAdd,
-    string[] names
-  ) {}
-  function foobar() payable owner(myPrice) returns (
-    uint[],
-    address myAdd,
-    string[] names
-  );
+  function foobar()
+    payable
+    owner(myPrice)
+    returns (uint[], address myAdd, string[] names)
+  {}
+  function foobar()
+    payable
+    owner(myPrice)
+    returns (uint[], address myAdd, string[] names);
 
   Voter you = Voter(1, true);
 

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -63,7 +63,10 @@ contract BasicIterator {
     }
   }
 
-  function getSum() constant returns (uint) { // "constant" just means this function returns something to the caller
+  function getSum()
+    constant
+    returns (uint) // "constant" just means this function returns something to the caller
+  {
     // which is immediately followed by what type gets returned, in this case a full uint256
     uint8 sum = 0;
     uint8 x = 0;

--- a/tests/FunctionDefinitions/FunctionDefinitions.sol
+++ b/tests/FunctionDefinitions/FunctionDefinitions.sol
@@ -1,0 +1,37 @@
+contract FunctionDefinitions {
+  function noParamsNoModifiers() {
+    a = 1;
+  }
+
+  function oneParam(uint x) {
+    a = 1;
+  }
+
+  function oneModifier() modifier1 {
+    a = 1;
+  }
+
+  function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) {
+    a = 1;
+  }
+
+  function manyModifiers() modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+
+  function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 {
+    a = 1;
+  }
+
+  function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+
+  function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 {
+    a = 1;
+  }
+
+  function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+}

--- a/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,150 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FunctionDefinitions.sol 1`] = `
+contract FunctionDefinitions {
+  function noParamsNoModifiers() {
+    a = 1;
+  }
+
+  function oneParam(uint x) {
+    a = 1;
+  }
+
+  function oneModifier() modifier1 {
+    a = 1;
+  }
+
+  function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) {
+    a = 1;
+  }
+
+  function manyModifiers() modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+
+  function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 {
+    a = 1;
+  }
+
+  function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+
+  function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 {
+    a = 1;
+  }
+
+  function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
+    a = 1;
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract FunctionDefinitions {
+  function noParamsNoModifiers() {
+    a = 1;
+  }
+
+  function oneParam(uint x) {
+    a = 1;
+  }
+
+  function oneModifier() modifier1 {
+    a = 1;
+  }
+
+  function manyParams(
+    uint x1,
+    uint x2,
+    uint x3,
+    uint x4,
+    uint x5,
+    uint x6,
+    uint x7,
+    uint x8,
+    uint x9,
+    uint x10
+  ) {
+    a = 1;
+  }
+
+  function manyModifiers()
+    modifier1
+    modifier2
+    modifier3
+    modifier4
+    modifier5
+    modifier6
+    modifier7
+    modifier8
+    modifier9
+    modifier10
+  {
+    a = 1;
+  }
+
+  function someParamsSomeModifiers(uint x1, uint x2, uint x3)
+    modifier1
+    modifier2
+    modifier3
+  {
+    a = 1;
+  }
+
+  function someParamsManyModifiers(uint x1, uint x2, uint x3)
+    modifier1
+    modifier2
+    modifier3
+    modifier4
+    modifier5
+    modifier6
+    modifier7
+    modifier8
+    modifier9
+    modifier10
+  {
+    a = 1;
+  }
+
+  function manyParamsSomeModifiers(
+    uint x1,
+    uint x2,
+    uint x3,
+    uint x4,
+    uint x5,
+    uint x6,
+    uint x7,
+    uint x8,
+    uint x9,
+    uint x10
+  ) modifier1 modifier2 modifier3 {
+    a = 1;
+  }
+
+  function manyParamsManyModifiers(
+    uint x1,
+    uint x2,
+    uint x3,
+    uint x4,
+    uint x5,
+    uint x6,
+    uint x7,
+    uint x8,
+    uint x9,
+    uint x10
+  )
+    modifier1
+    modifier2
+    modifier3
+    modifier4
+    modifier5
+    modifier6
+    modifier7
+    modifier8
+    modifier9
+    modifier10
+  {
+    a = 1;
+  }
+}
+
+`;

--- a/tests/FunctionDefinitions/jsfmt.spec.js
+++ b/tests/FunctionDefinitions/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
@@ -78,7 +78,9 @@ contract IndexOf {
 
   int whatwastheval = -10; // -2 = not yet tested, as separate from -1, tested but error
 
-  function indexOf(string _a, string _b) returns (int) { // _a = string to search, _b = string we want to find
+  function indexOf(string _a, string _b)
+    returns (int) // _a = string to search, _b = string we want to find
+  {
     bytes memory a = bytes(_a);
     bytes memory b = bytes(_b);
 

--- a/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
@@ -88,7 +88,13 @@ contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
     uint256 _goal,
     uint256 _cap,
     address _wallet
-  ) public CappedCrowdsale(_cap) FinalizableCrowdsale RefundableCrowdsale(_goal) Crowdsale(_startTime, _endTime, _rate, _wallet) {
+  )
+    public
+    CappedCrowdsale(_cap)
+    FinalizableCrowdsale
+    RefundableCrowdsale(_goal)
+    Crowdsale(_startTime, _endTime, _rate, _wallet)
+  {
     //As goal needs to be met for a successful crowdsale
     //the value needs to less or equal than a cap which is limit for accepted funds
     require(_goal <= _cap);

--- a/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
@@ -76,11 +76,10 @@ contract SplittableCommodity is MintableCommodity {
     bytes operatorData
   );
 
-  function split(
-    uint _tokenId,
-    address _to,
-    uint256 _amount
-  ) public whenNotPaused {
+  function split(uint _tokenId, address _to, uint256 _amount)
+    public
+    whenNotPaused
+  {
     address supplierProxy = IContractRegistry(
       contractRegistry
     ).getLatestProxyAddr("Supplier");

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -919,10 +919,11 @@ library strings {
      * @param other The second slice to compare.
      * @return The result of the comparison.
      */
-  function compare(
-    slice memory self,
-    slice memory other
-  ) internal pure returns (int) {
+  function compare(slice memory self, slice memory other)
+    internal
+    pure
+    returns (int)
+  {
     uint shortest = self._len;
     if (other._len < self._len) shortest = other._len;
 
@@ -956,9 +957,11 @@ library strings {
      * @param self The second slice to compare.
      * @return True if the slices are equal, false otherwise.
      */
-  function equals(slice memory self, slice memory other) internal pure returns (
-    bool
-  ) {
+  function equals(slice memory self, slice memory other)
+    internal
+    pure
+    returns (bool)
+  {
     return compare(self, other) == 0;
   }
 
@@ -969,10 +972,11 @@ library strings {
      * @param rune The slice that will contain the first rune.
      * @return \`rune\`.
      */
-  function nextRune(
-    slice memory self,
-    slice memory rune
-  ) internal pure returns (slice memory) {
+  function nextRune(slice memory self, slice memory rune)
+    internal
+    pure
+    returns (slice memory)
+  {
     rune._ptr = self._ptr;
 
     if (self._len == 0) {
@@ -1016,9 +1020,11 @@ library strings {
      * @param self The slice to operate on.
      * @return A slice containing only the first rune from \`self\`.
      */
-  function nextRune(slice memory self) internal pure returns (
-    slice memory ret
-  ) {
+  function nextRune(slice memory self)
+    internal
+    pure
+    returns (slice memory ret)
+  {
     nextRune(self, ret);
   }
 
@@ -1090,10 +1096,11 @@ library strings {
      * @param needle The slice to search for.
      * @return True if the slice starts with the provided text, false otherwise.
      */
-  function startsWith(
-    slice memory self,
-    slice memory needle
-  ) internal pure returns (bool) {
+  function startsWith(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (bool)
+  {
     if (self._len < needle._len) {
       return false;
     }
@@ -1119,10 +1126,11 @@ library strings {
      * @param needle The slice to search for.
      * @return \`self\`
      */
-  function beyond(
-    slice memory self,
-    slice memory needle
-  ) internal pure returns (slice memory) {
+  function beyond(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory)
+  {
     if (self._len < needle._len) {
       return self;
     }
@@ -1151,10 +1159,11 @@ library strings {
      * @param needle The slice to search for.
      * @return True if the slice starts with the provided text, false otherwise.
      */
-  function endsWith(
-    slice memory self,
-    slice memory needle
-  ) internal pure returns (bool) {
+  function endsWith(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (bool)
+  {
     if (self._len < needle._len) {
       return false;
     }
@@ -1182,9 +1191,11 @@ library strings {
      * @param needle The slice to search for.
      * @return \`self\`
      */
-  function until(slice memory self, slice memory needle) internal pure returns (
-    slice memory
-  ) {
+  function until(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory)
+  {
     if (self._len < needle._len) {
       return self;
     }
@@ -1208,12 +1219,11 @@ library strings {
 
   // Returns the memory address of the first byte of the first occurrence of
   // \`needle\` in \`self\`, or the first byte after \`self\` if not found.
-  function findPtr(
-    uint selflen,
-    uint selfptr,
-    uint needlelen,
-    uint needleptr
-  ) private pure returns (uint) {
+  function findPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr)
+    private
+    pure
+    returns (uint)
+  {
     uint ptr = selfptr;
     uint idx;
 
@@ -1262,12 +1272,11 @@ library strings {
 
   // Returns the memory address of the first byte after the last occurrence of
   // \`needle\` in \`self\`, or the address of \`self\` if not found.
-  function rfindPtr(
-    uint selflen,
-    uint selfptr,
-    uint needlelen,
-    uint needleptr
-  ) private pure returns (uint) {
+  function rfindPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr)
+    private
+    pure
+    returns (uint)
+  {
     uint ptr;
 
     if (needlelen <= selflen) {
@@ -1321,9 +1330,11 @@ library strings {
      * @param needle The text to search for.
      * @return \`self\`.
      */
-  function find(slice memory self, slice memory needle) internal pure returns (
-    slice memory
-  ) {
+  function find(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory)
+  {
     uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
     self._len -= ptr - self._ptr;
     self._ptr = ptr;
@@ -1338,9 +1349,11 @@ library strings {
      * @param needle The text to search for.
      * @return \`self\`.
      */
-  function rfind(slice memory self, slice memory needle) internal pure returns (
-    slice memory
-  ) {
+  function rfind(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory)
+  {
     uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
     self._len = ptr - self._ptr;
     return self;
@@ -1356,11 +1369,11 @@ library strings {
      * @param token An output parameter to which the first token is written.
      * @return \`token\`.
      */
-  function split(
-    slice memory self,
-    slice memory needle,
-    slice memory token
-  ) internal pure returns (slice memory) {
+  function split(slice memory self, slice memory needle, slice memory token)
+    internal
+    pure
+    returns (slice memory)
+  {
     uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
     token._ptr = self._ptr;
     token._len = ptr - self._ptr;
@@ -1383,9 +1396,11 @@ library strings {
      * @param needle The text to search for in \`self\`.
      * @return The part of \`self\` up to the first occurrence of \`delim\`.
      */
-  function split(slice memory self, slice memory needle) internal pure returns (
-    slice memory token
-  ) {
+  function split(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory token)
+  {
     split(self, needle, token);
   }
 
@@ -1399,11 +1414,11 @@ library strings {
      * @param token An output parameter to which the first token is written.
      * @return \`token\`.
      */
-  function rsplit(
-    slice memory self,
-    slice memory needle,
-    slice memory token
-  ) internal pure returns (slice memory) {
+  function rsplit(slice memory self, slice memory needle, slice memory token)
+    internal
+    pure
+    returns (slice memory)
+  {
     uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
     token._ptr = ptr;
     token._len = self._len - (ptr - self._ptr);
@@ -1425,10 +1440,11 @@ library strings {
      * @param needle The text to search for in \`self\`.
      * @return The part of \`self\` after the last occurrence of \`delim\`.
      */
-  function rsplit(
-    slice memory self,
-    slice memory needle
-  ) internal pure returns (slice memory token) {
+  function rsplit(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (slice memory token)
+  {
     rsplit(self, needle, token);
   }
 
@@ -1438,9 +1454,11 @@ library strings {
      * @param needle The text to search for in \`self\`.
      * @return The number of occurrences of \`needle\` found in \`self\`.
      */
-  function count(slice memory self, slice memory needle) internal pure returns (
-    uint cnt
-  ) {
+  function count(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (uint cnt)
+  {
     uint ptr = findPtr(
       self._len,
       self._ptr,
@@ -1464,10 +1482,11 @@ library strings {
      * @param needle The text to search for in \`self\`.
      * @return True if \`needle\` is found in \`self\`, false otherwise.
      */
-  function contains(
-    slice memory self,
-    slice memory needle
-  ) internal pure returns (bool) {
+  function contains(slice memory self, slice memory needle)
+    internal
+    pure
+    returns (bool)
+  {
     return rfindPtr(
       self._len,
       self._ptr,
@@ -1483,9 +1502,11 @@ library strings {
      * @param other The second slice to concatenate.
      * @return The concatenation of the two strings.
      */
-  function concat(slice memory self, slice memory other) internal pure returns (
-    string memory
-  ) {
+  function concat(slice memory self, slice memory other)
+    internal
+    pure
+    returns (string memory)
+  {
     string memory ret = new string(self._len + other._len);
     uint retptr;
     assembly {
@@ -1504,9 +1525,11 @@ library strings {
      * @return A newly allocated string containing all the slices in \`parts\`,
      *         joined with \`self\`.
      */
-  function join(slice memory self, slice[] memory parts) internal pure returns (
-    string memory
-  ) {
+  function join(slice memory self, slice[] memory parts)
+    internal
+    pure
+    returns (string memory)
+  {
     if (parts.length == 0) return "";
 
     uint length = self._len * (parts.length - 1);


### PR DESCRIPTION
Closes #101.

I don't like how this handles this scenario:

```
  function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 {
    a = 1;
  }
```

That is printed as this:

```
  function someParamsSomeModifiers(uint x1, uint x2, uint x3)
    modifier1
    modifier2
    modifier3
  {
    a = 1;
  }
```

while I'd prefer this:

```
  function someParamsSomeModifiers(
    uint x1,
    uint x2,
    uint x3
  ) modifier1 modifier2 modifier3 {
    a = 1;
  }
```

I mean: if the function definition is too long, break the params first. If that's not enough, then break the modifiers. But, according to [this](https://github.com/prettier/prettier/blob/master/commands.md#group), `group` breaks the "outermost" group first (I guess that's the last one) so I don't know if there's some way of doing this.

@j-f1 do you know if there's some trick we can use here?