### PR TITLE
Fixed tuple errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "escape-string-regexp": "^1.0.5",
     "extract-comments": "^1.1.0",
     "prettier": "^1.15.3",
-    "solidity-parser-antlr": "^0.3.3",
+    "solidity-parser-antlr": "^0.4.0",
     "string-width": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     {
       "email": "victorio.franco@gmail.com",
       "name": "Franco Victorio"
+    },
+    {
+      "email": "hi@mudit.blog",
+      "name": "Mudit Gupta"
     }
   ],
   "license": "MIT",

--- a/src/printer.js
+++ b/src/printer.js
@@ -31,9 +31,10 @@ function printPreservingEmptyLines(path, key, options, print) {
 function genericPrint(path, options, print) {
   const node = path.getValue();
   let doc;
-  if (node === null)
-    return ''
-    
+  if (node === null) {
+    return '';
+  }
+
   switch (node.type) {
     case 'SourceUnit':
       return concat([

--- a/src/printer.js
+++ b/src/printer.js
@@ -313,7 +313,7 @@ function genericPrint(path, options, print) {
         ', ',
         path.map(statementPath => {
           if (!statementPath.getValue()) {
-            return ', ';
+            return '';
           }
           return print(statementPath);
         }, 'variables')

--- a/src/printer.js
+++ b/src/printer.js
@@ -31,6 +31,9 @@ function printPreservingEmptyLines(path, key, options, print) {
 function genericPrint(path, options, print) {
   const node = path.getValue();
   let doc;
+  if (node === null)
+    return ''
+    
   switch (node.type) {
     case 'SourceUnit':
       return concat([

--- a/src/printer.js
+++ b/src/printer.js
@@ -311,12 +311,7 @@ function genericPrint(path, options, print) {
 
       doc = join(
         ', ',
-        path.map(statementPath => {
-          if (!statementPath.getValue()) {
-            return '';
-          }
-          return print(statementPath);
-        }, 'variables')
+        path.map(statementPath => print(statementPath), 'variables')
       );
 
       if (node.variables.length > 1 || startsWithVar) {

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -771,11 +771,11 @@ contract VariableDeclarationTuple {
   function ham() {
     var (x, y) = (10, 20);
     var (a, b) = getMyTuple();
-    var (, , c) = (10, 20);
+    var (, c) = (10, 20);
     var (d, , ) = (10, 20, 30);
-    var (, , e, , , f, , ) = (10, 20, 30, 40, 50);
+    var (, e, , f, ) = (10, 20, 30, 40, 50);
 
-    var (num1, num2, num3, , , num5) = (10, 20, 30, 40, 50);
+    var (num1, num2, num3, , num5) = (10, 20, 30, 40, 50);
   }
 }
 

--- a/tests/Tupples/Tupples.sol
+++ b/tests/Tupples/Tupples.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.5.0;
+
+contract demo {
+    function hello() public view returns(bool,bool) {}    
+    function hello2() public view returns(bool) {}
+    function hello3() public view returns(bool,bool,bool) {}   
+
+}
+
+contract Tupples {
+    function world(address payable _yo) public view {
+        bool yo;
+        yo = demo(_yo).hello2();
+        (yo, ) = demo(_yo).hello();
+        (, yo) = demo(_yo).hello();
+        (yo, , yo) = demo(_yo).hello3();
+        (yo, yo) = demo(_yo).hello();
+    }
+}

--- a/tests/Tupples/Tupples.sol
+++ b/tests/Tupples/Tupples.sol
@@ -11,7 +11,7 @@ contract Tupples {
     function world(address payable _yo) public view {
         bool yo;
         yo = demo(_yo).hello2();
-        //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
+        (yo, ) = demo(_yo).hello();
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();

--- a/tests/Tupples/Tupples.sol
+++ b/tests/Tupples/Tupples.sol
@@ -11,7 +11,7 @@ contract Tupples {
     function world(address payable _yo) public view {
         bool yo;
         yo = demo(_yo).hello2();
-        (yo, ) = demo(_yo).hello();
+        //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();

--- a/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
@@ -14,7 +14,7 @@ contract Tupples {
     function world(address payable _yo) public view {
         bool yo;
         yo = demo(_yo).hello2();
-        (yo, ) = demo(_yo).hello();
+        //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();
@@ -33,7 +33,7 @@ contract Tupples {
   function world(address payable _yo) public view {
     bool yo;
     yo = demo(_yo).hello2();
-    (yo) = demo(_yo).hello();
+    //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
     (, yo) = demo(_yo).hello();
     (yo, , yo) = demo(_yo).hello3();
     (yo, yo) = demo(_yo).hello();

--- a/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tupples.sol 1`] = `
+pragma solidity ^0.5.0;
+
+contract demo {
+    function hello() public view returns(bool,bool) {}    
+    function hello2() public view returns(bool) {}
+    function hello3() public view returns(bool,bool,bool) {}   
+
+}
+
+contract Tupples {
+    function world(address payable _yo) public view {
+        bool yo;
+        yo = demo(_yo).hello2();
+        (yo, ) = demo(_yo).hello();
+        (, yo) = demo(_yo).hello();
+        (yo, , yo) = demo(_yo).hello3();
+        (yo, yo) = demo(_yo).hello();
+    }
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.0;
+
+contract demo {
+  function hello() public view returns (bool, bool) {}
+  function hello2() public view returns (bool) {}
+  function hello3() public view returns (bool, bool, bool) {}
+
+}
+
+contract Tupples {
+  function world(address payable _yo) public view {
+    bool yo;
+    yo = demo(_yo).hello2();
+    (yo) = demo(_yo).hello();
+    (, yo) = demo(_yo).hello();
+    (yo, , yo) = demo(_yo).hello3();
+    (yo, yo) = demo(_yo).hello();
+  }
+}
+
+`;

--- a/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
@@ -14,7 +14,7 @@ contract Tupples {
     function world(address payable _yo) public view {
         bool yo;
         yo = demo(_yo).hello2();
-        //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
+        (yo, ) = demo(_yo).hello();
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();
@@ -33,7 +33,7 @@ contract Tupples {
   function world(address payable _yo) public view {
     bool yo;
     yo = demo(_yo).hello2();
-    //(yo, ) = demo(_yo).hello(); Uncomment this when solidity parser is fixed
+    (yo, ) = demo(_yo).hello();
     (, yo) = demo(_yo).hello();
     (yo, , yo) = demo(_yo).hello3();
     (yo, yo) = demo(_yo).hello();

--- a/tests/Tupples/jsfmt.spec.js
+++ b/tests/Tupples/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
Fixed:
1) Prettier was throwing on `(, yo) = demo(_yo).hello();`
2) `(yo, ) = demo(_yo).hello();` was getting prettified to `(yo) = demo(_yo).hello();`
3) Tupples in VariableExpressions were broken. For example,
`var (,c) = (10, 20);` was getting prettified to `var (, , c) = (10, 20);`
3 was part of the tests but the test screenshot for 3 had the incorrect result so the tests were passing.

fixes #79 
