### PR TITLE
Fixed tuples and updated parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "escape-string-regexp": "^1.0.5",
     "extract-comments": "^1.1.0",
     "prettier": "^1.15.3",
-    "solidity-parser-antlr": "^0.3.3",
+    "solidity-parser-antlr": "^0.4.0",
     "string-width": "^3.0.0"
   }
 }

--- a/src/printer.js
+++ b/src/printer.js
@@ -309,7 +309,7 @@ function genericPrint(path, options, print) {
         ', ',
         path.map(statementPath => {
           if (!statementPath.getValue()) {
-            return ', ';
+            return '';
           }
           return print(statementPath);
         }, 'variables')

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -771,11 +771,11 @@ contract VariableDeclarationTuple {
   function ham() {
     var (x, y) = (10, 20);
     var (a, b) = getMyTuple();
-    var (, , c) = (10, 20);
+    var (, c) = (10, 20);
     var (d, , ) = (10, 20, 30);
-    var (, , e, , , f, , ) = (10, 20, 30, 40, 50);
+    var (, e, , f, ) = (10, 20, 30, 40, 50);
 
-    var (num1, num2, num3, , , num5) = (10, 20, 30, 40, 50);
+    var (num1, num2, num3, , num5) = (10, 20, 30, 40, 50);
   }
 }
 


### PR DESCRIPTION
Tupples in VariableExpressions were broken. For example,
`var (,c) = (10, 20);`
was getting prettified to
`var (, , c) = (10, 20);`

The test screenshot had the incorrect result so the tests were passing.