### PR TITLE
Conditional formating

### DIFF
--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,19 +1,23 @@
 /* eslint-disable implicit-arrow-linebreak */
 const {
   doc: {
-    builders: { join }
+    builders: { concat, group, indent, line }
   }
 } = require('prettier');
 
 const Conditional = {
   print: ({ path, print }) =>
-    join(' ', [
-      path.call(print, 'condition'),
-      '?',
-      path.call(print, 'trueExpression'),
-      ':',
-      path.call(print, 'falseExpression')
-    ])
+    group(
+      concat([
+        path.call(print, 'condition'),
+        indent(line),
+        '? ',
+        path.call(print, 'trueExpression'),
+        indent(line),
+        ': ',
+        path.call(print, 'falseExpression')
+      ])
+    )
 };
 
 module.exports = Conditional;

--- a/tests/Conditional/Conditional.sol
+++ b/tests/Conditional/Conditional.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function foo() {
+        address contextAddress = longAddress_ == address(0) ? msg.sender : currentContextAddress_;
+    }
+
+    // TODO: work with a break in the condition level.
+    // function foo() {
+    //     address contextAddress = veryVeryVeryVeryVeryVeryVeryVeryVeryLongAddress_ == address(0) ? msg.sender : currentContextAddress_;
+    // }
+
+    function bar() {
+        uint a = true ? 0 : 1;
+    }
+}

--- a/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Conditional.sol 1`] = `
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function foo() {
+        address contextAddress = longAddress_ == address(0) ? msg.sender : currentContextAddress_;
+    }
+
+    // TODO: work with a break in the condition level.
+    // function foo() {
+    //     address contextAddress = veryVeryVeryVeryVeryVeryVeryVeryVeryLongAddress_ == address(0) ? msg.sender : currentContextAddress_;
+    // }
+
+    function bar() {
+        uint a = true ? 0 : 1;
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.4.24;
+
+contract Conditional {
+    function foo() {
+        address contextAddress = longAddress_ == address(0)
+            ? msg.sender
+            : currentContextAddress_;
+    }
+
+    // TODO: work with a break in the condition level.
+    // function foo() {
+    //     address contextAddress = veryVeryVeryVeryVeryVeryVeryVeryVeryLongAddress_ == address(0) ? msg.sender : currentContextAddress_;
+    // }
+
+    function bar() {
+        uint a = true ? 0 : 1;
+    }
+}
+
+`;

--- a/tests/Conditional/jsfmt.spec.js
+++ b/tests/Conditional/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
Fix for #117

I took inspiration from the format that prettier uses in javascript.

```Solidity
// a long conditional splits into 3 lines, condition, trueExpression, and falseExpression
address contextAddress = longAddress_ == address(0)
    ? msg.sender
    : currentContextAddress_;

// a short conditional fits in a line
uint a = true ? 0 : 1;
```