### PR TITLE
split multiple base contracts

### DIFF
--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -1,33 +1,53 @@
+/* eslint-disable implicit-arrow-linebreak */
 const {
   doc: {
-    builders: { concat, indent, join, line }
+    builders: { concat, group, indent, join, line }
   }
 } = require('prettier');
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 
-const ContractDefinition = {
-  print: ({ node, options, path, print }) => {
-    let parts = [node.kind, ' ', node.name];
-
-    if (node.baseContracts.length > 0) {
-      parts = parts.concat([
-        ' is ',
-        join(', ', path.map(print, 'baseContracts'))
-      ]);
-    }
-
-    parts.push(' {');
-    if (node.subNodes.length > 0) {
-      parts = parts.concat([
-        indent(line),
-        indent(printPreservingEmptyLines(path, 'subNodes', options, print)),
-        line
-      ]);
-    }
-    parts.push('}');
-
-    return concat(parts);
+const inheritance = (node, path, print) => {
+  if (node.baseContracts.length > 0) {
+    return concat([
+      ' is',
+      indent(
+        concat([
+          line,
+          join(concat([',', line]), path.map(print, 'baseContracts'))
+        ])
+      )
+    ]);
   }
+  return '';
+};
+
+const body = (node, path, options, print) => {
+  if (node.subNodes.length > 0) {
+    return concat([
+      indent(line),
+      indent(printPreservingEmptyLines(path, 'subNodes', options, print)),
+      line
+    ]);
+  }
+  return '';
+};
+
+const ContractDefinition = {
+  print: ({ node, options, path, print }) =>
+    concat([
+      group(
+        concat([
+          node.kind,
+          ' ',
+          node.name,
+          inheritance(node, path, print),
+          line,
+          '{'
+        ])
+      ),
+      body(node, path, options, print),
+      '}'
+    ])
 };
 
 module.exports = ContractDefinition;

--- a/tests/ContractDefinitions/ContractDefinitions.sol
+++ b/tests/ContractDefinitions/ContractDefinitions.sol
@@ -1,0 +1,2 @@
+contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 {
+}

--- a/tests/ContractDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ContractDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContractDefinitions.sol 1`] = `
+contract ContractDefinition is Contract1, Contract2, Contract3, Contract4, Contract5 {
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract ContractDefinition is
+    Contract1,
+    Contract2,
+    Contract3,
+    Contract4,
+    Contract5
+{}
+
+`;

--- a/tests/ContractDefinitions/jsfmt.spec.js
+++ b/tests/ContractDefinitions/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
solving #113 

Before prettier
```Solidity
contract Foo is AContract, AnotherContract, YetAnotherContract, ThisShouldBeSplit {
  function foo(uint x, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8) {
    a = 1;
  }
}
```

After prettier
```Solidity
contract Foo is
    AContract,
    AnotherContract,
    YetAnotherContract,
    ThisShouldBeSplit
{
    function foo(
        uint x,
        uint x2,
        uint x3,
        uint x4,
        uint x5,
        uint x6,
        uint x7,
        uint x8
    ) {
        a = 1;
    }
}
```