### PR TITLE
avoid splitting parentheses of a function call without arguments

### DIFF
--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -1,48 +1,61 @@
+/* eslint-disable implicit-arrow-linebreak */
 const {
   doc: {
     builders: { concat, group, indent, join, line, softline }
   }
 } = require('prettier');
 
-const FunctionCall = {
-  print: ({ node, path, print }) => {
-    let doc;
-    if (node.names && node.names.length > 0) {
-      doc = concat([
-        '{',
-        group(
-          concat([
-            indent(
-              concat([
-                softline,
-                join(
-                  concat([',', line]),
-                  path
-                    .map(print, 'arguments')
-                    .map((arg, index) => concat([node.names[index], ': ', arg]))
-                )
-              ])
-            ),
-            softline
-          ])
-        ),
-        '}'
-      ]);
-    } else {
-      doc = group(
+const printObject = (node, path, print) =>
+  group(
+    concat([
+      '{',
+      indent(
         concat([
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'arguments'))
-            ])
-          ),
-          softline
+          softline,
+          join(
+            concat([',', line]),
+            path
+              .map(print, 'arguments')
+              .map((arg, index) => concat([node.names[index], ': ', arg]))
+          )
         ])
-      );
-    }
-    return concat([path.call(print, 'expression'), '(', doc, ')']);
+      ),
+      softline,
+      '}'
+    ])
+  );
+
+const printParameters = (node, path, print) =>
+  group(
+    concat([
+      indent(
+        concat([
+          softline,
+          join(concat([',', line]), path.map(print, 'arguments'))
+        ])
+      ),
+      softline
+    ])
+  );
+
+const printArguments = (node, path, print) => {
+  if (node.names && node.names.length > 0) {
+    return printObject(node, path, print);
   }
+  if (node.arguments && node.arguments.length > 0) {
+    return printParameters(node, path, print);
+  }
+  return '';
+};
+
+const FunctionCall = {
+  print: ({ node, path, print }) =>
+    concat([
+      path.call(print, 'expression'),
+      '(',
+      printArguments(node, path, print),
+      ')'
+    ])
 };
 
 module.exports = FunctionCall;

--- a/tests/FunctionCalls/FunctionCalls.sol
+++ b/tests/FunctionCalls/FunctionCalls.sol
@@ -1,0 +1,5 @@
+contract FunctionCalls {
+    function foo() {
+        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+}

--- a/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FunctionCalls.sol 1`] = `
+contract FunctionCalls {
+    function foo() {
+        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract FunctionCalls {
+    function foo() {
+        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+}
+
+`;

--- a/tests/FunctionCalls/jsfmt.spec.js
+++ b/tests/FunctionCalls/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
halfway fixing #115
still working on splitting function calls on the `.` character.