### PR TITLE
fixing array indentation and also solved the return statements.

### DIFF
--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -1,23 +1,29 @@
+/* eslint-disable implicit-arrow-linebreak */
 const {
   doc: {
-    builders: { concat, join }
+    builders: { concat, group, indent, join, line, softline }
   }
 } = require('prettier');
 
 const TupleExpression = {
-  print: ({ node, path, print }) => {
-    let doc;
-    // @TODO: remove hack once solidity-parser-antlr is fixed
-    if (node.components) {
-      doc = join(', ', path.map(print, 'components'));
-    } else {
-      doc = join(', ', path.map(print, 'elements'));
-    }
-    if (node.isArray) {
-      return concat(['[', doc, ']']);
-    }
-    return concat(['(', doc, ')']);
-  }
+  // @TODO: remove hack once solidity-parser-antlr is fixed
+  print: ({ node, path, print }) =>
+    group(
+      concat([
+        node.isArray ? '[' : '(',
+        indent(
+          concat([
+            softline,
+            join(
+              concat([',', line]),
+              path.map(print, node.components ? 'components' : 'elements')
+            )
+          ])
+        ),
+        softline,
+        node.isArray ? ']' : ')'
+      ])
+    )
 };
 
 module.exports = TupleExpression;

--- a/tests/Arrays/Arrays.sol
+++ b/tests/Arrays/Arrays.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.2;
+
+contract Arrays {
+    bytes32[] public permissions = [bytes32("addPartner"), bytes32("removePartner"), bytes32("addGroup"), bytes32("removeGroup"), bytes32("addUserToGroup"), bytes32("removeUserFromGroup"), bytes32("addSolution"), bytes32("removeSolution"), bytes32("addLibrary"), bytes32("removeLibrary"), bytes32("addPermissionToGroup"), bytes32("removePermissionFromGroup")];
+}

--- a/tests/Arrays/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Arrays/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Arrays.sol 1`] = `
+pragma solidity ^0.5.2;
+
+contract Arrays {
+    bytes32[] public permissions = [bytes32("addPartner"), bytes32("removePartner"), bytes32("addGroup"), bytes32("removeGroup"), bytes32("addUserToGroup"), bytes32("removeUserFromGroup"), bytes32("addSolution"), bytes32("removeSolution"), bytes32("addLibrary"), bytes32("removeLibrary"), bytes32("addPermissionToGroup"), bytes32("removePermissionFromGroup")];
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.2;
+
+contract Arrays {
+    bytes32[] public permissions = [
+        bytes32("addPartner"),
+        bytes32("removePartner"),
+        bytes32("addGroup"),
+        bytes32("removeGroup"),
+        bytes32("addUserToGroup"),
+        bytes32("removeUserFromGroup"),
+        bytes32("addSolution"),
+        bytes32("removeSolution"),
+        bytes32("addLibrary"),
+        bytes32("removeLibrary"),
+        bytes32("addPermissionToGroup"),
+        bytes32("removePermissionFromGroup")
+    ];
+}
+
+`;

--- a/tests/Arrays/jsfmt.spec.js
+++ b/tests/Arrays/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
@@ -87,7 +87,9 @@ contract IndexOf {
         if (a.length < 1 || b.length < 1 || (b.length > a.length)) {
             whatwastheval = -1;
             return -1;
-        } else if (a.length > (2 ** 128 - 1)) // since we have to be able to return -1 (if the char isn't found or input error), this function must return an "int" type with a max length of (2^128 - 1)
+        } else if (a.length > (
+            2 ** 128 - 1
+        )) // since we have to be able to return -1 (if the char isn't found or input error), this function must return an "int" type with a max length of (2^128 - 1)
         {
             whatwastheval = -1;
             return -1;
@@ -97,7 +99,9 @@ contract IndexOf {
                 if (a[i] == b[0]) // found the first char of b
                 {
                     subindex = 1;
-                    while (subindex < b.length && (i + subindex) < a.length && a[i + subindex] == b[subindex]) { // search until the chars don't match or until we reach the end of a or b
+                    while (subindex < b.length && (
+                        i + subindex
+                    ) < a.length && a[i + subindex] == b[subindex]) { // search until the chars don't match or until we reach the end of a or b
                         subindex++;
                     }
                     if (subindex == b.length) {

--- a/tests/StyleGuide/FunctionDeclaration.sol
+++ b/tests/StyleGuide/FunctionDeclaration.sol
@@ -81,7 +81,6 @@ contract FunctionDeclaration {
     {
         doSomething();
 
-        /* TODO: long return list should split */
         return (veryVeryLongReturnArg1,
                 veryVeryLongReturnArg1,
                 veryVeryLongReturnArg1);

--- a/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
@@ -250,7 +250,6 @@ contract FunctionDeclaration {
     {
         doSomething();
 
-        /* TODO: long return list should split */
         return (veryVeryLongReturnArg1,
                 veryVeryLongReturnArg1,
                 veryVeryLongReturnArg1);
@@ -398,8 +397,11 @@ contract FunctionDeclaration {
     {
         doSomething();
 
-        /* TODO: long return list should split */
-        return (veryVeryLongReturnArg1, veryVeryLongReturnArg1, veryVeryLongReturnArg1);
+        return (
+            veryVeryLongReturnArg1,
+            veryVeryLongReturnArg1,
+            veryVeryLongReturnArg1
+        );
     }
 }
 


### PR DESCRIPTION
Solving #145, by chance this also solves #140 (sorry @minggas).

However this uncovered 2 hidden bugs.

1. Trailing comments are considered in the `printWidth` rule.
2. `if` and `while` and `for` conditions should break in the logic operators. `||`, `&&`, `<`, `>`,`<=`, `>=`, `==`