### PR TITLE
Indent if while for body when splits

### DIFF
--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -1,8 +1,22 @@
 const {
   doc: {
-    builders: { concat, group, indent, line, softline }
+    builders: { concat, group, ifBreak, indent, line, softline }
   }
 } = require('prettier');
+
+const printBody = (node, path, print) => {
+  if (node.body.type === 'Block') {
+    return concat([' ', path.call(print, 'body')]);
+  }
+
+  return group(
+    concat([
+      ifBreak(concat([' {']), ''),
+      indent(concat([line, path.call(print, 'body')])),
+      ifBreak(concat([line, '}']), '')
+    ])
+  );
+};
 
 const ForStatement = {
   print: ({ node, path, print }) =>
@@ -25,10 +39,10 @@ const ForStatement = {
             ])
           ),
           softline,
-          ') '
+          ')'
         ])
       ),
-      path.call(print, 'body')
+      printBody(node, path, print)
     ])
 };
 

--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, group, ifBreak, indent, line, softline }
+    builders: { concat, group, indent, line, softline }
   }
 } = require('prettier');
 
@@ -9,13 +9,7 @@ const printBody = (node, path, print) => {
     return concat([' ', path.call(print, 'body')]);
   }
 
-  return group(
-    concat([
-      ifBreak(concat([' {']), ''),
-      indent(concat([line, path.call(print, 'body')])),
-      ifBreak(concat([line, '}']), '')
-    ])
-  );
+  return group(indent(concat([line, path.call(print, 'body')])));
 };
 
 const ForStatement = {

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -14,13 +14,18 @@ const printTrueBody = (node, path, print) => {
   }
 
   const ifWithinIf = node.trueBody.type === 'IfStatement';
+
   const openHug = ' {';
   const closeHug = concat([line, '}', node.falseBody ? ' ' : '']);
+
+  const openNotHug = '';
+  const closeNotHug = node.falseBody ? hardline : '';
+
   return group(
     concat([
-      ifBreak(openHug, ifWithinIf ? openHug : ''),
+      ifBreak(openHug, ifWithinIf ? openHug : openNotHug),
       indent(concat([line, path.call(print, 'trueBody')])),
-      ifBreak(closeHug, ifWithinIf ? closeHug : node.falseBody ? hardline : '')
+      ifBreak(closeHug, ifWithinIf ? closeHug : closeNotHug)
     ])
   );
 };

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -1,32 +1,17 @@
 const {
   doc: {
-    builders: { concat, group, hardline, ifBreak, indent, line, softline }
+    builders: { concat, group, hardline, indent, line, softline }
   }
 } = require('prettier');
 
 const printTrueBody = (node, path, print) => {
   if (node.trueBody.type === 'Block') {
-    return concat([
-      ' ',
-      path.call(print, 'trueBody'),
-      node.falseBody ? ' ' : ''
-    ]);
+    return concat([' ', path.call(print, 'trueBody')]);
   }
 
   const ifWithinIf = node.trueBody.type === 'IfStatement';
-
-  const openHug = ' {';
-  const closeHug = concat([line, '}', node.falseBody ? ' ' : '']);
-
-  const openNotHug = '';
-  const closeNotHug = node.falseBody ? hardline : '';
-
   return group(
-    concat([
-      ifBreak(openHug, ifWithinIf ? openHug : openNotHug),
-      indent(concat([line, path.call(print, 'trueBody')])),
-      ifBreak(closeHug, ifWithinIf ? closeHug : closeNotHug)
-    ])
+    indent(concat([ifWithinIf ? hardline : line, path.call(print, 'trueBody')]))
   );
 };
 
@@ -38,38 +23,35 @@ const printFalseBody = (node, path, print) => {
     return concat([' ', path.call(print, 'falseBody')]);
   }
 
-  return group(
-    concat([
-      ifBreak(' {', ''),
-      indent(concat([line, path.call(print, 'falseBody')])),
-      ifBreak(concat([line, '}']), '')
-    ])
-  );
+  return group(indent(concat([line, path.call(print, 'falseBody')])));
 };
-
-const printIf = (node, path, print) =>
-  concat([
-    group(
-      concat([
-        'if (',
-        indent(concat([softline, path.call(print, 'condition')])),
-        softline,
-        ')'
-      ])
-    ),
-    printTrueBody(node, path, print)
-  ]);
 
 const printElse = (node, path, print) => {
   if (node.falseBody) {
-    return concat(['else', printFalseBody(node, path, print)]);
+    const elseOnSameLine = node.trueBody.type === 'Block';
+    return concat([
+      elseOnSameLine ? ' ' : hardline,
+      'else',
+      printFalseBody(node, path, print)
+    ]);
   }
   return '';
 };
 
 const IfStatement = {
   print: ({ node, path, print }) =>
-    concat([printIf(node, path, print), printElse(node, path, print)])
+    concat([
+      group(
+        concat([
+          'if (',
+          indent(concat([softline, path.call(print, 'condition')])),
+          softline,
+          ')'
+        ])
+      ),
+      printTrueBody(node, path, print),
+      printElse(node, path, print)
+    ])
 };
 
 module.exports = IfStatement;

--- a/src/nodes/WhileStatement.js
+++ b/src/nodes/WhileStatement.js
@@ -1,21 +1,35 @@
 const {
   doc: {
-    builders: { concat, group, indent, softline }
+    builders: { concat, group, ifBreak, indent, line, softline }
   }
 } = require('prettier');
 
+const printBody = (node, path, print) => {
+  if (node.body.type === 'Block') {
+    return concat([' ', path.call(print, 'body')]);
+  }
+
+  return group(
+    concat([
+      ifBreak(concat([' {']), ''),
+      indent(concat([line, path.call(print, 'body')])),
+      ifBreak(concat([line, '}']), '')
+    ])
+  );
+};
+
 const WhileStatement = {
-  print: ({ path, print }) =>
+  print: ({ node, path, print }) =>
     concat([
       group(
         concat([
           'while (',
           indent(concat([softline, path.call(print, 'condition')])),
           softline,
-          ') '
+          ')'
         ])
       ),
-      path.call(print, 'body')
+      printBody(node, path, print)
     ])
 };
 

--- a/src/nodes/WhileStatement.js
+++ b/src/nodes/WhileStatement.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, group, ifBreak, indent, line, softline }
+    builders: { concat, group, indent, line, softline }
   }
 } = require('prettier');
 
@@ -9,13 +9,7 @@ const printBody = (node, path, print) => {
     return concat([' ', path.call(print, 'body')]);
   }
 
-  return group(
-    concat([
-      ifBreak(concat([' {']), ''),
-      indent(concat([line, path.call(print, 'body')])),
-      ifBreak(concat([line, '}']), '')
-    ])
-  );
+  return group(indent(concat([line, path.call(print, 'body')])));
 };
 
 const WhileStatement = {

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -532,8 +532,9 @@ library IntegerSet {
         returns (bool alreadyPresent)
     {
         uint index = self.index[value];
-        if (index > 0) return true;
-        else {
+        if (index > 0) {
+            return true;
+        } else {
             if (self.items.length == 0) self.items.length = 1;
             index = self.items.length++;
             self.items[index] = value;

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -532,9 +532,8 @@ library IntegerSet {
         returns (bool alreadyPresent)
     {
         uint index = self.index[value];
-        if (index > 0) {
-            return true;
-        } else {
+        if (index > 0) return true;
+        else {
             if (self.items.length == 0) self.items.length = 1;
             index = self.items.length++;
             self.items[index] = value;

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -86,9 +86,11 @@ contract Contract {
     }
 
     function ifBlockInOneLine(uint a) returns (uint b) {
-        if (a < 0) b = 0x67;
-        else if (a == 0) b = 0x12;
-        else b = 0x78;
+        if (a < 0) {
+            b = 0x67;
+        } else if (a == 0) {
+            b = 0x12;
+        } else b = 0x78;
     }
 
     function forWithoutBlock() {
@@ -98,10 +100,12 @@ contract Contract {
     }
 
     function fun(uint256 a) returns (uint) {
-        if (something) foo();
-        // comment
-        else if (somethingElse) bar();
-        else whatever();
+        if (something) {
+            foo();
+            // comment
+        } else if (somethingElse) {
+            bar();
+        } else whatever();
     }
 }
 

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -86,11 +86,9 @@ contract Contract {
     }
 
     function ifBlockInOneLine(uint a) returns (uint b) {
-        if (a < 0) {
-            b = 0x67;
-        } else if (a == 0) {
-            b = 0x12;
-        } else b = 0x78;
+        if (a < 0) b = 0x67;
+        else if (a == 0) b = 0x12;
+        else b = 0x78;
     }
 
     function forWithoutBlock() {
@@ -100,12 +98,11 @@ contract Contract {
     }
 
     function fun(uint256 a) returns (uint) {
-        if (something) {
+        if (something)
             foo();
             // comment
-        } else if (somethingElse) {
-            bar();
-        } else whatever();
+        else if (somethingElse) bar();
+        else whatever();
     }
 }
 

--- a/tests/ForStatements/ForStatements.sol
+++ b/tests/ForStatements/ForStatements.sol
@@ -1,0 +1,19 @@
+contract ForStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+
+        for (uint i; i < 100; i++) a++;
+
+        for (i = 0; i < 100; i++) a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+
+        for (i = 0; i < 100; i++) { a++; }
+
+        for (i = 0; i < 100; i++) { a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE); }
+
+        for (uint veryLongVariableName; veryLongVariableName < 100; veryLongVariableName++) a++;
+
+        for (veryLongVariableName = 0; veryLongVariableName < 100; veryLongVariableName++) { a++; }
+    }
+}

--- a/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
@@ -29,9 +29,8 @@ contract ForStatements {
 
         for (uint i; i < 100; i++) a++;
 
-        for (i = 0; i < 100; i++) {
+        for (i = 0; i < 100; i++)
             a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
-        }
 
         for (i = 0; i < 100; i++) {
             a++;

--- a/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForStatements.sol 1`] = `
+contract ForStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+
+        for (uint i; i < 100; i++) a++;
+
+        for (i = 0; i < 100; i++) a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+
+        for (i = 0; i < 100; i++) { a++; }
+
+        for (i = 0; i < 100; i++) { a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE); }
+
+        for (uint veryLongVariableName; veryLongVariableName < 100; veryLongVariableName++) a++;
+
+        for (veryLongVariableName = 0; veryLongVariableName < 100; veryLongVariableName++) { a++; }
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract ForStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+
+        for (uint i; i < 100; i++) a++;
+
+        for (i = 0; i < 100; i++) {
+            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+        }
+
+        for (i = 0; i < 100; i++) {
+            a++;
+        }
+
+        for (i = 0; i < 100; i++) {
+            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+        }
+
+        for (
+            uint veryLongVariableName;
+            veryLongVariableName < 100;
+            veryLongVariableName++
+        ) a++;
+
+        for (
+            veryLongVariableName = 0;
+            veryLongVariableName < 100;
+            veryLongVariableName++
+        ) {
+            a++;
+        }
+    }
+}
+
+`;

--- a/tests/ForStatements/jsfmt.spec.js
+++ b/tests/ForStatements/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/IfStatements/IfStatements.sol
+++ b/tests/IfStatements/IfStatements.sol
@@ -92,5 +92,21 @@ contract IfStatements {
         if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
         else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
         else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) return true; else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) {return true;} else {return false;}
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;} else {return false;}}
+
+        if (simpleIf) {if (simpleIfWithinIf) return true;} else return false;
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;}} else {return false;}
+
+        if (simpleIf) if (simpleIfWithinIf) return true; else return false; else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) {return true;} else {return false;} else {return false;}
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;} else {return false;}} else return false;
     }
 }

--- a/tests/IfStatements/IfStatements.sol
+++ b/tests/IfStatements/IfStatements.sol
@@ -2,53 +2,95 @@ contract IfStatements {
     function hi() public {
         if (simpleIf) return true;
 
-        if (simpleIf) {
-            return true;
-        }
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+
+        if (simpleIf) return true;
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else return false;
+
+        if (simpleIf) return true;
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false);
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false);
+        else return false;
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return false;
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
 
         if (simpleIf) { return true; }
-        else {
-            return false;
-        }
+
+        if (simpleIf) { return true; }
+        else return false;
 
         if (simpleIf) return true;
-        else
-            return false;
+        else { return false; }
 
-        if (simpleIf) {return true;}
-        else
-            return false;
+        if (simpleIf) { return true; }
+        else { return false; }
 
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) return (true,false);
+        else return false;
 
         if (simpleIf) return true;
-        else {
-            return false;
-        }
+        else if (simpleElseIf) return (true,false);
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) return (true,false);
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {
-            return true;
-        }
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) { return (true,false); }
+        else return false;
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
-        else {
-            return false;
-        }
+        if (simpleIf) return true;
+        else if (simpleElseIf) { return (true,false); }
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {return true;}
-        else {
-            return false;
-        }
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {return true;}
-        else
-            return false;
+        if (simpleIf) { return true; }
+        else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
+        else return false;
 
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
+        else if (simpleElseIf) { return (true,false); }
+        else return false;
 
-            if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
-            else
-                return false;
-
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
+        else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
+        else return false;
     }
 }

--- a/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
@@ -95,6 +95,22 @@ contract IfStatements {
         if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
         else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
         else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) return true; else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) {return true;} else {return false;}
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;} else {return false;}}
+
+        if (simpleIf) {if (simpleIfWithinIf) return true;} else return false;
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;}} else {return false;}
+
+        if (simpleIf) if (simpleIfWithinIf) return true; else return false; else return false;
+
+        if (simpleIf) if (simpleIfWithinIf) {return true;} else {return false;} else {return false;}
+
+        if (simpleIf) {if (simpleIfWithinIf) {return true;} else {return false;}} else return false;
     }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -478,6 +494,64 @@ contract IfStatements {
             ) * 1000
         ) {
             return (true, false);
+        } else return false;
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else return false;
+        }
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) return true;
+        } else return false;
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            }
+        } else {
+            return false;
+        }
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else return false;
+        } else return false;
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        if (simpleIf) {
+            if (simpleIfWithinIf) {
+                return true;
+            } else {
+                return false;
+            }
         } else return false;
     }
 }

--- a/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
@@ -5,54 +5,96 @@ contract IfStatements {
     function hi() public {
         if (simpleIf) return true;
 
-        if (simpleIf) {
-            return true;
-        }
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+
+        if (simpleIf) return true;
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else return false;
+
+        if (simpleIf) return true;
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false);
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false);
+        else return false;
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return false;
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return false;
+
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
+
+        if (simpleIf) return (true,true,true,true,true,true,true,true,true,true,true);
+        else if (simpleElseIf) return (true,false,true,false,true,false,true,false,true,false);
+        else return (false,false,false,false,false,false,false,false,false,false,false);
 
         if (simpleIf) { return true; }
-        else {
-            return false;
-        }
+
+        if (simpleIf) { return true; }
+        else return false;
 
         if (simpleIf) return true;
-        else
-            return false;
+        else { return false; }
 
-        if (simpleIf) {return true;}
-        else
-            return false;
+        if (simpleIf) { return true; }
+        else { return false; }
 
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) return (true,false);
+        else return false;
 
         if (simpleIf) return true;
-        else {
-            return false;
-        }
+        else if (simpleElseIf) return (true,false);
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) return (true,false);
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {
-            return true;
-        }
+        if (simpleIf) { return true; }
+        else if (simpleElseIf) { return (true,false); }
+        else return false;
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
-        else {
-            return false;
-        }
+        if (simpleIf) return true;
+        else if (simpleElseIf) { return (true,false); }
+        else { return false; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {return true;}
-        else {
-            return false;
-        }
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
 
-        if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) {return true;}
-        else
-            return false;
+        if (simpleIf) { return true; }
+        else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
+        else return false;
 
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
+        else if (simpleElseIf) { return (true,false); }
+        else return false;
 
-            if (thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition) return true;
-            else
-                return false;
-
+        if (veryComplicatedComputation(variable1, variable2) == (400 + 500) * 1000) { return true; }
+        else if (veryComplicatedComputation(variable3, variable4) == (400 + 500) * 1000) { return (true,false); }
+        else return false;
     }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +103,297 @@ contract IfStatements {
         if (simpleIf) return true;
 
         if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        }
+
+        if (simpleIf) {
             return true;
+        } else return false;
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else return false;
+
+        if (simpleIf) {
+            return true;
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else return false;
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else return false;
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false
+            );
+        } else return false;
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else if (simpleElseIf) {
+            return (
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false
+            );
+        } else return false;
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false
+            );
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return (
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true
+            );
+        } else if (simpleElseIf) {
+            return (
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                false
+            );
+        } else {
+            return (
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            );
+        }
+
+        if (simpleIf) {
+            return true;
+        }
+
+        if (simpleIf) {
+            return true;
+        } else return false;
+
+        if (simpleIf) {
+            return true;
+        } else {
+            return false;
         }
 
         if (simpleIf) {
@@ -70,54 +402,83 @@ contract IfStatements {
             return false;
         }
 
-        if (simpleIf) return true;
-        else return false;
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else return false;
 
         if (simpleIf) {
             return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else {
+            return false;
+        }
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else {
+            return false;
+        }
+
+        if (simpleIf) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
         } else return false;
 
-        if (simpleIf) return true;
-        else {
-            return false;
-        }
-
-        if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
-        ) return true;
-
-        if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
-        ) {
+        if (simpleIf) {
             return true;
-        }
-
-        if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
-        ) return true;
-        else {
-            return false;
-        }
-
-        if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
-        ) {
-            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
         } else {
             return false;
         }
 
         if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
+            veryComplicatedComputation(variable1, variable2) == (
+                400 + 500
+            ) * 1000
         ) {
             return true;
+        }
+
+        if (simpleIf) {
+            return true;
+        } else if (
+            veryComplicatedComputation(variable3, variable4) == (
+                400 + 500
+            ) * 1000
+        ) {
+            return (true, false);
         } else return false;
 
         if (
-            thisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongCondition
-        ) return true;
-        else return false;
+            veryComplicatedComputation(variable1, variable2) == (
+                400 + 500
+            ) * 1000
+        ) {
+            return true;
+        } else if (simpleElseIf) {
+            return (true, false);
+        } else return false;
 
+        if (
+            veryComplicatedComputation(variable1, variable2) == (
+                400 + 500
+            ) * 1000
+        ) {
+            return true;
+        } else if (
+            veryComplicatedComputation(variable3, variable4) == (
+                400 + 500
+            ) * 1000
+        ) {
+            return (true, false);
+        } else return false;
     }
 }
 

--- a/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IfStatements/__snapshots__/jsfmt.spec.js.snap
@@ -118,7 +118,7 @@ contract IfStatements {
     function hi() public {
         if (simpleIf) return true;
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -132,13 +132,11 @@ contract IfStatements {
                 true,
                 true
             );
-        }
 
-        if (simpleIf) {
-            return true;
-        } else return false;
+        if (simpleIf) return true;
+        else return false;
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -152,11 +150,10 @@ contract IfStatements {
                 true,
                 true
             );
-        } else return false;
+        else return false;
 
-        if (simpleIf) {
-            return true;
-        } else {
+        if (simpleIf) return true;
+        else
             return (
                 false,
                 false,
@@ -170,9 +167,8 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -186,7 +182,7 @@ contract IfStatements {
                 true,
                 true
             );
-        } else {
+        else
             return (
                 false,
                 false,
@@ -200,15 +196,12 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else return false;
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true, false);
+        else return false;
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -222,15 +215,12 @@ contract IfStatements {
                 true,
                 true
             );
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else return false;
+        else if (simpleElseIf) return (true, false);
+        else return false;
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else {
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true, false);
+        else
             return (
                 false,
                 false,
@@ -244,9 +234,8 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -260,9 +249,8 @@ contract IfStatements {
                 true,
                 true
             );
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else {
+        else if (simpleElseIf) return (true, false);
+        else
             return (
                 false,
                 false,
@@ -276,11 +264,9 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
+        if (simpleIf) return true;
+        else if (simpleElseIf)
             return (
                 true,
                 false,
@@ -293,9 +279,9 @@ contract IfStatements {
                 true,
                 false
             );
-        } else return false;
+        else return false;
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -309,7 +295,7 @@ contract IfStatements {
                 true,
                 true
             );
-        } else if (simpleElseIf) {
+        else if (simpleElseIf)
             return (
                 true,
                 false,
@@ -322,11 +308,10 @@ contract IfStatements {
                 true,
                 false
             );
-        } else return false;
+        else return false;
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
+        if (simpleIf) return true;
+        else if (simpleElseIf)
             return (
                 true,
                 false,
@@ -339,7 +324,7 @@ contract IfStatements {
                 true,
                 false
             );
-        } else {
+        else
             return (
                 false,
                 false,
@@ -353,9 +338,8 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
-        if (simpleIf) {
+        if (simpleIf)
             return (
                 true,
                 true,
@@ -369,7 +353,7 @@ contract IfStatements {
                 true,
                 true
             );
-        } else if (simpleElseIf) {
+        else if (simpleElseIf)
             return (
                 true,
                 false,
@@ -382,7 +366,7 @@ contract IfStatements {
                 true,
                 false
             );
-        } else {
+        else
             return (
                 false,
                 false,
@@ -396,7 +380,6 @@ contract IfStatements {
                 false,
                 false
             );
-        }
 
         if (simpleIf) {
             return true;
@@ -406,9 +389,8 @@ contract IfStatements {
             return true;
         } else return false;
 
-        if (simpleIf) {
-            return true;
-        } else {
+        if (simpleIf) return true;
+        else {
             return false;
         }
 
@@ -420,23 +402,19 @@ contract IfStatements {
 
         if (simpleIf) {
             return true;
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else return false;
+        } else if (simpleElseIf) return (true, false);
+        else return false;
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else {
+        if (simpleIf) return true;
+        else if (simpleElseIf) return (true, false);
+        else {
             return false;
         }
 
         if (simpleIf) {
             return true;
-        } else if (simpleElseIf) {
-            return (true, false);
-        } else {
+        } else if (simpleElseIf) return (true, false);
+        else {
             return false;
         }
 
@@ -446,9 +424,8 @@ contract IfStatements {
             return (true, false);
         } else return false;
 
-        if (simpleIf) {
-            return true;
-        } else if (simpleElseIf) {
+        if (simpleIf) return true;
+        else if (simpleElseIf) {
             return (true, false);
         } else {
             return false;
@@ -496,19 +473,16 @@ contract IfStatements {
             return (true, false);
         } else return false;
 
-        if (simpleIf) {
-            if (simpleIfWithinIf) {
-                return true;
-            } else return false;
-        }
+        if (simpleIf)
+            if (simpleIfWithinIf) return true;
+            else return false;
 
-        if (simpleIf) {
+        if (simpleIf)
             if (simpleIfWithinIf) {
                 return true;
             } else {
                 return false;
             }
-        }
 
         if (simpleIf) {
             if (simpleIfWithinIf) {
@@ -530,19 +504,18 @@ contract IfStatements {
             return false;
         }
 
-        if (simpleIf) {
-            if (simpleIfWithinIf) {
-                return true;
-            } else return false;
-        } else return false;
+        if (simpleIf)
+            if (simpleIfWithinIf) return true;
+            else return false;
+        else return false;
 
-        if (simpleIf) {
+        if (simpleIf)
             if (simpleIfWithinIf) {
                 return true;
             } else {
                 return false;
             }
-        } else {
+        else {
             return false;
         }
 

--- a/tests/WhileStatements/WhileStatements.sol
+++ b/tests/WhileStatements/WhileStatements.sol
@@ -1,0 +1,20 @@
+contract WhileStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+        uint veryLongVariableName;
+
+        while (a < 100) a++;
+
+        while (a < 200) a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+
+        while (a < 300) { a++; }
+
+        while (a < 400) { a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE); }
+
+        while (a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 500) a++;
+
+        while (a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 600) { a++; }
+    }
+}

--- a/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WhileStatements.sol 1`] = `
+contract WhileStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+        uint veryLongVariableName;
+
+        while (a < 100) a++;
+
+        while (a < 200) a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+
+        while (a < 300) { a++; }
+
+        while (a < 400) { a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE); }
+
+        while (a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 500) a++;
+
+        while (a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 600) { a++; }
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract WhileStatements {
+    uint constant LONG_VARIABLE = 1;
+
+    function hi() public {
+        uint a;
+        uint veryLongVariableName;
+
+        while (a < 100) a++;
+
+        while (a < 200) {
+            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+        }
+
+        while (a < 300) {
+            a++;
+        }
+
+        while (a < 400) {
+            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+        }
+
+        while (
+            a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 500
+        ) a++;
+
+        while (
+            a < veryLongVariableName.add(LONG_VARIABLE).add(LONG_VARIABLE) * 600
+        ) {
+            a++;
+        }
+    }
+}
+
+`;

--- a/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
@@ -31,9 +31,8 @@ contract WhileStatements {
 
         while (a < 100) a++;
 
-        while (a < 200) {
+        while (a < 200)
             a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
-        }
 
         while (a < 300) {
             a++;

--- a/tests/WhileStatements/jsfmt.spec.js
+++ b/tests/WhileStatements/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
while solving #138
I found that there's a mismatch between the AST for `if (x) return true;` and `if (x) { return true; }`.
Nonetheless, I found some benefits in the exercise of creating the feature so for the moment as a compromise, this PR indents the bodies of an `IfStatement`, `ForStatement`, and `WhileStatement` in case of them being too long.
I also added the case of forcing the indentation of a nested `if`.
```Solidity
// Before Prettier
if (a) if (b) return true; else return false; else if (c) break; else throw;

// After Prettier
if (a)
    if (b) return true;
    else return false;
else if (c) break;
else throw;
```
