### PR TITLE
Fixing "Modifier-style base constructor call without arguments" compiling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "extract-comments": "^1.1.0",
     "prettier": "^1.15.3",
     "semver": "^5.6.0",
-    "solidity-parser-antlr": "^0.4.0",
+    "solidity-parser-antlr": "^0.4.4",
     "string-width": "^3.0.0"
   }
 }

--- a/src/nodes/ModifierInvocation.js
+++ b/src/nodes/ModifierInvocation.js
@@ -4,7 +4,7 @@ const {
   }
 } = require('prettier');
 
-const modifierArguments = (node, path, print, options) => {
+const modifierArguments = (node, path, print) => {
   if (node.arguments && node.arguments.length > 0) {
     return group(
       concat([
@@ -20,6 +20,7 @@ const modifierArguments = (node, path, print, options) => {
       ])
     );
   }
+
   // TODO: remove Capital letter Hack once solidity-parser-antlr fixes this
   if (
     path.getParentNode().isConstructor && // if we are in a Constructor.
@@ -31,8 +32,8 @@ const modifierArguments = (node, path, print, options) => {
 };
 
 const ModifierInvocation = {
-  print: ({ node, path, print, options }) =>
-    concat([node.name, modifierArguments(node, path, print, options)])
+  print: ({ node, path, print }) =>
+    concat([node.name, modifierArguments(node, path, print)])
 };
 
 module.exports = ModifierInvocation;

--- a/src/nodes/ModifierInvocation.js
+++ b/src/nodes/ModifierInvocation.js
@@ -5,29 +5,26 @@ const {
 } = require('prettier');
 
 const modifierArguments = (node, path, print) => {
-  if (node.arguments && node.arguments.length > 0) {
-    return group(
-      concat([
-        '(',
-        indent(
-          concat([
-            softline,
-            join(concat([',', line]), path.map(print, 'arguments'))
-          ])
-        ),
-        softline,
-        ')'
-      ])
-    );
-  }
+  if (node.arguments) {
+    if (node.arguments.length > 0) {
+      return group(
+        concat([
+          '(',
+          indent(
+            concat([
+              softline,
+              join(concat([',', line]), path.map(print, 'arguments'))
+            ])
+          ),
+          softline,
+          ')'
+        ])
+      );
+    }
 
-  // TODO: remove Capital letter Hack once solidity-parser-antlr fixes this
-  if (
-    path.getParentNode().isConstructor && // if we are in a Constructor.
-    node.name[0] !== node.name[0].toLowerCase() // Modifier starts with a Capital letter.
-  ) {
     return '()';
   }
+
   return '';
 };
 

--- a/src/nodes/ModifierInvocation.js
+++ b/src/nodes/ModifierInvocation.js
@@ -1,17 +1,38 @@
 const {
   doc: {
-    builders: { concat, join }
+    builders: { concat, group, indent, join, line, softline }
   }
 } = require('prettier');
 
-const ModifierInvocation = {
-  print: ({ node, path, print }) => {
-    let doc = node.name;
-    if (node.arguments && node.arguments.length > 0) {
-      doc = concat([doc, '(', join(', ', path.map(print, 'arguments')), ')']);
-    }
-    return doc;
+const modifierArguments = (node, path, print, options) => {
+  if (node.arguments && node.arguments.length > 0) {
+    return group(
+      concat([
+        '(',
+        indent(
+          concat([
+            softline,
+            join(concat([',', line]), path.map(print, 'arguments'))
+          ])
+        ),
+        softline,
+        ')'
+      ])
+    );
   }
+  // TODO: remove Capital letter Hack once solidity-parser-antlr fixes this
+  if (
+    path.getParentNode().isConstructor && // if we are in a Constructor.
+    node.name[0] !== node.name[0].toLowerCase() // Modifier starts with a Capital letter.
+  ) {
+    return '()';
+  }
+  return '';
+};
+
+const ModifierInvocation = {
+  print: ({ node, path, print, options }) =>
+    concat([node.name, modifierArguments(node, path, print, options)])
 };
 
 module.exports = ModifierInvocation;

--- a/tests/Constructors/Constructors.sol
+++ b/tests/Constructors/Constructors.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.5.2;
+
+contract Constructors is Ownable, Changeable {
+  function Constructors(variable1) public Changeable(variable1) Ownable() onlyOwner {
+  }
+
+  constructor(variable1, variable2, variable3, variable4, variable5, variable6, variable7) public Changeable(variable1, variable2, variable3, variable4, variable5, variable6, variable7) Ownable() onlyOwner {}
+}

--- a/tests/Constructors/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Constructors/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Constructors.sol 1`] = `
+pragma solidity ^0.5.2;
+
+contract Constructors is Ownable, Changeable {
+  function Constructors(variable1) public Changeable(variable1) Ownable() onlyOwner {
+  }
+
+  constructor(variable1, variable2, variable3, variable4, variable5, variable6, variable7) public Changeable(variable1, variable2, variable3, variable4, variable5, variable6, variable7) Ownable() onlyOwner {}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.2;
+
+contract Constructors is Ownable, Changeable {
+    function Constructors(variable1)
+        public
+        Changeable(variable1)
+        Ownable()
+        onlyOwner
+    {}
+
+    constructor(
+        variable1,
+        variable2,
+        variable3,
+        variable4,
+        variable5,
+        variable6,
+        variable7
+    )
+        public
+        Changeable(
+            variable1,
+            variable2,
+            variable3,
+            variable4,
+            variable5,
+            variable6,
+            variable7
+        )
+        Ownable()
+        onlyOwner
+    {}
+}
+
+`;

--- a/tests/Constructors/jsfmt.spec.js
+++ b/tests/Constructors/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
@@ -90,7 +90,7 @@ contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
     )
         public
         CappedCrowdsale(_cap)
-        FinalizableCrowdsale
+        FinalizableCrowdsale()
         RefundableCrowdsale(_goal)
         Crowdsale(_startTime, _endTime, _rate, _wallet)
     {


### PR DESCRIPTION
Fixes #160 

the AST doesn't give us much info regarding modifiers metadata.
In this case, I'm relying on Constructor calls starting with an Uppercase letter.

I'll write an issue in [solidity-parser-antlr](https://github.com/federicobond/solidity-parser-antlr/issues/67) to see if they can solve this one.