### PR TITLE
indenting chained member and function call

### DIFF
--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -1,12 +1,30 @@
 const {
   doc: {
-    builders: { concat }
+    builders: { concat, group, indent, softline }
   }
 } = require('prettier');
 
+const isBeginnigOfChain = path => {
+  const parentNodeType = path.getParentNode().type;
+
+  if (parentNodeType === 'MemberAccess') return false;
+  if (parentNodeType === 'FunctionCall') {
+    const grandParentNodeType = path.getParentNode(1).type;
+    return grandParentNodeType !== 'MemberAccess';
+  }
+
+  return true;
+};
+
 const MemberAccess = {
-  print: ({ node, path, print }) =>
-    concat([path.call(print, 'expression'), '.', node.memberName])
+  print: ({ node, path, print }) => {
+    const doc = concat([
+      path.call(print, 'expression'),
+      indent(concat([softline, '.', node.memberName]))
+    ]);
+
+    return isBeginnigOfChain(path) ? group(doc) : doc;
+  }
 };
 
 module.exports = MemberAccess;

--- a/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,8 @@ contract FunctionCalls {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract FunctionCalls {
     function foo() {
-        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+        address veryLongValidatorAddress = veryVeryVeryLongSignature
+            .popLast20Bytes();
     }
 }
 

--- a/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
@@ -100,9 +100,8 @@ contract IndexOf {
                 {
                     subindex = 1;
                     while (
-                        subindex < b.length && (
-                            i + subindex
-                        ) < a.length && a[i + subindex] == b[subindex] // search until the chars don't match or until we reach the end of a or b
+                        subindex < b.length && (i + subindex) < a
+                            .length && a[i + subindex] == b[subindex] // search until the chars don't match or until we reach the end of a or b
                     ) {
                         subindex++;
                     }

--- a/tests/MemberAccess/MemberAccess.sol
+++ b/tests/MemberAccess/MemberAccess.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+contract MemberAccess {
+    function() {
+        a.b.c.d;
+        a.b().c.d;
+        a.b.c.d();
+        a.b().c().d();
+        veryLongVariable.veryLongMember.veryLongMember.veryLongMember.veryLongMember.veryLongMember;
+        veryLongVariable.veryLongCall(veryLongAttribute).veryLongMember.veryLongMember.veryLongMember;
+        veryLongVariable.veryLongMember.veryLongCall(veryLongAttribute).veryLongMember.veryLongMember;
+        veryLongVariable.veryLongMember.veryLongMember.veryLongMember.veryLongCall(veryLongAttribute);
+        veryLongVariable.veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute);
+    }
+}

--- a/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MemberAccess.sol 1`] = `
+pragma solidity ^0.5.0;
+
+contract MemberAccess {
+    function() {
+        a.b.c.d;
+        a.b().c.d;
+        a.b.c.d();
+        a.b().c().d();
+        veryLongVariable.veryLongMember.veryLongMember.veryLongMember.veryLongMember.veryLongMember;
+        veryLongVariable.veryLongCall(veryLongAttribute).veryLongMember.veryLongMember.veryLongMember;
+        veryLongVariable.veryLongMember.veryLongCall(veryLongAttribute).veryLongMember.veryLongMember;
+        veryLongVariable.veryLongMember.veryLongMember.veryLongMember.veryLongCall(veryLongAttribute);
+        veryLongVariable.veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute);
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.0;
+
+contract MemberAccess {
+    function() {
+        a.b.c.d;
+        a.b().c.d;
+        a.b.c.d();
+        a.b().c().d();
+        veryLongVariable
+            .veryLongMember
+            .veryLongMember
+            .veryLongMember
+            .veryLongMember
+            .veryLongMember;
+        veryLongVariable
+            .veryLongCall(veryLongAttribute)
+            .veryLongMember
+            .veryLongMember
+            .veryLongMember;
+        veryLongVariable
+            .veryLongMember
+            .veryLongCall(veryLongAttribute)
+            .veryLongMember
+            .veryLongMember;
+        veryLongVariable
+            .veryLongMember
+            .veryLongMember
+            .veryLongMember
+            .veryLongCall(veryLongAttribute);
+        veryLongVariable
+            .veryLongCall(veryLongAttribute)
+            .veryLongCall(veryLongAttribute)
+            .veryLongCall(veryLongAttribute);
+    }
+}
+
+`;

--- a/tests/MemberAccess/jsfmt.spec.js
+++ b/tests/MemberAccess/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
@@ -80,15 +80,12 @@ contract SplittableCommodity is MintableCommodity {
         public
         whenNotPaused
     {
-        address supplierProxy = IContractRegistry(
-            contractRegistry
-        ).getLatestProxyAddr("Supplier");
+        address supplierProxy = IContractRegistry(contractRegistry)
+            .getLatestProxyAddr("Supplier");
         require(
-            msg.sender == IContractRegistry(
-                contractRegistry
-            ).getLatestProxyAddr("FifoCrcMarket") || ISupplier(
-                supplierProxy
-            ).isAllowed(this, "IMintableCommodity"),
+            msg.sender == IContractRegistry(contractRegistry)
+                .getLatestProxyAddr("FifoCrcMarket") || ISupplier(supplierProxy)
+                .isAllowed(this, "IMintableCommodity"),
             "Splitting can only be done when both the ISplittableCommodity interface is enabled and is called by a supplier or the FifoCrcMarket is used."
         );
 
@@ -109,9 +106,8 @@ contract SplittableCommodity is MintableCommodity {
         );
 
         if (
-            msg.sender == IContractRegistry(
-                contractRegistry
-            ).getLatestProxyAddr("FifoCrcMarket")
+            msg.sender == IContractRegistry(contractRegistry)
+                .getLatestProxyAddr("FifoCrcMarket")
         ) {
             _transfer(ownerOf(_tokenId), _to, newCRCId);
         } else {

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1500,12 +1500,8 @@ library strings {
         pure
         returns (bool)
     {
-        return rfindPtr(
-            self._len,
-            self._ptr,
-            needle._len,
-            needle._ptr
-        ) != self._ptr;
+        return rfindPtr(self._len, self._ptr, needle._len, needle._ptr) != self
+            ._ptr;
     }
 
     /*


### PR DESCRIPTION
closes #115 
Before this PR

```Solidity
veryLongVariable.veryLongMember.veryLongMember.veryLongMember.veryLongMember.veryLongMember;
```

After this PR
```Solidity
veryLongVariable
    .veryLongMember
    .veryLongMember
    .veryLongMember
    .veryLongMember
    .veryLongMember;
```

This cleans up the code in many places, so the snapshot where updated and reviewed.