### PR TITLE
adding vs-code integration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const languages = [
   {
     extensions: ['.sol'],
     name: 'Solidity',
-    parsers: ['solidity-parse']
+    parsers: ['solidity-parse'],
+    vscodeLanguageIds: ['solidity']
   }
 ];
 


### PR DESCRIPTION
There's a PR for `prettier-vscode` that will allow the use of third-party plugins.

Steps:
- uninstall `prettier-vscode` (if you had it)
- uncheck Extensions: Auto Update
- install `prettier-vscode` using the instructions from https://github.com/prettier/prettier-vscode/pull/757
- have prettier and prettier-plugin-solidity in your project.
  `npm install --save-dev prettier prettier-plugin-solidity`
- config format on save

Once `prettier-vscode` has accepted the PR.
- reinstall `prettier-vscode` from the official release.