### PR TITLE
 Adding support for the common configuration spacingBrackets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const { handleComments } = require('./prettier-comments');
 
 const massageAstNode = require('./clean');
 const loc = require('./loc');
+const options = require('./options');
 const parse = require('./parser');
 const print = require('./printer');
 
@@ -57,7 +58,7 @@ const printers = {
 
 // https://prettier.io/docs/en/plugins.html#defaultoptions
 const defaultOptions = {
-  // @TODO fix indentation in block comments
+  bracketSpacing: false,
   tabWidth: 4
 };
 
@@ -65,5 +66,6 @@ module.exports = {
   languages,
   parsers,
   printers,
+  options,
   defaultOptions
 };

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -1,18 +1,26 @@
 const {
   doc: {
-    builders: { concat, join }
+    builders: { concat, group, indent, join, line, softline }
   }
 } = require('prettier');
 
 const EnumDefinition = {
-  print: ({ node, path, print }) =>
-    concat([
-      'enum ',
-      node.name,
-      ' {',
-      join(', ', path.map(print, 'members')),
-      '}'
-    ])
+  print: ({ node, path, print, options }) =>
+    group(
+      concat([
+        'enum ',
+        node.name,
+        ' {',
+        indent(
+          concat([
+            options.bracketSpacing ? line : softline,
+            join(concat([',', line]), path.map(print, 'members'))
+          ])
+        ),
+        options.bracketSpacing ? line : softline,
+        '}'
+      ])
+    )
 };
 
 module.exports = EnumDefinition;

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -4,13 +4,13 @@ const {
   }
 } = require('prettier');
 
-const printObject = (node, path, print) =>
+const printObject = (node, path, print, options) =>
   group(
     concat([
       '{',
       indent(
         concat([
-          softline,
+          options.bracketSpacing ? line : softline,
           join(
             concat([',', line]),
             path
@@ -19,7 +19,7 @@ const printObject = (node, path, print) =>
           )
         ])
       ),
-      softline,
+      options.bracketSpacing ? line : softline,
       '}'
     ])
   );
@@ -37,9 +37,9 @@ const printParameters = (node, path, print) =>
     ])
   );
 
-const printArguments = (node, path, print) => {
+const printArguments = (node, path, print, options) => {
   if (node.names && node.names.length > 0) {
-    return printObject(node, path, print);
+    return printObject(node, path, print, options);
   }
   if (node.arguments && node.arguments.length > 0) {
     return printParameters(node, path, print);
@@ -48,11 +48,11 @@ const printArguments = (node, path, print) => {
 };
 
 const FunctionCall = {
-  print: ({ node, path, print }) =>
+  print: ({ node, path, print, options }) =>
     concat([
       path.call(print, 'expression'),
       '(',
-      printArguments(node, path, print),
+      printArguments(node, path, print, options),
       ')'
     ])
 };

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,54 @@
+const CATEGORY_GLOBAL = 'Global';
+const CATEGORY_COMMON = 'Common';
+
+const options = {
+  bracketSpacing: {
+    since: '0.0.0',
+    category: CATEGORY_COMMON,
+    type: 'boolean',
+    default: false,
+    description: 'Print spaces between brackets.',
+    oppositeDescription: 'Do not print spaces between brackets.'
+  },
+  printWidth: {
+    since: '0.0.0',
+    category: CATEGORY_GLOBAL,
+    type: 'int',
+    default: 80,
+    description: 'The line length where Prettier will try wrap.',
+    range: {
+      start: 0,
+      end: Infinity,
+      step: 1
+    }
+  },
+  // TODO: uncomment when https://github.com/prettier-solidity/prettier-plugin-solidity/pull/144
+  //       is merged.
+  // singleQuote: {
+  //   since: '0.0.0',
+  //   category: CATEGORY_COMMON,
+  //   type: 'boolean',
+  //   default: false,
+  //   description: 'Use single quotes instead of double quotes.'
+  // },
+  tabWidth: {
+    type: 'int',
+    category: CATEGORY_GLOBAL,
+    default: 4,
+    description: 'Number of spaces per indentation level.',
+    range: {
+      start: 0,
+      end: Infinity,
+      step: 1
+    }
+  },
+  useTabs: {
+    since: '1.0.0',
+    category: CATEGORY_GLOBAL,
+    type: 'boolean',
+    default: false,
+    description: 'Indent with tabs instead of spaces.'
+  }
+};
+
+module.exports = options;

--- a/tests/EnumDefinitions/EnumDefinitions.sol
+++ b/tests/EnumDefinitions/EnumDefinitions.sol
@@ -1,0 +1,4 @@
+contract EnumDefinitions {
+    enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+}

--- a/tests/EnumDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/EnumDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnumDefinitions.sol 1`] = `
+contract EnumDefinitions {
+    enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract EnumDefinitions {
+    enum ActionChoices {GoLeft, GoRight, GoStraight, SitStill}
+    enum States {
+        State1,
+        State2,
+        State3,
+        State4,
+        State5,
+        State6,
+        State7,
+        State8,
+        State9
+    }
+}
+
+`;
+
+exports[`EnumDefinitions.sol 2`] = `
+contract EnumDefinitions {
+    enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum States { State1, State2, State3, State4, State5, State6, State7, State8, State9 }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract EnumDefinitions {
+    enum ActionChoices { GoLeft, GoRight, GoStraight, SitStill }
+    enum States {
+        State1,
+        State2,
+        State3,
+        State4,
+        State5,
+        State6,
+        State7,
+        State8,
+        State9
+    }
+}
+
+`;

--- a/tests/EnumDefinitions/jsfmt.spec.js
+++ b/tests/EnumDefinitions/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, { bracketSpacing: true });

--- a/tests/FunctionCalls/FunctionCalls.sol
+++ b/tests/FunctionCalls/FunctionCalls.sol
@@ -2,4 +2,18 @@ contract FunctionCalls {
     function foo() {
         address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
     }
+
+    function foo() {
+      Voter you = Voter(1, true);
+
+      Voter me = Voter({
+          weight: 2,
+          voted: abstain()
+      });
+
+      Voter airbnb = Voter({
+        weight: 2,
+        voted: true,
+      });
+    }
 }

--- a/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -5,11 +5,70 @@ contract FunctionCalls {
     function foo() {
         address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
     }
+
+    function foo() {
+      Voter you = Voter(1, true);
+
+      Voter me = Voter({
+          weight: 2,
+          voted: abstain()
+      });
+
+      Voter airbnb = Voter({
+        weight: 2,
+        voted: true,
+      });
+    }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract FunctionCalls {
     function foo() {
         address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+
+    function foo() {
+        Voter you = Voter(1, true);
+
+        Voter me = Voter({weight: 2, voted: abstain()});
+
+        Voter airbnb = Voter({weight: 2, voted: true});
+    }
+}
+
+`;
+
+exports[`FunctionCalls.sol 2`] = `
+contract FunctionCalls {
+    function foo() {
+        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+
+    function foo() {
+      Voter you = Voter(1, true);
+
+      Voter me = Voter({
+          weight: 2,
+          voted: abstain()
+      });
+
+      Voter airbnb = Voter({
+        weight: 2,
+        voted: true,
+      });
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract FunctionCalls {
+    function foo() {
+        address veryLongValidatorAddress = veryVeryVeryLongSignature.popLast20Bytes();
+    }
+
+    function foo() {
+        Voter you = Voter(1, true);
+
+        Voter me = Voter({ weight: 2, voted: abstain() });
+
+        Voter airbnb = Voter({ weight: 2, voted: true });
     }
 }
 

--- a/tests/FunctionCalls/jsfmt.spec.js
+++ b/tests/FunctionCalls/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname);
+run_spec(__dirname, { bracketSpacing: true });


### PR DESCRIPTION
Additionally added the options object.
Prettier would not accept the default option `false` until I described it in this object.
Reading the official plugins, they relist every supported option, so I figured we do the same here.

As following the style guide, the default is no space.
