### PR TITLE
Adding the option to standardise the type declarations

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,6 @@
 const CATEGORY_GLOBAL = 'Global';
 const CATEGORY_COMMON = 'Common';
+const CATEGORY_SOLIDITY = 'Solidity';
 
 const options = {
   bracketSpacing: {
@@ -48,6 +49,27 @@ const options = {
     type: 'boolean',
     default: false,
     description: 'Indent with tabs instead of spaces.'
+  },
+  explicitTypes: {
+    category: CATEGORY_SOLIDITY,
+    type: 'choice',
+    default: 'always',
+    description: 'Change when type aliases are used.',
+    choices: [
+      {
+        value: 'always',
+        description:
+          'Prefer the explicit types `uint256`, `int256`, and `bytes1`.'
+      },
+      {
+        value: 'never',
+        description: 'Prefer the type aliases `uint`, `int`, and `byte`.'
+      },
+      {
+        value: 'preserve',
+        description: 'Respect the type used by the developer.'
+      }
+    ]
   }
 };
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,7 +2,7 @@ const extract = require('extract-comments');
 // https://prettier.io/docs/en/plugins.html#parsers
 const parser = require('solidity-parser-antlr');
 
-function parse(text) {
+function parse(text, parsers, options) {
   const parsed = parser.parse(text, { loc: true, range: true });
   parsed.comments = extract(text);
 
@@ -13,6 +13,17 @@ function parse(text) {
       }
       if (ctx.loopExpression) {
         ctx.loopExpression.omitSemicolon = true;
+      }
+    },
+    ElementaryTypeName(ctx) {
+      if (options.explicitTypes === 'always') {
+        if (ctx.name === 'uint') ctx.name = 'uint256';
+        if (ctx.name === 'int') ctx.name = 'int256';
+        if (ctx.name === 'byte') ctx.name = 'bytes1';
+      } else if (options.explicitTypes === 'never') {
+        if (ctx.name === 'uint256') ctx.name = 'uint';
+        if (ctx.name === 'int256') ctx.name = 'int';
+        if (ctx.name === 'bytes1') ctx.name = 'byte';
       }
     }
   });

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -449,20 +449,20 @@ contract test {
     function test() {
         choices = ActionChoices.GoStraight;
     }
-    function getChoice() returns (uint d) {
+    function getChoice() returns (uint256 d) {
         d = uint256(choices);
     }
     ActionChoices choices;
 }
 
 contract Base {
-    function Base(uint i) {
+    function Base(uint256 i) {
         m_i = i;
     }
-    uint public m_i;
+    uint256 public m_i;
 }
 contract Derived is Base(0) {
-    function Derived(uint i) Base(i) {}
+    function Derived(uint256 i) Base(i) {}
 }
 
 contract C {
@@ -481,7 +481,7 @@ contract C {
 }
 
 contract test {
-    function f(uint x, uint y) returns (uint z) {
+    function f(uint256 x, uint256 y) returns (uint256 z) {
         var c = x + 3;
         var b = 7 + (c * (8 - 7)) - x;
         return -(-b | 0);
@@ -489,30 +489,30 @@ contract test {
 }
 
 contract test {
-    function f(uint x, uint y) returns (uint z) {
+    function f(uint256 x, uint256 y) returns (uint256 z) {
         return 10;
     }
 }
 
 contract c {
-    function() returns (uint) {
+    function() returns (uint256) {
         return g(8);
     }
-    function g(uint pos) internal returns (uint) {
+    function g(uint256 pos) internal returns (uint256) {
         setData(pos, 8);
         return getData(pos);
     }
-    function setData(uint pos, uint value) internal {
+    function setData(uint256 pos, uint256 value) internal {
         data[pos] = value;
     }
-    function getData(uint pos) internal {
+    function getData(uint256 pos) internal {
         return data[pos];
     }
-    mapping(uint => uint) data;
+    mapping(uint256 => uint256) data;
 }
 
 contract Sharer {
-    function sendHalf(address addr) returns (uint balance) {
+    function sendHalf(address addr) returns (uint256 balance) {
         if (!addr.send(msg.value / 2)) throw; // also reverts the transfer to Sharer
         return address(this).balance;
     }
@@ -522,16 +522,16 @@ contract Sharer {
 library IntegerSet {
     struct data {
         /// Mapping item => index (or zero if not present)
-        mapping(uint => uint) index;
+        mapping(uint256 => uint256) index;
         /// Items by index (index 0 is invalid), items with index[item] == 0 are invalid.
-        uint[] items;
+        uint256[] items;
         /// Number of stored items.
-        uint size;
+        uint256 size;
     }
-    function insert(data storage self, uint value)
+    function insert(data storage self, uint256 value)
         returns (bool alreadyPresent)
     {
-        uint index = self.index[value];
+        uint256 index = self.index[value];
         if (index > 0) return true;
         else {
             if (self.items.length == 0) self.items.length = 1;
@@ -542,24 +542,24 @@ library IntegerSet {
             return false;
         }
     }
-    function remove(data storage self, uint value) returns (bool success) {
-        uint index = self.index[value];
+    function remove(data storage self, uint256 value) returns (bool success) {
+        uint256 index = self.index[value];
         if (index == 0) return false;
         delete self.index[value];
         delete self.items[index];
         self.size--;
     }
-    function contains(data storage self, uint value) returns (bool) {
+    function contains(data storage self, uint256 value) returns (bool) {
         return self.index[value] > 0;
     }
-    function iterate_start(data storage self) returns (uint index) {
+    function iterate_start(data storage self) returns (uint256 index) {
         return iterate_advance(self, 0);
     }
-    function iterate_valid(data storage self, uint index) returns (bool) {
+    function iterate_valid(data storage self, uint256 index) returns (bool) {
         return index < self.items.length;
     }
-    function iterate_advance(data storage self, uint index)
-        returns (uint r_index)
+    function iterate_advance(data storage self, uint256 index)
+        returns (uint256 r_index)
     {
         index++;
         while (
@@ -567,7 +567,9 @@ library IntegerSet {
         ) index++;
         return index;
     }
-    function iterate_get(data storage self, uint index) returns (uint value) {
+    function iterate_get(data storage self, uint256 index)
+        returns (uint256 value)
+    {
         return self.items[index];
     }
 }
@@ -577,14 +579,14 @@ contract User {
     /// Just a struct holding our data.
     IntegerSet.data data;
     /// Insert something
-    function insert(uint v) returns (uint size) {
+    function insert(uint256 v) returns (uint256 size) {
         /// Sends \`data\` via reference, so IntegerSet can modify it.
         IntegerSet.insert(data, v);
         /// We can access members of the struct - but we should take care not to mess with them.
         return data.size;
     }
     /// Computes the sum of all stored data.
-    function sum() returns (uint s) {
+    function sum() returns (uint256 s) {
         for (
             var i = IntegerSet.iterate_start(data);
             IntegerSet.iterate_valid(data, i);
@@ -595,7 +597,7 @@ contract User {
 
 // This broke it at one point (namely the modifiers).
 contract DualIndex {
-    mapping(uint => mapping(uint => uint)) data;
+    mapping(uint256 => mapping(uint256 => uint256)) data;
     address public admin;
 
     modifier restricted {
@@ -606,8 +608,8 @@ contract DualIndex {
         admin = msg.sender;
     }
 
-    function set(uint key1, uint key2, uint value) restricted {
-        uint[2][4] memory defaults; // "memory" broke things at one time.
+    function set(uint256 key1, uint256 key2, uint256 value) restricted {
+        uint256[2][4] memory defaults; // "memory" broke things at one time.
         data[key1][key2] = value;
     }
 
@@ -615,7 +617,7 @@ contract DualIndex {
         admin = _admin;
     }
 
-    function lookup(uint key1, uint key2) returns (uint) {
+    function lookup(uint256 key1, uint256 key2) returns (uint256) {
         return data[key1][key2];
     }
 }
@@ -627,18 +629,18 @@ contract B {}
 contract C is A, B {}
 
 contract TestPrivate {
-    uint private value;
+    uint256 private value;
 }
 
 contract TestInternal {
-    uint internal value;
+    uint256 internal value;
 }
 
 contract FromSolparse is A, B, TestPrivate, TestInternal {
     function() {
-        uint a = 6 ** 9;
+        uint256 a = 6 ** 9;
         var (x) = 100;
-        uint y = 2 days;
+        uint256 y = 2 days;
     }
 }
 
@@ -659,17 +661,17 @@ library VarHasBrackets {
 }
 
 library UsingExampleLibrary {
-    function sum(uint[] storage self) returns (uint s) {
-        for (uint i = 0; i < self.length; i++) s += self[i];
+    function sum(uint256[] storage self) returns (uint256 s) {
+        for (uint256 i = 0; i < self.length; i++) s += self[i];
     }
 }
 
 contract UsingExampleContract {
-    using UsingExampleLibrary for uint[];
+    using UsingExampleLibrary for uint256[];
 }
 
 contract NewStuff {
-    uint[] b;
+    uint256[] b;
 
     function someFunction() payable {
         string storage a = hex"ab1248fe";
@@ -715,9 +717,9 @@ contract assemblyLocalBinding {
 }
 
 contract assemblyReturn {
-    uint a = 10;
+    uint256 a = 10;
 
-    function get() constant returns (uint) {
+    function get() constant returns (uint256) {
         assembly {
             mstore(0x40, sload(0))
             byte(0)
@@ -728,40 +730,40 @@ contract assemblyReturn {
 }
 
 contract usesConst {
-    uint const = 0;
+    uint256 const = 0;
 }
 
 contract memoryArrays {
-    uint seven = 7;
+    uint256 seven = 7;
 
-    function returnNumber(uint number) returns (uint) {
+    function returnNumber(uint256 number) returns (uint256) {
         return number;
     }
 
     function alloc() {
-        uint[] memory a = new uint[](7);
-        uint[] memory b = new uint[](returnNumber(seven));
+        uint256[] memory a = new uint256[](7);
+        uint256[] memory b = new uint256[](returnNumber(seven));
     }
 }
 
 contract DeclarativeExpressions {
-    uint a;
-    uint b = 7;
-    uint b2 = 0;
-    uint public c;
-    uint public constant d;
-    uint public constant e;
-    uint private constant f = 7;
+    uint256 a;
+    uint256 b = 7;
+    uint256 b2 = 0;
+    uint256 public c;
+    uint256 public constant d;
+    uint256 public constant e;
+    uint256 private constant f = 7;
     struct S {
-        uint q;
+        uint256 q;
     }
 
-    function ham(S storage s1, uint[] storage arr) internal {
-        uint x;
-        uint y = 7;
+    function ham(S storage s1, uint256[] storage arr) internal {
+        uint256 x;
+        uint256 y = 7;
         S storage s2 = s1;
-        uint[] memory stor;
-        uint[] storage stor2 = arr;
+        uint256[] memory stor;
+        uint256[] storage stor2 = arr;
     }
 }
 
@@ -782,13 +784,13 @@ contract VariableDeclarationTuple {
 }
 
 contract TypeIndexSpacing {
-    uint[7] x;
-    uint[] y;
+    uint256[7] x;
+    uint256[] y;
 }
 
 contract Ballot {
     struct Voter {
-        uint weight;
+        uint256 weight;
         bool voted;
     }
 
@@ -799,12 +801,12 @@ contract Ballot {
     function foobar()
         payable
         owner(myPrice)
-        returns (uint[], address myAdd, string[] names)
+        returns (uint256[], address myAdd, string[] names)
     {}
     function foobar()
         payable
         owner(myPrice)
-        returns (uint[], address myAdd, string[] names);
+        returns (uint256[], address myAdd, string[] names);
 
     Voter you = Voter(1, true);
 
@@ -814,7 +816,7 @@ contract Ballot {
 }
 
 contract multilineReturn {
-    function a() returns (uint x) {
+    function a() returns (uint256 x) {
         return 5;
     }
 }

--- a/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BasicIterator/__snapshots__/jsfmt.spec.js.snap
@@ -67,7 +67,7 @@ contract BasicIterator {
 
     function getSum()
         constant
-        returns (uint) // "constant" just means this function returns something to the caller
+        returns (uint256) // "constant" just means this function returns something to the caller
     {
         // which is immediately followed by what type gets returned, in this case a full uint256
         uint8 sum = 0;

--- a/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
@@ -34,7 +34,7 @@ contract Conditional {
     // }
 
     function bar() {
-        uint a = true ? 0 : 1;
+        uint256 a = true ? 0 : 1;
     }
 }
 

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -57,7 +57,7 @@ pragma solidity ^0.4.24;
 
 contract Contract {
     struct StructWithFunctionTypes {
-        function(uint, uint) returns (bool) a;
+        function(uint256, uint256) returns (bool) a;
         function(bytes32, bytes32) internal view[] b;
         function(bytes32, bytes32) internal[] c;
         function(bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)
@@ -86,19 +86,19 @@ contract Contract {
         _;
     }
 
-    function ifBlockInOneLine(uint a) returns (uint b) {
+    function ifBlockInOneLine(uint256 a) returns (uint256 b) {
         if (a < 0) b = 0x67;
         else if (a == 0) b = 0x12;
         else b = 0x78;
     }
 
     function forWithoutBlock() {
-        uint i;
-        uint sum;
+        uint256 i;
+        uint256 sum;
         for (i = 0; i < 10; i++) sum += i;
     }
 
-    function fun(uint256 a) returns (uint) {
+    function fun(uint256 a) returns (uint256) {
         if (something)
             foo();
             // comment

--- a/tests/ExplicitVariableTypes/ExplicitVariableTypes.sol
+++ b/tests/ExplicitVariableTypes/ExplicitVariableTypes.sol
@@ -1,0 +1,30 @@
+pragma solidity 0.5.8;
+
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+
+    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+        public
+        returns (uint, int256, byte, uint256, int, bytes1)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}

--- a/tests/ExplicitVariableTypes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ExplicitVariableTypes/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExplicitVariableTypes.sol 1`] = `
+pragma solidity 0.5.8;
+
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+
+    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+        public
+        returns (uint, int256, byte, uint256, int, bytes1)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity 0.5.8;
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint256 public e;
+    int256 public f;
+    bytes1 public g;
+
+    struct S {
+        uint256 a;
+        int256 b;
+        bytes1 c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(
+        uint256 _a,
+        int256 _b,
+        bytes1 _c,
+        uint256 _e,
+        int256 _f,
+        bytes1 _g
+    );
+
+    function func(
+        uint256 _a,
+        int256 _b,
+        bytes1 _c,
+        uint256 _e,
+        int256 _f,
+        bytes1 _g
+    ) public returns (uint256, int256, bytes1, uint256, int256, bytes1) {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+
+`;
+
+exports[`ExplicitVariableTypes.sol 2`] = `
+pragma solidity 0.5.8;
+
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+
+    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+        public
+        returns (uint, int256, byte, uint256, int, bytes1)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity 0.5.8;
+
+contract VariableTypesMixed {
+    uint public a;
+    int public b;
+    byte public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint e;
+        int f;
+        byte g;
+    }
+
+    event Event(uint _a, int _b, byte _c, uint _e, int _f, byte _g);
+
+    function func(uint _a, int _b, byte _c, uint _e, int _f, byte _g)
+        public
+        returns (uint, int, byte, uint, int, byte)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+
+`;
+
+exports[`ExplicitVariableTypes.sol 3`] = `
+pragma solidity 0.5.8;
+
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+
+    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+        public
+        returns (uint, int256, byte, uint256, int, bytes1)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity 0.5.8;
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    bytes1 public c;
+    uint public e;
+    int public f;
+    byte public g;
+
+    struct S {
+        uint a;
+        int b;
+        byte c;
+        uint256 e;
+        int256 f;
+        bytes1 g;
+    }
+
+    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+
+    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+        public
+        returns (uint, int256, byte, uint256, int, bytes1)
+    {
+        emit Event(_a, _b, _c, _e, _f, _g);
+        return (_a, _b, _c, _e, _f, _g);
+    }
+}
+
+`;

--- a/tests/ExplicitVariableTypes/jsfmt.spec.js
+++ b/tests/ExplicitVariableTypes/jsfmt.spec.js
@@ -1,0 +1,3 @@
+run_spec(__dirname);
+run_spec(__dirname, { explicitTypes: 'never' });
+run_spec(__dirname, { explicitTypes: 'preserve' });

--- a/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ForStatements/__snapshots__/jsfmt.spec.js.snap
@@ -22,12 +22,12 @@ contract ForStatements {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract ForStatements {
-    uint constant LONG_VARIABLE = 1;
+    uint256 constant LONG_VARIABLE = 1;
 
     function hi() public {
-        uint a;
+        uint256 a;
 
-        for (uint i; i < 100; i++) a++;
+        for (uint256 i; i < 100; i++) a++;
 
         for (i = 0; i < 100; i++)
             a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
@@ -41,7 +41,7 @@ contract ForStatements {
         }
 
         for (
-            uint veryLongVariableName;
+            uint256 veryLongVariableName;
             veryLongVariableName < 100;
             veryLongVariableName++
         ) a++;

--- a/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -116,23 +116,23 @@ contract FunctionDefinitions {
 interface FunctionInterfaces {
     function noParamsNoModifiersNoReturns();
 
-    function oneParam(uint x);
+    function oneParam(uint256 x);
 
     function oneModifier() modifier1;
 
-    function oneReturn() returns (uint y1);
+    function oneReturn() returns (uint256 y1);
 
     function manyParams(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     );
 
     function manyModifiers()
@@ -149,39 +149,43 @@ interface FunctionInterfaces {
 
     function manyReturns()
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         );
 
-    function someParamsSomeModifiers(uint x1, uint x2, uint x3)
+    function someParamsSomeModifiers(uint256 x1, uint256 x2, uint256 x3)
         modifier1
         modifier2
         modifier3;
 
-    function someParamsSomeReturns(uint x1, uint x2, uint x3)
-        returns (uint y1, uint y2, uint y3);
+    function someParamsSomeReturns(uint256 x1, uint256 x2, uint256 x3)
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
     function someModifiersSomeReturns()
         modifier1
         modifier2
         modifier3
-        returns (uint y1, uint y2, uint y3);
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
-    function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3)
+    function someParamSomeModifiersSomeReturns(
+        uint256 x1,
+        uint256 x2,
+        uint256 x3
+    )
         modifier1
         modifier2
         modifier3
-        returns (uint y1, uint y2, uint y3);
+        returns (uint256 y1, uint256 y2, uint256 y3);
 
-    function someParamsManyModifiers(uint x1, uint x2, uint x3)
+    function someParamsManyModifiers(uint256 x1, uint256 x2, uint256 x3)
         modifier1
         modifier2
         modifier3
@@ -193,57 +197,57 @@ interface FunctionInterfaces {
         modifier9
         modifier10;
 
-    function someParamsManyReturns(uint x1, uint x2, uint x3)
+    function someParamsManyReturns(uint256 x1, uint256 x2, uint256 x3)
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         );
 
     function manyParamsSomeModifiers(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     ) modifier1 modifier2 modifier3;
 
     function manyParamssomeReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
-    ) returns (uint y1, uint y2, uint y3);
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
+    ) returns (uint256 y1, uint256 y2, uint256 y3);
 
     function manyParamsManyModifiers(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         modifier1
         modifier2
@@ -257,41 +261,41 @@ interface FunctionInterfaces {
         modifier10;
 
     function manyParamsManyReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         );
 
     function manyParamsManyModifiersManyReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         modifier1
         modifier2
@@ -304,16 +308,16 @@ interface FunctionInterfaces {
         modifier9
         modifier10
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         );
 }
 
@@ -322,7 +326,7 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function oneParam(uint x) {
+    function oneParam(uint256 x) {
         a = 1;
     }
 
@@ -330,21 +334,21 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function oneReturn() returns (uint y1) {
+    function oneReturn() returns (uint256 y1) {
         a = 1;
     }
 
     function manyParams(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     ) {
         a = 1;
     }
@@ -366,22 +370,22 @@ contract FunctionDefinitions {
 
     function manyReturns()
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         )
     {
         a = 1;
     }
 
-    function someParamsSomeModifiers(uint x1, uint x2, uint x3)
+    function someParamsSomeModifiers(uint256 x1, uint256 x2, uint256 x3)
         modifier1
         modifier2
         modifier3
@@ -389,8 +393,8 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function someParamsSomeReturns(uint x1, uint x2, uint x3)
-        returns (uint y1, uint y2, uint y3)
+    function someParamsSomeReturns(uint256 x1, uint256 x2, uint256 x3)
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
@@ -399,21 +403,25 @@ contract FunctionDefinitions {
         modifier1
         modifier2
         modifier3
-        returns (uint y1, uint y2, uint y3)
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
 
-    function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3)
+    function someParamSomeModifiersSomeReturns(
+        uint256 x1,
+        uint256 x2,
+        uint256 x3
+    )
         modifier1
         modifier2
         modifier3
-        returns (uint y1, uint y2, uint y3)
+        returns (uint256 y1, uint256 y2, uint256 y3)
     {
         a = 1;
     }
 
-    function someParamsManyModifiers(uint x1, uint x2, uint x3)
+    function someParamsManyModifiers(uint256 x1, uint256 x2, uint256 x3)
         modifier1
         modifier2
         modifier3
@@ -428,64 +436,64 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function someParamsManyReturns(uint x1, uint x2, uint x3)
+    function someParamsManyReturns(uint256 x1, uint256 x2, uint256 x3)
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         )
     {
         a = 1;
     }
 
     function manyParamsSomeModifiers(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     ) modifier1 modifier2 modifier3 {
         a = 1;
     }
 
     function manyParamssomeReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
-    ) returns (uint y1, uint y2, uint y3) {
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
+    ) returns (uint256 y1, uint256 y2, uint256 y3) {
         a = 1;
     }
 
     function manyParamsManyModifiers(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         public
         modifier1
@@ -503,44 +511,44 @@ contract FunctionDefinitions {
     }
 
     function manyParamsManyReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         )
     {
         a = 1;
     }
 
     function manyParamsManyModifiersManyReturns(
-        uint x1,
-        uint x2,
-        uint x3,
-        uint x4,
-        uint x5,
-        uint x6,
-        uint x7,
-        uint x8,
-        uint x9,
-        uint x10
+        uint256 x1,
+        uint256 x2,
+        uint256 x3,
+        uint256 x4,
+        uint256 x5,
+        uint256 x6,
+        uint256 x7,
+        uint256 x8,
+        uint256 x9,
+        uint256 x10
     )
         modifier1
         modifier2
@@ -553,16 +561,16 @@ contract FunctionDefinitions {
         modifier9
         modifier10
         returns (
-            uint y1,
-            uint y2,
-            uint y3,
-            uint y4,
-            uint y5,
-            uint y6,
-            uint y7,
-            uint y8,
-            uint y9,
-            uint y10
+            uint256 y1,
+            uint256 y2,
+            uint256 y3,
+            uint256 y4,
+            uint256 y5,
+            uint256 y6,
+            uint256 y7,
+            uint256 y8,
+            uint256 y9,
+            uint256 y10
         )
     {
         a = 1;

--- a/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IndexOf/__snapshots__/jsfmt.spec.js.snap
@@ -76,10 +76,10 @@ contract IndexOf {
         creator = msg.sender;
     }
 
-    int whatwastheval = -10; // -2 = not yet tested, as separate from -1, tested but error
+    int256 whatwastheval = -10; // -2 = not yet tested, as separate from -1, tested but error
 
     function indexOf(string _a, string _b)
-        returns (int) // _a = string to search, _b = string we want to find
+        returns (int256) // _a = string to search, _b = string we want to find
     {
         bytes memory a = bytes(_a);
         bytes memory b = bytes(_b);
@@ -94,8 +94,8 @@ contract IndexOf {
             whatwastheval = -1;
             return -1;
         } else {
-            uint subindex = 0;
-            for (uint i = 0; i < a.length; i++) {
+            uint256 subindex = 0;
+            for (uint256 i = 0; i < a.length; i++) {
                 if (a[i] == b[0]) // found the first char of b
                 {
                     subindex = 1;
@@ -107,8 +107,8 @@ contract IndexOf {
                         subindex++;
                     }
                     if (subindex == b.length) {
-                        whatwastheval = int(i);
-                        return int(i);
+                        whatwastheval = int256(i);
+                        return int256(i);
                     }
                 }
             }
@@ -117,7 +117,7 @@ contract IndexOf {
         }
     }
 
-    function whatWasTheVal() constant returns (int) {
+    function whatWasTheVal() constant returns (int256) {
         return whatwastheval;
     }
 

--- a/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleAuction/__snapshots__/jsfmt.spec.js.snap
@@ -132,21 +132,21 @@ contract SimpleAuction {
     // absolute unix timestamps (seconds since 1970-01-01)
     // or time periods in seconds.
     address public beneficiary;
-    uint public auctionEnd;
+    uint256 public auctionEnd;
 
     // Current state of the auction.
     address public highestBidder;
-    uint public highestBid;
+    uint256 public highestBid;
 
     // Allowed withdrawals of previous bids
-    mapping(address => uint) pendingReturns;
+    mapping(address => uint256) pendingReturns;
 
     // Set to true at the end, disallows any change
     bool ended;
 
     // Events that will be fired on changes.
-    event HighestBidIncreased(address bidder, uint amount);
-    event AuctionEnded(address winner, uint amount);
+    event HighestBidIncreased(address bidder, uint256 amount);
+    event AuctionEnded(address winner, uint256 amount);
 
     // The following is a so-called natspec comment,
     // recognizable by the three slashes.
@@ -156,7 +156,7 @@ contract SimpleAuction {
     /// Create a simple auction with \`_biddingTime\`
     /// seconds bidding time on behalf of the
     /// beneficiary address \`_beneficiary\`.
-    constructor(uint _biddingTime, address _beneficiary) public {
+    constructor(uint256 _biddingTime, address _beneficiary) public {
         beneficiary = _beneficiary;
         auctionEnd = now + _biddingTime;
     }
@@ -195,7 +195,7 @@ contract SimpleAuction {
 
     /// Withdraw a bid that was overbid.
     function withdraw() public returns (bool) {
-        uint amount = pendingReturns[msg.sender];
+        uint256 amount = pendingReturns[msg.sender];
         if (amount > 0) {
             // It is important to set this to zero because the recipient
             // can call this function again as part of the receiving call

--- a/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SimpleStorage/__snapshots__/jsfmt.spec.js.snap
@@ -20,13 +20,13 @@ pragma solidity ^0.4.0;
 
 contract SimpleStorage {
     string public name = "SimpleStorage";
-    uint storedData;
+    uint256 storedData;
 
-    function set(uint x) public {
+    function set(uint256 x) public {
         storedData = x;
     }
 
-    function get() public view returns (uint) {
+    function get() public view returns (uint256) {
         return storedData;
     }
 }

--- a/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
@@ -76,7 +76,7 @@ contract SplittableCommodity is MintableCommodity {
         bytes operatorData
     );
 
-    function split(uint _tokenId, address _to, uint256 _amount)
+    function split(uint256 _tokenId, address _to, uint256 _amount)
         public
         whenNotPaused
     {
@@ -101,7 +101,7 @@ contract SplittableCommodity is MintableCommodity {
             locked: false,
             misc: commodities[_tokenId].misc
         });
-        uint newCRCId = commodities.push(_commodity).sub(1);
+        uint256 newCRCId = commodities.push(_commodity).sub(1);
         require(
             newCRCId <= 18446744073709551616,
             "You can only split a commodity if it is within a valid index range"

--- a/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
@@ -115,7 +115,7 @@ pragma solidity >=0.4.0 <0.7.0;
 contract ControlStructures {
     struct Bank {
         address owner;
-        uint balance;
+        uint256 balance;
     }
 
     function() {
@@ -127,7 +127,7 @@ contract ControlStructures {
             break;
         }
 
-        for (uint a; a < 10; a++) {
+        for (uint256 a; a < 10; a++) {
             doSomethingElse();
         }
 
@@ -306,19 +306,19 @@ contract X is B, C, D {
 pragma solidity >=0.4.0 <0.7.0;
 
 contract FunctionDeclaration {
-    function increment(uint x) public pure returns (uint) {
+    function increment(uint256 x) public pure returns (uint256) {
         return x + 1;
     }
 
-    function increment(uint x) public pure returns (uint) {
+    function increment(uint256 x) public pure returns (uint256) {
         return x + 1;
     }
 
-    function increment(uint x) public pure returns (uint) {
+    function increment(uint256 x) public pure returns (uint256) {
         return x + 1;
     }
 
-    function increment(uint x) public pure returns (uint) {
+    function increment(uint256 x) public pure returns (uint256) {
         return x + 1;
     }
 
@@ -407,40 +407,42 @@ contract FunctionDeclaration {
 
 // Base contracts just to make this compile
 contract B {
-    constructor(uint) public {}
+    constructor(uint256) public {}
 }
 
 contract C {
-    constructor(uint, uint) public {}
+    constructor(uint256, uint256) public {}
 }
 
 contract D {
-    constructor(uint) public {}
+    constructor(uint256) public {}
 }
 
 /* TODO: constructors calls have priority over visibility */
 contract A is B, C, D {
-    uint x;
+    uint256 x;
 
-    constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
-        public
-        B(param1)
-        C(param2, param3)
-        D(param4)
-    {
+    constructor(
+        uint256 param1,
+        uint256 param2,
+        uint256 param3,
+        uint256 param4,
+        uint256 param5
+    ) public B(param1) C(param2, param3) D(param4) {
         x = param5;
     }
 }
 
 contract X is B, C, D {
-    uint x;
+    uint256 x;
 
-    constructor(uint param1, uint param2, uint param3, uint param4, uint param5)
-        public
-        B(param1)
-        C(param2, param3)
-        D(param4)
-    {
+    constructor(
+        uint256 param1,
+        uint256 param2,
+        uint256 param3,
+        uint256 param4,
+        uint256 param5
+    ) public B(param1) C(param2, param3) D(param4) {
         x = param5;
     }
 }
@@ -461,10 +463,10 @@ contract Mappings {
 pragma solidity >=0.4.0 <0.7.0;
 
 contract Mappings {
-    mapping(uint => uint) map;
+    mapping(uint256 => uint256) map;
     mapping(address => bool) registeredAddresses;
-    mapping(uint => mapping(bool => Data[])) public data;
-    mapping(uint => mapping(uint => s)) data;
+    mapping(uint256 => mapping(bool => Data[])) public data;
+    mapping(uint256 => mapping(uint256 => s)) data;
 }
 
 `;
@@ -688,7 +690,7 @@ contract VariableDeclarations {
 pragma solidity >=0.4.0 <0.7.0;
 
 contract VariableDeclarations {
-    uint[] x;
+    uint256[] x;
 }
 
 `;
@@ -718,7 +720,7 @@ contract WhitespaceInExpressions {
         long_variable = 3;
     }
 
-    function spam(uint i, Coin coin) public;
+    function spam(uint256 i, Coin coin) public;
 }
 
 `;

--- a/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
@@ -23,11 +23,11 @@ contract WhileStatements {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract WhileStatements {
-    uint constant LONG_VARIABLE = 1;
+    uint256 constant LONG_VARIABLE = 1;
 
     function hi() public {
-        uint a;
-        uint veryLongVariableName;
+        uint256 a;
+        uint256 veryLongVariableName;
 
         while (a < 100) a++;
 

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -759,11 +759,11 @@ pragma solidity ^0.4.14;
 
 library strings {
     struct slice {
-        uint _len;
-        uint _ptr;
+        uint256 _len;
+        uint256 _ptr;
     }
 
-    function memcpy(uint dest, uint src, uint len) private pure {
+    function memcpy(uint256 dest, uint256 src, uint256 len) private pure {
         // Copy word-length chunks while possible
         for (; len >= 32; len -= 32) {
             assembly {
@@ -774,7 +774,7 @@ library strings {
         }
 
         // Copy remaining bytes
-        uint mask = 256 ** (32 - len) - 1;
+        uint256 mask = 256 ** (32 - len) - 1;
         assembly {
             let srcpart := and(mload(src), not(mask))
             let destpart := and(mload(dest), mask)
@@ -788,7 +788,7 @@ library strings {
      * @return A newly allocated slice containing the entire string.
      */
     function toSlice(string memory self) internal pure returns (slice memory) {
-        uint ptr;
+        uint256 ptr;
         assembly {
             ptr := add(self, 0x20)
         }
@@ -800,24 +800,24 @@ library strings {
      * @param self The value to find the length of.
      * @return The length of the string, from 0 to 32.
      */
-    function len(bytes32 self) internal pure returns (uint) {
-        uint ret;
+    function len(bytes32 self) internal pure returns (uint256) {
+        uint256 ret;
         if (self == 0) return 0;
         if (self & 0xffffffffffffffffffffffffffffffff == 0) {
             ret += 16;
-            self = bytes32(uint(self) / 0x100000000000000000000000000000000);
+            self = bytes32(uint256(self) / 0x100000000000000000000000000000000);
         }
         if (self & 0xffffffffffffffff == 0) {
             ret += 8;
-            self = bytes32(uint(self) / 0x10000000000000000);
+            self = bytes32(uint256(self) / 0x10000000000000000);
         }
         if (self & 0xffffffff == 0) {
             ret += 4;
-            self = bytes32(uint(self) / 0x100000000);
+            self = bytes32(uint256(self) / 0x100000000);
         }
         if (self & 0xffff == 0) {
             ret += 2;
-            self = bytes32(uint(self) / 0x10000);
+            self = bytes32(uint256(self) / 0x10000);
         }
         if (self & 0xff == 0) {
             ret += 1;
@@ -859,7 +859,7 @@ library strings {
      */
     function toString(slice memory self) internal pure returns (string memory) {
         string memory ret = new string(self._len);
-        uint retptr;
+        uint256 retptr;
         assembly {
             retptr := add(ret, 32)
         }
@@ -876,10 +876,10 @@ library strings {
      * @param self The slice to operate on.
      * @return The length of the slice in runes.
      */
-    function len(slice memory self) internal pure returns (uint l) {
+    function len(slice memory self) internal pure returns (uint256 l) {
         // Starting at ptr-31 means the LSB will be the byte we care about
-        uint ptr = self._ptr - 31;
-        uint end = ptr + self._len;
+        uint256 ptr = self._ptr - 31;
+        uint256 end = ptr + self._len;
         for (l = 0; ptr < end; l++) {
             uint8 b;
             assembly {
@@ -922,16 +922,16 @@ library strings {
     function compare(slice memory self, slice memory other)
         internal
         pure
-        returns (int)
+        returns (int256)
     {
-        uint shortest = self._len;
+        uint256 shortest = self._len;
         if (other._len < self._len) shortest = other._len;
 
-        uint selfptr = self._ptr;
-        uint otherptr = other._ptr;
-        for (uint idx = 0; idx < shortest; idx += 32) {
-            uint a;
-            uint b;
+        uint256 selfptr = self._ptr;
+        uint256 otherptr = other._ptr;
+        for (uint256 idx = 0; idx < shortest; idx += 32) {
+            uint256 a;
+            uint256 b;
             assembly {
                 a := mload(selfptr)
                 b := mload(otherptr)
@@ -943,12 +943,12 @@ library strings {
                     mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
                 }
                 uint256 diff = (a & mask) - (b & mask);
-                if (diff != 0) return int(diff);
+                if (diff != 0) return int256(diff);
             }
             selfptr += 32;
             otherptr += 32;
         }
-        return int(self._len) - int(other._len);
+        return int256(self._len) - int256(other._len);
     }
 
     /*
@@ -984,8 +984,8 @@ library strings {
             return rune;
         }
 
-        uint l;
-        uint b;
+        uint256 l;
+        uint256 b;
         // Load the first byte of the rune into the LSBs of b
         assembly {
             b := and(mload(sub(mload(add(self, 32)), 31)), 0xFF)
@@ -1033,20 +1033,20 @@ library strings {
      * @param self The slice to operate on.
      * @return The number of the first codepoint in the slice.
      */
-    function ord(slice memory self) internal pure returns (uint ret) {
+    function ord(slice memory self) internal pure returns (uint256 ret) {
         if (self._len == 0) {
             return 0;
         }
 
-        uint word;
-        uint length;
-        uint divisor = 2 ** 248;
+        uint256 word;
+        uint256 length;
+        uint256 divisor = 2 ** 248;
 
         // Load the rune into the MSBs of b
         assembly {
             word := mload(mload(add(self, 32)))
         }
-        uint b = word / divisor;
+        uint256 b = word / divisor;
         if (b < 0x80) {
             ret = b;
             length = 1;
@@ -1066,7 +1066,7 @@ library strings {
             return 0;
         }
 
-        for (uint i = 1; i < length; i++) {
+        for (uint256 i = 1; i < length; i++) {
             divisor = divisor / 256;
             b = (word / divisor) & 0xFF;
             if (b & 0xC0 != 0x80) {
@@ -1174,7 +1174,7 @@ library strings {
             return false;
         }
 
-        uint selfptr = self._ptr + self._len - needle._len;
+        uint256 selfptr = self._ptr + self._len - needle._len;
 
         if (selfptr == needle._ptr) {
             return true;
@@ -1209,7 +1209,7 @@ library strings {
             return self;
         }
 
-        uint selfptr = self._ptr + self._len - needle._len;
+        uint256 selfptr = self._ptr + self._len - needle._len;
         bool equal = true;
         if (selfptr != needle._ptr) {
             assembly {
@@ -1231,13 +1231,14 @@ library strings {
 
     // Returns the memory address of the first byte of the first occurrence of
     // \`needle\` in \`self\`, or the first byte after \`self\` if not found.
-    function findPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr)
-        private
-        pure
-        returns (uint)
-    {
-        uint ptr = selfptr;
-        uint idx;
+    function findPtr(
+        uint256 selflen,
+        uint256 selfptr,
+        uint256 needlelen,
+        uint256 needleptr
+    ) private pure returns (uint256) {
+        uint256 ptr = selfptr;
+        uint256 idx;
 
         if (needlelen <= selflen) {
             if (needlelen <= 32) {
@@ -1248,7 +1249,7 @@ library strings {
                     needledata := and(mload(needleptr), mask)
                 }
 
-                uint end = selfptr + selflen - needlelen;
+                uint256 end = selfptr + selflen - needlelen;
                 bytes32 ptrdata;
                 assembly {
                     ptrdata := and(mload(ptr), mask)
@@ -1285,12 +1286,12 @@ library strings {
     // Returns the memory address of the first byte after the last occurrence of
     // \`needle\` in \`self\`, or the address of \`self\` if not found.
     function rfindPtr(
-        uint selflen,
-        uint selfptr,
-        uint needlelen,
-        uint needleptr
-    ) private pure returns (uint) {
-        uint ptr;
+        uint256 selflen,
+        uint256 selfptr,
+        uint256 needlelen,
+        uint256 needleptr
+    ) private pure returns (uint256) {
+        uint256 ptr;
 
         if (needlelen <= selflen) {
             if (needlelen <= 32) {
@@ -1348,7 +1349,7 @@ library strings {
         pure
         returns (slice memory)
     {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len -= ptr - self._ptr;
         self._ptr = ptr;
         return self;
@@ -1367,7 +1368,7 @@ library strings {
         pure
         returns (slice memory)
     {
-        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len = ptr - self._ptr;
         return self;
     }
@@ -1387,7 +1388,7 @@ library strings {
         pure
         returns (slice memory)
     {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = self._ptr;
         token._len = ptr - self._ptr;
         if (ptr == self._ptr + self._len) {
@@ -1432,7 +1433,7 @@ library strings {
         pure
         returns (slice memory)
     {
-        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = ptr;
         token._len = self._len - (ptr - self._ptr);
         if (ptr == self._ptr) {
@@ -1470,9 +1471,9 @@ library strings {
     function count(slice memory self, slice memory needle)
         internal
         pure
-        returns (uint cnt)
+        returns (uint256 cnt)
     {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) +
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) +
             needle._len;
         while (ptr <= self._ptr + self._len) {
             cnt++;
@@ -1516,7 +1517,7 @@ library strings {
         returns (string memory)
     {
         string memory ret = new string(self._len + other._len);
-        uint retptr;
+        uint256 retptr;
         assembly {
             retptr := add(ret, 32)
         }
@@ -1540,13 +1541,13 @@ library strings {
     {
         if (parts.length == 0) return "";
 
-        uint length = self._len * (parts.length - 1);
-        for (uint i = 0; i < parts.length; i++) {
+        uint256 length = self._len * (parts.length - 1);
+        for (uint256 i = 0; i < parts.length; i++) {
             length += parts[i]._len;
         }
 
         string memory ret = new string(length);
-        uint retptr;
+        uint256 retptr;
         assembly {
             retptr := add(ret, 32)
         }


### PR DESCRIPTION
This PR will enable the team to decide what type of unit declaration they would rather have across the project.
`explicitTypes: always` will force every instance of `uint`, `int`, and `byte` to be expanded as `uint256`, `int256`, and `bytes1`.
The option `explicitTypes: never` will prefer `uint`, `int`, and `byte` over the aliases.
Finally the option `explicitTypes: preserve` will leave the declaration untouched.

The manipulation is done in the parsing step, so there will be no problem when comparing the AST.

As a best practice, I choose to have this option as `always` by default, but we can change this.