### PR TITLE
braket spacing and indenting in import directives

### DIFF
--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, join }
+    builders: { concat, group, indent, join, line, softline }
   }
 } = require('prettier');
 const { printString } = require('../prettier-comments/common/util');
@@ -14,15 +14,21 @@ const ImportDirective = {
     } else if (node.symbolAliases) {
       doc = concat([
         '{',
-        join(
-          ', ',
-          node.symbolAliases.map(([a, b]) => (b ? [a, b].join(' as ') : a))
+        indent(
+          concat([
+            options.bracketSpacing ? line : softline,
+            join(
+              concat([',', line]),
+              node.symbolAliases.map(([a, b]) => (b ? `${a} as ${b}` : a))
+            )
+          ])
         ),
+        options.bracketSpacing ? line : softline,
         '} from ',
         doc
       ]);
     }
-    return concat(['import ', doc, ';']);
+    return group(concat(['import ', doc, ';']));
   }
 };
 

--- a/tests/ImportDirective/ImportDirectives.sol
+++ b/tests/ImportDirective/ImportDirectives.sol
@@ -1,0 +1,5 @@
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import * as SomeSymbol from "AnotherFile.sol";
+import {symbol1 as alias, symbol2} from "File.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";

--- a/tests/ImportDirective/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ImportDirective/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ImportDirectives.sol 1`] = `
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import * as SomeSymbol from "AnotherFile.sol";
+import {symbol1 as alias, symbol2} from "File.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import "AnotherFile.sol" as SomeSymbol;
+import {symbol1 as alias, symbol2} from "File.sol";
+import {
+    symbol1 as alias1,
+    symbol2 as alias2,
+    symbol3 as alias3,
+    symbol4
+} from "File2.sol";
+
+`;
+
+exports[`ImportDirectives.sol 2`] = `
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import * as SomeSymbol from "AnotherFile.sol";
+import {symbol1 as alias, symbol2} from "File.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import "SomeFile.sol";
+import "SomeFile.sol" as SomeOtherFile;
+import "AnotherFile.sol" as SomeSymbol;
+import { symbol1 as alias, symbol2 } from "File.sol";
+import {
+    symbol1 as alias1,
+    symbol2 as alias2,
+    symbol3 as alias3,
+    symbol4
+} from "File2.sol";
+
+`;

--- a/tests/ImportDirective/jsfmt.spec.js
+++ b/tests/ImportDirective/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, { bracketSpacing: true });


### PR DESCRIPTION
Simple enough.

before the PR while using `bracketSpacing = true` we would print:

```Solidity
import {symbol1 as alias, symbol2} from "File.sol";
import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";
```

after the PR:

```Solidity
import { symbol1 as alias, symbol2 } from "File.sol";
import {
    symbol1 as alias1,
    symbol2 as alias2,
    symbol3 as alias3,
    symbol4
} from "File2.sol";
```

It is a case that I didn't even know existed in import rules 😂 