### PR TITLE
Avoid having small right operand on its own line

### DIFF
--- a/src/binary-operator-printers/arithmetic.js
+++ b/src/binary-operator-printers/arithmetic.js
@@ -38,13 +38,17 @@ module.exports = {
     const groupIfNecessary = groupIfNecessaryBuilder(path);
     const indentIfNecessary = indentIfNecessaryBuilder(path);
 
+    const right = concat([node.operator, line, path.call(print, 'right')]);
+    // If it's a single binary operation, avoid having a small right
+    // operand like - 1 on its own line
+    const shouldGroup =
+      node.left.type !== 'BinaryOperation' &&
+      path.getParentNode().type !== 'BinaryOperation';
     return groupIfNecessary(
       concat([
         path.call(print, 'left'),
         ' ',
-        indentIfNecessary(
-          concat([node.operator, line, path.call(print, 'right')])
-        )
+        indentIfNecessary(shouldGroup ? group(right) : right)
       ])
     );
   }

--- a/src/binary-operator-printers/comparison.js
+++ b/src/binary-operator-printers/comparison.js
@@ -23,13 +23,17 @@ module.exports = {
   print: (node, path, print) => {
     const indentIfNecessary = indentIfNecessaryBuilder(path);
 
+    const right = concat([node.operator, line, path.call(print, 'right')]);
+    // If it's a single binary operation, avoid having a small right
+    // operand like - 1 on its own line
+    const shouldGroup =
+      node.left.type !== 'BinaryOperation' &&
+      path.getParentNode().type !== 'BinaryOperation';
     return group(
       concat([
         path.call(print, 'left'),
         ' ',
-        indentIfNecessary(
-          concat([node.operator, line, path.call(print, 'right')])
-        )
+        indentIfNecessary(shouldGroup ? group(right) : right)
       ])
     );
   }

--- a/src/binary-operator-printers/exponentiation.js
+++ b/src/binary-operator-printers/exponentiation.js
@@ -7,11 +7,21 @@ const {
 module.exports = {
   match: op => op === '**',
   print: (node, path, print) => {
+    const right = concat([
+      ifBreak(' ', ''),
+      node.operator,
+      softline,
+      path.call(print, 'right')
+    ]);
+    // If it's a single binary operation, avoid having a small right
+    // operand like - 1 on its own line
+    const shouldGroup =
+      node.left.type !== 'BinaryOperation' &&
+      path.getParentNode().type !== 'BinaryOperation';
     return group(
       concat([
         path.call(print, 'left'),
-        ifBreak(' ', ''),
-        indent(concat([node.operator, softline, path.call(print, 'right')]))
+        indent(shouldGroup ? group(right) : right)
       ])
     );
   }

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -26,13 +26,17 @@ module.exports = {
     const groupIfNecessary = groupIfNecessaryBuilder(path);
     const indentIfNecessary = indentIfNecessaryBuilder(path);
 
+    const right = concat([node.operator, line, path.call(print, 'right')]);
+    // If it's a single binary operation, avoid having a small right
+    // operand like - 1 on its own line
+    const shouldGroup =
+      node.left.type !== 'BinaryOperation' &&
+      path.getParentNode().type !== 'BinaryOperation';
     return groupIfNecessary(
       concat([
         path.call(print, 'left'),
         ' ',
-        indentIfNecessary(
-          concat([node.operator, line, path.call(print, 'right')])
-        )
+        indentIfNecessary(shouldGroup ? group(right) : right)
       ])
     );
   }

--- a/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
@@ -246,8 +246,7 @@ contract ArithmeticOperators {
             veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
-        ) +
-            c;
+        ) + c;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) +
@@ -264,20 +263,17 @@ contract ArithmeticOperators {
         if (
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) +
-                c
+            ) + c
         ) {}
         a(
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) +
-                c
+            ) + c
         );
         return
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) +
-            c;
+            ) + c;
     }
 }
 
@@ -330,8 +326,7 @@ contract ArithmeticOperators {
                 veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
-        ) **
-            c;
+        )**c;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) **
@@ -348,20 +343,17 @@ contract ArithmeticOperators {
         if (
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) **
-                c
+            )**c
         ) {}
         a(
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) **
-                c
+            )**c
         );
         return
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) **
-                c;
+            )**c;
     }
 }
 
@@ -490,8 +482,7 @@ contract ComparisonOperators {
             veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
-        ) ==
-            c;
+        ) == c;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) <
@@ -508,20 +499,17 @@ contract ComparisonOperators {
         if (
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ==
-            c
+            ) == c
         ) {}
         a(
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ==
-                c
+            ) == c
         );
         return
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ==
-            c;
+            ) == c;
     }
 }
 
@@ -605,8 +593,7 @@ contract LogicalOperators {
         ) {}
         if (
             (veryVeryVeryVeryVeryLongVariableCalledA &&
-                veryVeryVeryVeryVeryLongVariableCalledB) ||
-            c
+                veryVeryVeryVeryVeryLongVariableCalledB) || c
         ) {}
         if (
             veryVeryVeryVeryVeryLongVariableCalledA ||
@@ -626,8 +613,7 @@ contract LogicalOperators {
         ) {}
         while (
             (veryVeryVeryVeryVeryLongVariableCalledA &&
-                veryVeryVeryVeryVeryLongVariableCalledB) ||
-            c
+                veryVeryVeryVeryVeryLongVariableCalledB) || c
         ) {}
         while (
             veryVeryVeryVeryVeryLongVariableCalledA ||
@@ -650,8 +636,7 @@ contract LogicalOperators {
             veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
-        ) ||
-            c;
+        ) || c;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) ||
@@ -668,20 +653,17 @@ contract LogicalOperators {
         if (
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ||
-            c
+            ) || c
         ) {}
         a(
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ||
-                c
+            ) || c
         );
         return
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
-            ) ||
-            c;
+            ) || c;
     }
 }
 


### PR DESCRIPTION
Would you consider grouping the right operand, like [language-js](https://github.com/prettier/prettier/blob/master/src/language-js/printer-estree.js#L5899), "to avoid having a small right part like -1 be on its own line"?