### PR TITLE
Return statements are already indented

### DIFF
--- a/src/binary-operator-printers/arithmetic.js
+++ b/src/binary-operator-printers/arithmetic.js
@@ -20,6 +20,7 @@ const indentIfNecessaryBuilder = path => doc => {
   let node = path.getNode();
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
+    if (parentNode.type === 'ReturnStatement') return doc;
     if (
       parentNode.type !== 'BinaryOperation' ||
       comparison.match(parentNode.operator)

--- a/src/binary-operator-printers/comparison.js
+++ b/src/binary-operator-printers/comparison.js
@@ -8,6 +8,7 @@ const indentIfNecessaryBuilder = path => doc => {
   let node = path.getNode();
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
+    if (parentNode.type === 'ReturnStatement') return doc;
     if (parentNode.type === 'IfStatement') return doc;
     if (parentNode.type === 'ForStatement') return doc;
     if (parentNode.type === 'WhileStatement') return doc;

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -11,6 +11,7 @@ const indentIfNecessaryBuilder = path => doc => {
   let node = path.getNode();
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
+    if (parentNode.type === 'ReturnStatement') return doc;
     if (parentNode.type === 'IfStatement') return doc;
     if (parentNode.type === 'WhileStatement') return doc;
     if (parentNode.type !== 'BinaryOperation') return indent(doc);

--- a/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
@@ -243,7 +243,7 @@ contract ArithmeticOperators {
         );
         return
             veryVeryVeryVeryVeryLongVariableCalledA +
-                veryVeryVeryVeryVeryLongVariableCalledB;
+            veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) +
@@ -277,7 +277,7 @@ contract ArithmeticOperators {
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
             ) +
-                c;
+            c;
     }
 }
 
@@ -393,7 +393,7 @@ contract ShiftOperators {
         );
         return
             veryVeryVeryVeryVeryLongVariableCalledA <<
-                veryVeryVeryVeryVeryLongVariableCalledB;
+            veryVeryVeryVeryVeryLongVariableCalledB;
     }
 }
 
@@ -428,7 +428,7 @@ contract BitOperators {
         );
         return
             veryVeryVeryVeryVeryLongVariableCalledA &
-                veryVeryVeryVeryVeryLongVariableCalledB;
+            veryVeryVeryVeryVeryLongVariableCalledB;
     }
 }
 
@@ -487,7 +487,7 @@ contract ComparisonOperators {
         );
         return
             veryVeryVeryVeryVeryLongVariableCalledA ==
-                veryVeryVeryVeryVeryLongVariableCalledB;
+            veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) ==
@@ -521,7 +521,7 @@ contract ComparisonOperators {
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
             ) ==
-                c;
+            c;
     }
 }
 
@@ -647,7 +647,7 @@ contract LogicalOperators {
         );
         return
             veryVeryVeryVeryVeryLongVariableCalledA ||
-                veryVeryVeryVeryVeryLongVariableCalledB;
+            veryVeryVeryVeryVeryLongVariableCalledB;
         veryVeryVeryVeryVeryLongFunctionCalledA(
             veryVeryVeryVeryVeryLongVariableCalledB
         ) ||
@@ -681,7 +681,7 @@ contract LogicalOperators {
             veryVeryVeryVeryVeryLongFunctionCalledA(
                 veryVeryVeryVeryVeryLongVariableCalledB
             ) ||
-                c;
+            c;
     }
 }
 

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1501,7 +1501,7 @@ library strings {
     {
         return
             rfindPtr(self._len, self._ptr, needle._len, needle._ptr) !=
-                self._ptr;
+            self._ptr;
     }
 
     /*


### PR DESCRIPTION
### Before

```Solidity
return
    keccak(self, offset, self.length - offset) ==
        keccak(other, otherOffset, other.length - otherOffset);
```

### After

```Solidity
return
    keccak(self, offset, self.length - offset) ==
    keccak(other, otherOffset, other.length - otherOffset);
```