### PR TITLE
adding support for prettier-ignore

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1,4 +1,5 @@
 const nodes = require('./nodes');
+const { hasNodeIgnoreComment } = require('./prettier-comments/common/util.js');
 
 function genericPrint(path, options, print) {
   const node = path.getValue();
@@ -8,6 +9,10 @@ function genericPrint(path, options, print) {
 
   if (!(node.type in nodes)) {
     throw new Error(`Unknown type: ${JSON.stringify(node.type)}`);
+  }
+
+  if (hasNodeIgnoreComment(node)) {
+    return options.originalText.slice(node.range[0], node.range[1] + 1);
   }
 
   return nodes[node.type].print({ node, options, path, print });

--- a/tests/PrettierIgnore/PrettierIgnore.sol
+++ b/tests/PrettierIgnore/PrettierIgnore.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.2;
+
+contract PrettierIgnore {
+  function() public payable {
+      matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+
+// prettier-ignore
+matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+  }
+}

--- a/tests/PrettierIgnore/PrettierIgnore.sol
+++ b/tests/PrettierIgnore/PrettierIgnore.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.2;
 
 contract PrettierIgnore {
-  function() public payable {
-      matrix(
-  1, 0, 0,
-  0, 1, 0,
-  0, 0, 1
-);
+    function() public payable {
+        matrix(
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+        );
 
-// prettier-ignore
-matrix(
-  1, 0, 0,
-  0, 1, 0,
-  0, 0, 1
-);
-  }
+        // prettier-ignore
+        matrix(
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+        );
+    }
 }

--- a/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
@@ -4,20 +4,20 @@ exports[`PrettierIgnore.sol 1`] = `
 pragma solidity ^0.5.2;
 
 contract PrettierIgnore {
-  function() public payable {
-      matrix(
-  1, 0, 0,
-  0, 1, 0,
-  0, 0, 1
-);
+    function() public payable {
+        matrix(
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+        );
 
-// prettier-ignore
-matrix(
-  1, 0, 0,
-  0, 1, 0,
-  0, 0, 1
-);
-  }
+        // prettier-ignore
+        matrix(
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+        );
+    }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.5.2;
@@ -28,10 +28,10 @@ contract PrettierIgnore {
 
         // prettier-ignore
         matrix(
-  1, 0, 0,
-  0, 1, 0,
-  0, 0, 1
-);
+            1, 0, 0,
+            0, 1, 0,
+            0, 0, 1
+        );
     }
 }
 

--- a/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrettierIgnore.sol 1`] = `
+pragma solidity ^0.5.2;
+
+contract PrettierIgnore {
+  function() public payable {
+      matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+
+// prettier-ignore
+matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity ^0.5.2;
+
+contract PrettierIgnore {
+    function() public payable {
+        matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
+
+        // prettier-ignore
+        matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+    }
+}
+
+`;

--- a/tests/PrettierIgnore/jsfmt.spec.js
+++ b/tests/PrettierIgnore/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
Using the util `hasNodeIgnoreComment` we can filter and print the original code instead of processing that branch of the tree.