### PR TITLE
true and false Expression need to be indented in case the line breaks

### DIFF
--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -9,12 +9,8 @@ const Conditional = {
     group(
       concat([
         path.call(print, 'condition'),
-        indent(line),
-        '? ',
-        path.call(print, 'trueExpression'),
-        indent(line),
-        ': ',
-        path.call(print, 'falseExpression')
+        indent(concat([line, '? ', path.call(print, 'trueExpression')])),
+        indent(concat([line, ': ', path.call(print, 'falseExpression')]))
       ])
     )
 };

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -9,8 +9,16 @@ const Conditional = {
     group(
       concat([
         path.call(print, 'condition'),
-        indent(concat([line, '? ', path.call(print, 'trueExpression')])),
-        indent(concat([line, ': ', path.call(print, 'falseExpression')]))
+        indent(
+          concat([
+            line,
+            '? ',
+            path.call(print, 'trueExpression'),
+            line,
+            ': ',
+            path.call(print, 'falseExpression')
+          ])
+        )
       ])
     )
 };

--- a/tests/Conditional/Conditional.sol
+++ b/tests/Conditional/Conditional.sol
@@ -4,6 +4,15 @@ pragma solidity ^0.4.24;
 contract Conditional {
     function foo() {
         address contextAddress = longAddress_ == address(0) ? msg.sender : currentContextAddress_;
+        asset == ETH
+        ? require(address(uint160(msg.sender)).send(quantity), "failed to transfer ether") // explicit casting to `address payable`
+        : transferTokensToAccountSecurely(Token(asset), quantity, msg.sender);
+        asset == ETH
+        ? true
+        : transferTokensToAccountSecurely(Token(asset), quantity, msg.sender);
+        asset == ETH
+        ? require(address(uint160(msg.sender)).send(quantity), "failed to transfer ether")
+        : false;
     }
 
     // TODO: work with a break in the condition level.

--- a/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,15 @@ pragma solidity ^0.4.24;
 contract Conditional {
     function foo() {
         address contextAddress = longAddress_ == address(0) ? msg.sender : currentContextAddress_;
+        asset == ETH
+        ? require(address(uint160(msg.sender)).send(quantity), "failed to transfer ether") // explicit casting to \`address payable\`
+        : transferTokensToAccountSecurely(Token(asset), quantity, msg.sender);
+        asset == ETH
+        ? true
+        : transferTokensToAccountSecurely(Token(asset), quantity, msg.sender);
+        asset == ETH
+        ? require(address(uint160(msg.sender)).send(quantity), "failed to transfer ether")
+        : false;
     }
 
     // TODO: work with a break in the condition level.
@@ -26,6 +35,29 @@ contract Conditional {
         address contextAddress = longAddress_ == address(0)
             ? msg.sender
             : currentContextAddress_;
+        asset == ETH
+            ? require(
+                address(uint160(msg.sender)).send(quantity),
+                "failed to transfer ether"
+            ) // explicit casting to \`address payable\`
+            : transferTokensToAccountSecurely(
+                Token(asset),
+                quantity,
+                msg.sender
+            );
+        asset == ETH
+            ? true
+            : transferTokensToAccountSecurely(
+                Token(asset),
+                quantity,
+                msg.sender
+            );
+        asset == ETH
+            ? require(
+                address(uint160(msg.sender)).send(quantity),
+                "failed to transfer ether"
+            )
+            : false;
     }
 
     // TODO: work with a break in the condition level.


### PR DESCRIPTION
before:
```Solidity
        asset == ETH
            ? require(
            address(uint160(msg.sender)).send(quantity),
            "failed to transfer ether"
        ) // explicit casting to \`address payable\`
            : transferTokensToAccountSecurely(
            Token(asset),
            quantity,
            msg.sender
        );
```

after:
```Solidity
        asset == ETH
            ? require(
                address(uint160(msg.sender)).send(quantity),
                "failed to transfer ether"
            ) // explicit casting to \`address payable\`
            : transferTokensToAccountSecurely(
                Token(asset),
                quantity,
                msg.sender
            );
```