### PR TITLE
Removing extra empty lines at the end of a block

### DIFF
--- a/src/nodes/print-preserving-empty-lines.js
+++ b/src/nodes/print-preserving-empty-lines.js
@@ -23,6 +23,9 @@ function printPreservingEmptyLines(path, key, options, print) {
     }
   }, key);
 
+  if (parts.length > 1 && parts[parts.length - 1] === hardline) {
+    parts.pop();
+  }
   return concat(parts);
 }
 

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -652,7 +652,6 @@ contract CommentedOutFunction {
     // function something()
     //  uint x = 10;
     // }
-
 }
 
 library VarHasBrackets {

--- a/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SampleCrowdsale/__snapshots__/jsfmt.spec.js.snap
@@ -65,7 +65,6 @@ contract SampleCrowdsaleToken is MintableToken {
     string public constant name = "Sample Crowdsale Token";
     string public constant symbol = "SCT";
     uint8 public constant decimals = 18;
-
 }
 
 /**
@@ -102,7 +101,6 @@ contract SampleCrowdsale is CappedCrowdsale, RefundableCrowdsale {
     function createTokenContract() internal returns (MintableToken) {
         return new SampleCrowdsaleToken();
     }
-
 }
 
 `;

--- a/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/StyleGuide/__snapshots__/jsfmt.spec.js.snap
@@ -48,7 +48,6 @@ contract A {
 }
 */
 
-
 `;
 
 exports[`ControlStructures.sol 1`] = `
@@ -160,7 +159,6 @@ contract ControlStructures {
         else
             x -= 1;
         */
-
     }
 }
 

--- a/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
@@ -26,7 +26,6 @@ contract demo {
     function hello() public view returns (bool, bool) {}
     function hello2() public view returns (bool) {}
     function hello3() public view returns (bool, bool, bool) {}
-
 }
 
 contract Tupples {


### PR DESCRIPTION
before we preserved 1 empty line  if the developer originally had it with the exception of the first line. This would lead to this input:
```Solidity
contract A {

    function a() public {}

    function b() public {}

    function c() public {}

}
```

to be formatted as:
```Solidity
contract A {
    function a() public {}

    function b() public {}

    function c() public {}

}
```

The last line always bugged me so I decided to remove it, now it will look like this:

```Solidity
contract A {
    function a() public {}

    function b() public {}

    function c() public {}
}
```