### PR TITLE
Add support for virtual keyword and abstract contracts

### DIFF
--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -36,7 +36,7 @@ const ContractDefinition = {
     concat([
       group(
         concat([
-          node.kind,
+          node.kind === 'abstract' ? 'abstract contract' : node.kind,
           ' ',
           node.name,
           inheritance(node, path, print),

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -34,6 +34,13 @@ const visibility = node => {
   return '';
 };
 
+const virtual = node => {
+  if (node.isVirtual) {
+    return concat([line, 'virtual']);
+  }
+  return '';
+};
+
 const stateMutability = node => {
   if (node.stateMutability && node.stateMutability !== 'default') {
     return concat([line, node.stateMutability]);
@@ -81,6 +88,7 @@ const FunctionDefinition = {
         group(
           concat([
             visibility(node),
+            virtual(node),
             stateMutability(node),
             modifiers(node, path, print),
             returnParameters(node, path, print),

--- a/tests/AllSolidityFeatures/AllSolidityFeatures.sol
+++ b/tests/AllSolidityFeatures/AllSolidityFeatures.sol
@@ -417,3 +417,13 @@ contract continueStatement {
     while (true) { continue; }
   }
 }
+
+abstract  contract  AbstractContract {
+
+}
+
+contract  ContractWithVirtual
+{
+  function   foo() public virtual  returns  ( uint ) {
+  }
+}

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -420,6 +420,16 @@ contract continueStatement {
     while (true) { continue; }
   }
 }
+
+abstract  contract  AbstractContract {
+
+}
+
+contract  ContractWithVirtual
+{
+  function   foo() public virtual  returns  ( uint ) {
+  }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Examples taken from the Solidity documentation online.
 
@@ -887,6 +897,14 @@ contract continueStatement {
             continue;
         }
     }
+}
+
+
+abstract contract AbstractContract {}
+
+
+contract ContractWithVirtual {
+    function foo() public virtual returns (uint256) {}
 }
 
 `;


### PR DESCRIPTION
Part of #221.

Now `abstract contract` contracts are handled, and so are functions with the `virtual` keyword.

The `override` part is blocked by https://github.com/ConsenSys/solidity-parser-antlr/issues/2