### PR TITLE
ElementaryTypeName takes care of how to print state mutability

### DIFF
--- a/src/nodes/ArrayTypeName.js
+++ b/src/nodes/ArrayTypeName.js
@@ -5,22 +5,13 @@ const {
 } = require('prettier/standalone');
 
 const ArrayTypeName = {
-  print: ({ node, path, print }) => {
-    let stateMutability = '';
-    if (
-      node.baseTypeName.name === 'address' &&
-      node.baseTypeName.stateMutability
-    ) {
-      stateMutability = concat([' ', node.baseTypeName.stateMutability]);
-    }
-    return concat([
+  print: ({ node, path, print }) =>
+    concat([
       path.call(print, 'baseTypeName'),
-      stateMutability,
       '[',
       node.length ? path.call(print, 'length') : '',
       ']'
-    ]);
-  }
+    ])
 };
 
 module.exports = ArrayTypeName;

--- a/src/nodes/ElementaryTypeName.js
+++ b/src/nodes/ElementaryTypeName.js
@@ -4,12 +4,10 @@ const {
   }
 } = require('prettier/standalone');
 
-const stateMutability = node => {
-  if (node.stateMutability && node.stateMutability.length > 0) {
-    return concat([' ', node.stateMutability]);
-  }
-  return '';
-};
+const stateMutability = node =>
+  node.stateMutability && node.stateMutability.length > 0
+    ? concat([' ', node.stateMutability])
+    : '';
 
 const ElementaryTypeName = {
   print: ({ node }) => concat([node.name, stateMutability(node)])

--- a/src/nodes/ElementaryTypeName.js
+++ b/src/nodes/ElementaryTypeName.js
@@ -1,5 +1,18 @@
+const {
+  doc: {
+    builders: { concat }
+  }
+} = require('prettier/standalone');
+
+const stateMutability = node => {
+  if (node.stateMutability && node.stateMutability.length > 0) {
+    return concat([' ', node.stateMutability]);
+  }
+  return '';
+};
+
 const ElementaryTypeName = {
-  print: ({ node }) => node.name
+  print: ({ node }) => concat([node.name, stateMutability(node)])
 };
 
 module.exports = ElementaryTypeName;

--- a/src/nodes/VariableDeclaration.js
+++ b/src/nodes/VariableDeclaration.js
@@ -1,18 +1,24 @@
 const {
   doc: {
-    builders: { join }
+    builders: { concat }
   }
 } = require('prettier/standalone');
 
-const indexed = node => (node.isIndexed ? 'indexed' : '');
+const indexed = node => (node.isIndexed ? ' indexed' : '');
 
 const visibility = node =>
-  node.visibility !== 'default' ? node.visibility : '';
+  node.visibility && node.visibility !== 'default'
+    ? concat([' ', node.visibility])
+    : '';
 
-const constantKeyword = node => (node.isDeclaredConst ? 'constant' : '');
+const constantKeyword = node => (node.isDeclaredConst ? ' constant' : '');
 
 const storageLocation = node =>
-  node.visibility !== 'default' ? node.storageLocation : '';
+  node.storageLocation && node.visibility !== 'default'
+    ? concat([' ', node.storageLocation])
+    : '';
+
+const name = node => (node.name ? concat([' ', node.name]) : '');
 
 const VariableDeclaration = {
   print: ({ node, path, print }) => {
@@ -20,17 +26,14 @@ const VariableDeclaration = {
       return node.name;
     }
 
-    return join(
-      ' ',
-      [
-        path.call(print, 'typeName'),
-        indexed(node),
-        visibility(node),
-        constantKeyword(node),
-        storageLocation(node),
-        node.name
-      ].filter(element => element)
-    );
+    return concat([
+      path.call(print, 'typeName'),
+      indexed(node),
+      visibility(node),
+      constantKeyword(node),
+      storageLocation(node),
+      name(node)
+    ]);
   }
 };
 

--- a/src/nodes/VariableDeclaration.js
+++ b/src/nodes/VariableDeclaration.js
@@ -4,32 +4,30 @@ const {
   }
 } = require('prettier/standalone');
 
+const indexed = node => (node.isIndexed ? 'indexed' : '');
+
+const visibility = node =>
+  node.visibility !== 'default' ? node.visibility : '';
+
+const constantKeyword = node => (node.isDeclaredConst ? 'constant' : '');
+
+const storageLocation = node =>
+  node.visibility !== 'default' ? node.storageLocation : '';
+
 const VariableDeclaration = {
   print: ({ node, path, print }) => {
     if (!node.typeName) {
       return node.name;
     }
-    let doc = path.call(print, 'typeName');
-    if (node.isIndexed) {
-      doc = join(' ', [doc, 'indexed']);
-    }
-    const constantKeyword = node.isDeclaredConst ? 'constant' : '';
-    if (node.visibility === 'default') {
-      return join(
-        ' ',
-        [doc, node.typeName.stateMutability, constantKeyword, node.name].filter(
-          element => element
-        )
-      );
-    }
+
     return join(
       ' ',
       [
-        doc,
-        node.typeName.stateMutability,
-        node.visibility,
-        constantKeyword,
-        node.storageLocation,
+        path.call(print, 'typeName'),
+        indexed(node),
+        visibility(node),
+        constantKeyword(node),
+        storageLocation(node),
         node.name
       ].filter(element => element)
     );

--- a/tests/AddressPayable/AddressPayable.sol
+++ b/tests/AddressPayable/AddressPayable.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.2;
 
 contract AddressPayable {
+  using Address for address payable;
   address payable[] hello;
   function sendSomeEth(address payable to, address payable[] memory world) public payable {
     address payable target = to;

--- a/tests/AddressPayable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AddressPayable/__snapshots__/jsfmt.spec.js.snap
@@ -4,6 +4,7 @@ exports[`AddressPayable.sol 1`] = `
 pragma solidity ^0.5.2;
 
 contract AddressPayable {
+  using Address for address payable;
   address payable[] hello;
   function sendSomeEth(address payable to, address payable[] memory world) public payable {
     address payable target = to;
@@ -15,6 +16,7 @@ pragma solidity ^0.5.2;
 
 
 contract AddressPayable {
+    using Address for address payable;
     address payable[] hello;
 
     function sendSomeEth(address payable to, address payable[] memory world)


### PR DESCRIPTION
fixes #226

Before the PR we were manually choosing where to print state mutability in `ArrayTypeName` and `VariableDeclaration`.
Now we rely on `ElementaryTypeName` to do that for us.
plus a small refactor on `VariableDeclaration`