### PR TITLE
Splitting and indenting variable declarations when necesary

### DIFF
--- a/tests/Tupples/Tupples.sol
+++ b/tests/Tupples/Tupples.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.5.0;
 
 contract demo {
-    function hello() public view returns(bool,bool) {}    
+    function hello() public view returns(bool,bool) {}
     function hello2() public view returns(bool) {}
-    function hello3() public view returns(bool,bool,bool) {}   
+    function hello3() public view returns(bool,bool,bool) {}
 
 }
 
@@ -15,5 +15,11 @@ contract Tupples {
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();
+        (string memory holderId,
+string memory containerId,
+string memory parentContainerId,
+bytes32 volumeId,
+bytes32 subUnitId,
+bytes32 requestId) = getParamsById(paramsId);
     }
 }

--- a/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Tupples/__snapshots__/jsfmt.spec.js.snap
@@ -4,9 +4,9 @@ exports[`Tupples.sol 1`] = `
 pragma solidity ^0.5.0;
 
 contract demo {
-    function hello() public view returns(bool,bool) {}    
+    function hello() public view returns(bool,bool) {}
     function hello2() public view returns(bool) {}
-    function hello3() public view returns(bool,bool,bool) {}   
+    function hello3() public view returns(bool,bool,bool) {}
 
 }
 
@@ -18,8 +18,15 @@ contract Tupples {
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();
+        (string memory holderId,
+string memory containerId,
+string memory parentContainerId,
+bytes32 volumeId,
+bytes32 subUnitId,
+bytes32 requestId) = getParamsById(paramsId);
     }
-}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.5.0;
 
 
@@ -40,6 +47,14 @@ contract Tupples {
         (, yo) = demo(_yo).hello();
         (yo, , yo) = demo(_yo).hello3();
         (yo, yo) = demo(_yo).hello();
+        (
+            string memory holderId,
+            string memory containerId,
+            string memory parentContainerId,
+            bytes32 volumeId,
+            bytes32 subUnitId,
+            bytes32 requestId
+        ) = getParamsById(paramsId);
     }
 }
 


### PR DESCRIPTION
Fixes #225

Before PR:
```Solidity
(string memory holderId,string memory containerId, string memory parentContainerId, bytes32 volumeId, bytes32 subUnitId, bytes32 requestId) = getParamsById(
    paramsId
);
```

After PR:
```Solidity
(
    string memory holderId,
    string memory containerId,
    string memory parentContainerId,
    bytes32 volumeId,
    bytes32 subUnitId,
    bytes32 requestId
) = getParamsById(paramsId);
```