### PR TITLE
small detail on a do-while statement that breaks

### DIFF
--- a/src/nodes/DoWhileStatement.js
+++ b/src/nodes/DoWhileStatement.js
@@ -6,10 +6,12 @@ const {
 
 const printBody = (node, path, print) => {
   if (node.body.type === 'Block') {
-    return concat([' ', path.call(print, 'body')]);
+    return concat([' ', path.call(print, 'body'), ' ']);
   }
 
-  return group(indent(concat([line, path.call(print, 'body')])));
+  return group(
+    concat([indent(concat([line, path.call(print, 'body')])), line])
+  );
 };
 
 const DoWhileStatement = {
@@ -17,7 +19,7 @@ const DoWhileStatement = {
     concat([
       'do',
       printBody(node, path, print),
-      ' while (',
+      'while (',
       group(
         concat([
           indent(concat([softline, path.call(print, 'condition')])),

--- a/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/WhileStatements/__snapshots__/jsfmt.spec.js.snap
@@ -77,9 +77,8 @@ contract WhileStatements {
         do a++; while (a < 100);
 
         do
-            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(
-                LONG_VARIABLE
-            ); while (a < 200);
+            a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
+        while (a < 200);
 
         do {
             a++;


### PR DESCRIPTION
Before PR:
```Solidity
do
    a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(
        LONG_VARIABLE
    ); while (a < 200);
```
After PR:
```Solidity
do
    a = a.add(LONG_VARIABLE).add(LONG_VARIABLE).add(LONG_VARIABLE);
while (a < 200);
```