### PR TITLE
Print list

### DIFF
--- a/src/nodes/AssemblyCall.js
+++ b/src/nodes/AssemblyCall.js
@@ -1,31 +1,21 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const AssemblyCall = {
-  print: ({ node, path, print }) => {
-    if (node.arguments.length === 0) {
-      return node.functionName;
-    }
-    return concat([
-      node.functionName,
-      '(',
-      group(
-        concat([
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'arguments'))
-            ])
-          ),
-          softline
+  print: ({ node, path, print }) =>
+    node.arguments.length === 0
+      ? node.functionName
+      : concat([
+          node.functionName,
+          '(',
+          printList(path.map(print, 'arguments')),
+          ')'
         ])
-      ),
-      ')'
-    ]);
-  }
 };
 
 module.exports = AssemblyCall;

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -1,8 +1,10 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, join }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const AssemblyFunctionDefinition = {
   print: ({ node, path, print }) =>
@@ -10,17 +12,7 @@ const AssemblyFunctionDefinition = {
       'function ',
       node.name,
       '(',
-      group(
-        concat([
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'arguments'))
-            ])
-          ),
-          softline
-        ])
-      ),
+      printList(path.map(print, 'arguments')),
       ')',
       ' -> ',
       join(', ', path.map(print, 'returnArguments')),

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -20,12 +20,10 @@ const AssemblyFunctionDefinition = {
             concat([
               line,
               '->',
-              printList(
-                path.map(print, 'returnArguments'),
-                line,
-                concat([',', line]),
-                ''
-              )
+              printList(path.map(print, 'returnArguments'), {
+                firstSeparator: line,
+                lastSeparator: ''
+              })
             ])
           ),
           line

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, join }
+    builders: { concat, group, indent, line }
   }
 } = require('prettier/standalone');
 
@@ -14,9 +14,23 @@ const AssemblyFunctionDefinition = {
       '(',
       printList(path.map(print, 'arguments')),
       ')',
-      ' -> ',
-      join(', ', path.map(print, 'returnArguments')),
-      ' ',
+      group(
+        concat([
+          indent(
+            concat([
+              line,
+              '->',
+              printList(
+                path.map(print, 'returnArguments'),
+                line,
+                concat([',', line]),
+                ''
+              )
+            ])
+          ),
+          line
+        ])
+      ),
       path.call(print, 'body')
     ])
 };

--- a/src/nodes/AssemblyLocalDefinition.js
+++ b/src/nodes/AssemblyLocalDefinition.js
@@ -10,7 +10,7 @@ const AssemblyLocalDefinition = {
   print: ({ path, print }) =>
     concat([
       'let',
-      printList(path.map(print, 'names'), line),
+      printList(path.map(print, 'names'), { firstSeparator: line }),
       ':= ',
       path.call(print, 'expression')
     ])

--- a/src/nodes/AssemblyLocalDefinition.js
+++ b/src/nodes/AssemblyLocalDefinition.js
@@ -1,15 +1,17 @@
 const {
   doc: {
-    builders: { join }
+    builders: { concat, line }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const AssemblyLocalDefinition = {
   print: ({ path, print }) =>
-    join(' ', [
+    concat([
       'let',
-      join(', ', path.map(print, 'names')),
-      ':=',
+      printList(path.map(print, 'names'), line),
+      ':= ',
       path.call(print, 'expression')
     ])
 };

--- a/src/nodes/AssemblySwitch.js
+++ b/src/nodes/AssemblySwitch.js
@@ -11,7 +11,11 @@ const AssemblySwitch = {
     concat([
       'switch ',
       path.call(print, 'expression'),
-      printList(path.map(print, 'cases'), hardline, hardline, '')
+      printList(path.map(print, 'cases'), {
+        firstSeparator: hardline,
+        separator: hardline,
+        lastSeparator: ''
+      })
     ])
 };
 

--- a/src/nodes/AssemblySwitch.js
+++ b/src/nodes/AssemblySwitch.js
@@ -1,19 +1,18 @@
 const {
   doc: {
-    builders: { concat, hardline, indent, join }
+    builders: { concat, hardline }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const AssemblySwitch = {
-  print: ({ path, print }) => {
-    const doc = join(hardline, path.map(print, 'cases'));
-    return concat([
+  print: ({ path, print }) =>
+    concat([
       'switch ',
       path.call(print, 'expression'),
-      indent(hardline),
-      indent(doc)
-    ]);
-  }
+      printList(path.map(print, 'cases'), hardline, hardline, '')
+    ])
 };
 
 module.exports = AssemblySwitch;

--- a/src/nodes/CatchClause.js
+++ b/src/nodes/CatchClause.js
@@ -1,8 +1,10 @@
 const {
   doc: {
-    builders: { concat, group, join, indent, line, softline }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const CatchClause = {
   print: ({ node, path, print }) => {
@@ -11,17 +13,7 @@ const CatchClause = {
         'catch ',
         node.isReasonStringType ? 'Error' : '',
         '(',
-        group(
-          concat([
-            indent(
-              concat([
-                softline,
-                join(concat([',', line]), path.map(print, 'parameters'))
-              ])
-            ),
-            softline
-          ])
-        ),
+        printList(path.map(print, 'parameters')),
         ') ',
         path.call(print, 'body')
       ])

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -9,7 +9,10 @@ const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 
 const inheritance = (node, path, print) =>
   node.baseContracts.length > 0
-    ? concat([' is', printList(path.map(print, 'baseContracts'), line)])
+    ? concat([
+        ' is',
+        printList(path.map(print, 'baseContracts'), { firstSeparator: line })
+      ])
     : line;
 
 const body = (node, path, options, print) =>

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -1,35 +1,25 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line }
+    builders: { concat, group, indent, line }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 
-const inheritance = (node, path, print) => {
-  if (node.baseContracts.length > 0) {
-    return concat([
-      ' is',
-      indent(
-        concat([
-          line,
-          join(concat([',', line]), path.map(print, 'baseContracts'))
-        ])
-      )
-    ]);
-  }
-  return '';
-};
+const inheritance = (node, path, print) =>
+  node.baseContracts.length > 0
+    ? concat([' is', printList(path.map(print, 'baseContracts'), line)])
+    : line;
 
-const body = (node, path, options, print) => {
-  if (node.subNodes.length > 0) {
-    return concat([
-      indent(line),
-      indent(printPreservingEmptyLines(path, 'subNodes', options, print)),
-      line
-    ]);
-  }
-  return '';
-};
+const body = (node, path, options, print) =>
+  node.subNodes.length > 0
+    ? concat([
+        indent(line),
+        indent(printPreservingEmptyLines(path, 'subNodes', options, print)),
+        line
+      ])
+    : '';
 
 const ContractDefinition = {
   print: ({ node, options, path, print }) =>
@@ -40,7 +30,6 @@ const ContractDefinition = {
           ' ',
           node.name,
           inheritance(node, path, print),
-          line,
           '{'
         ])
       ),

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -13,10 +13,9 @@ const EnumDefinition = {
         'enum ',
         node.name,
         ' {',
-        printList(
-          path.map(print, 'members'),
-          options.bracketSpacing ? line : softline
-        ),
+        printList(path.map(print, 'members'), {
+          firstSeparator: options.bracketSpacing ? line : softline
+        }),
         '}'
       ])
     )

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -1,8 +1,10 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group, line, softline }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const EnumDefinition = {
   print: ({ node, path, print, options }) =>
@@ -11,13 +13,10 @@ const EnumDefinition = {
         'enum ',
         node.name,
         ' {',
-        indent(
-          concat([
-            options.bracketSpacing ? line : softline,
-            join(concat([',', line]), path.map(print, 'members'))
-          ])
+        printList(
+          path.map(print, 'members'),
+          options.bracketSpacing ? line : softline
         ),
-        options.bracketSpacing ? line : softline,
         '}'
       ])
     )

--- a/src/nodes/EventDefinition.js
+++ b/src/nodes/EventDefinition.js
@@ -1,25 +1,15 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat }
   }
 } = require('prettier/standalone');
 
-const parameters = (node, path, print) => {
-  if (node.parameters && node.parameters.length > 0) {
-    return group(
-      concat([
-        indent(
-          concat([
-            softline,
-            join(concat([',', line]), path.map(print, 'parameters'))
-          ])
-        ),
-        softline
-      ])
-    );
-  }
-  return '';
-};
+const printList = require('./print-list');
+
+const parameters = (node, path, print) =>
+  node.parameters && node.parameters.length > 0
+    ? printList(path.map(print, 'parameters'))
+    : '';
 
 const EventDefinition = {
   print: ({ node, path, print }) =>

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -14,7 +14,7 @@ const printObject = (node, path, print, options) =>
         path
           .map(print, 'arguments')
           .map((arg, index) => concat([node.names[index], ': ', arg])),
-        options.bracketSpacing ? line : softline
+        { firstSeparator: options.bracketSpacing ? line : softline }
       ),
       '}'
     ])

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -1,39 +1,22 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group, line, softline }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const printObject = (node, path, print, options) =>
   group(
     concat([
       '{',
-      indent(
-        concat([
-          options.bracketSpacing ? line : softline,
-          join(
-            concat([',', line]),
-            path
-              .map(print, 'arguments')
-              .map((arg, index) => concat([node.names[index], ': ', arg]))
-          )
-        ])
+      printList(
+        path
+          .map(print, 'arguments')
+          .map((arg, index) => concat([node.names[index], ': ', arg])),
+        options.bracketSpacing ? line : softline
       ),
-      options.bracketSpacing ? line : softline,
       '}'
-    ])
-  );
-
-const printParameters = (node, path, print) =>
-  group(
-    concat([
-      indent(
-        concat([
-          softline,
-          join(concat([',', line]), path.map(print, 'arguments'))
-        ])
-      ),
-      softline
     ])
   );
 
@@ -42,7 +25,7 @@ const printArguments = (node, path, print, options) => {
     return printObject(node, path, print, options);
   }
   if (node.arguments && node.arguments.length > 0) {
-    return printParameters(node, path, print);
+    return printList(path.map(print, 'arguments'));
   }
   return '';
 };

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -1,8 +1,10 @@
 const {
   doc: {
-    builders: { concat, dedent, group, indent, join, line, softline }
+    builders: { concat, dedent, group, indent, join, line }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const functionName = node => {
   if (node.isConstructor && !node.name) return 'constructor';
@@ -10,22 +12,10 @@ const functionName = node => {
   return 'function';
 };
 
-const parameters = (parametersType, node, path, print) => {
-  if (node[parametersType] && node[parametersType].length > 0) {
-    return group(
-      concat([
-        indent(
-          concat([
-            softline,
-            join(concat([',', line]), path.map(print, parametersType))
-          ])
-        ),
-        softline
-      ])
-    );
-  }
-  return '';
-};
+const parameters = (parametersType, node, path, print) =>
+  node[parametersType] && node[parametersType].length > 0
+    ? printList(path.map(print, parametersType))
+    : '';
 
 const visibility = node => {
   if (node.visibility && node.visibility !== 'default') {

--- a/src/nodes/FunctionTypeName.js
+++ b/src/nodes/FunctionTypeName.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line }
+    builders: { concat, group, indent, line }
   }
 } = require('prettier/standalone');
 
@@ -11,7 +11,7 @@ const returnTypes = (node, path, print) => {
     return concat([
       line,
       'returns (',
-      join(', ', path.map(print, 'returnTypes')),
+      printList(path.map(print, 'returnTypes')),
       ')'
     ]);
   }

--- a/src/nodes/FunctionTypeName.js
+++ b/src/nodes/FunctionTypeName.js
@@ -1,21 +1,10 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group, indent, join, line }
   }
 } = require('prettier/standalone');
 
-const parameterTypes = (node, path, print) =>
-  group(
-    concat([
-      indent(
-        concat([
-          softline,
-          join(concat([',', line]), path.map(print, 'parameterTypes'))
-        ])
-      ),
-      softline
-    ])
-  );
+const printList = require('./print-list');
 
 const returnTypes = (node, path, print) => {
   if (node.returnTypes.length > 0) {
@@ -47,7 +36,7 @@ const FunctionTypeName = {
   print: ({ node, path, print }) =>
     concat([
       'function(',
-      parameterTypes(node, path, print),
+      printList(path.map(print, 'parameterTypes')),
       ')',
       indent(
         group(

--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -17,7 +17,7 @@ const ImportDirective = {
         '{',
         printList(
           node.symbolAliases.map(([a, b]) => (b ? `${a} as ${b}` : a)),
-          options.bracketSpacing ? line : softline
+          { firstSeparator: options.bracketSpacing ? line : softline }
         ),
         '} from ',
         doc

--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -1,8 +1,9 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group, line, softline }
   }
 } = require('prettier/standalone');
+const printList = require('./print-list');
 const { printString } = require('../prettier-comments/common/util');
 
 const ImportDirective = {
@@ -14,16 +15,10 @@ const ImportDirective = {
     } else if (node.symbolAliases) {
       doc = concat([
         '{',
-        indent(
-          concat([
-            options.bracketSpacing ? line : softline,
-            join(
-              concat([',', line]),
-              node.symbolAliases.map(([a, b]) => (b ? `${a} as ${b}` : a))
-            )
-          ])
+        printList(
+          node.symbolAliases.map(([a, b]) => (b ? `${a} as ${b}` : a)),
+          options.bracketSpacing ? line : softline
         ),
-        options.bracketSpacing ? line : softline,
         '} from ',
         doc
       ]);

--- a/src/nodes/InheritanceSpecifier.js
+++ b/src/nodes/InheritanceSpecifier.js
@@ -1,28 +1,15 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
 
-const printArguments = (node, path, print) => {
-  if (node.arguments && node.arguments.length) {
-    return group(
-      concat([
-        '(',
-        indent(
-          concat([
-            softline,
-            join(concat([',', line]), path.map(print, 'arguments'))
-          ])
-        ),
-        softline,
-        ')'
-      ])
-    );
-  }
+const printList = require('./print-list');
 
-  return '';
-};
+const printArguments = (node, path, print) =>
+  node.arguments && node.arguments.length
+    ? group(concat(['(', printList(path.map(print, 'arguments')), ')']))
+    : '';
 
 const InheritanceSpecifier = {
   print: ({ node, path, print }) =>

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -1,28 +1,16 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const modifierParameters = (node, path, print) => {
   if (node.parameters) {
-    if (node.parameters.length > 0) {
-      return group(
-        concat([
-          '(',
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'parameters'))
-            ])
-          ),
-          softline,
-          ')'
-        ])
-      );
-    }
-
-    return '()';
+    return node.parameters.length > 0
+      ? group(concat(['(', printList(path.map(print, 'parameters')), ')']))
+      : '()';
   }
 
   return '';

--- a/src/nodes/ModifierInvocation.js
+++ b/src/nodes/ModifierInvocation.js
@@ -1,28 +1,16 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const modifierArguments = (node, path, print) => {
   if (node.arguments) {
-    if (node.arguments.length > 0) {
-      return group(
-        concat([
-          '(',
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'arguments'))
-            ])
-          ),
-          softline,
-          ')'
-        ])
-      );
-    }
-
-    return '()';
+    return node.arguments.length > 0
+      ? group(concat(['(', printList(path.map(print, 'arguments')), ')']))
+      : '()';
   }
 
   return '';

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -1,8 +1,10 @@
 const {
   doc: {
-    builders: { concat, hardline, indent, join, line }
+    builders: { concat, hardline }
   }
 } = require('prettier/standalone');
+
+const printList = require('./print-list');
 
 const StructDefinition = {
   print: ({ node, path, print }) =>
@@ -10,14 +12,11 @@ const StructDefinition = {
       'struct ',
       node.name,
       ' {',
-      indent(line),
-      indent(
-        join(
-          hardline,
-          path.map(print, 'members').map(element => concat([element, ';']))
-        )
+      printList(
+        path.map(print, 'members').map(element => concat([element, ';'])),
+        hardline,
+        hardline
       ),
-      hardline,
       '}'
     ])
 };

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -12,12 +12,11 @@ const StructDefinition = {
       'struct ',
       node.name,
       ' {',
-      printList(
-        path.map(print, 'members'),
-        hardline,
-        concat([';', hardline]),
-        concat([';', hardline])
-      ),
+      printList(path.map(print, 'members'), {
+        firstSeparator: hardline,
+        separator: concat([';', hardline]),
+        lastSeparator: concat([';', hardline])
+      }),
       '}'
     ])
 };

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -13,9 +13,10 @@ const StructDefinition = {
       node.name,
       ' {',
       printList(
-        path.map(print, 'members').map(element => concat([element, ';'])),
+        path.map(print, 'members'),
         hardline,
-        hardline
+        concat([';', hardline]),
+        concat([';', hardline])
       ),
       '}'
     ])

--- a/src/nodes/TryStatement.js
+++ b/src/nodes/TryStatement.js
@@ -1,29 +1,15 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group, indent, join, line }
   }
 } = require('prettier/standalone');
 
-const returnParameters = (node, path, print) => {
-  if (node.returnParameters) {
-    return concat([
-      'returns (',
-      group(
-        concat([
-          indent(
-            concat([
-              softline,
-              join(concat([',', line]), path.map(print, 'returnParameters'))
-            ])
-          ),
-          softline
-        ])
-      ),
-      ')'
-    ]);
-  }
-  return '';
-};
+const printList = require('./print-list');
+
+const returnParameters = (node, path, print) =>
+  node.returnParameters
+    ? concat(['returns (', printList(path.map(print, 'returnParameters')), ')'])
+    : '';
 
 const TryStatement = {
   print: ({ node, path, print }) =>

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -1,30 +1,17 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
 
-const contents = (node, path, print) => {
-  if (
-    node.components &&
-    node.components.length === 1 &&
-    node.components[0].type === 'BinaryOperation'
-  ) {
-    return path.map(print, 'components');
-  }
-  return [
-    indent(
-      concat([
-        softline,
-        join(
-          concat([',', line]),
-          path.map(print, node.components ? 'components' : 'elements')
-        )
-      ])
-    ),
-    softline
-  ];
-};
+const printList = require('./print-list');
+
+const contents = (node, path, print) =>
+  node.components &&
+  node.components.length === 1 &&
+  node.components[0].type === 'BinaryOperation'
+    ? path.map(print, 'components')
+    : [printList(path.map(print, node.components ? 'components' : 'elements'))];
 
 const TupleExpression = {
   // @TODO: remove hack once solidity-parser-antlr is fixed

--- a/src/nodes/VariableDeclarationStatement.js
+++ b/src/nodes/VariableDeclarationStatement.js
@@ -1,27 +1,13 @@
 const {
   doc: {
-    builders: { concat, group, indent, join, line, softline }
+    builders: { concat }
   }
 } = require('prettier/standalone');
 
+const printList = require('./print-list');
+
 const embraceVariables = (doc, embrace) =>
   embrace ? concat(['(', doc, ')']) : doc;
-
-const variables = (node, path, print) =>
-  group(
-    concat([
-      indent(
-        concat([
-          softline,
-          join(
-            concat([',', line]),
-            path.map(statementPath => print(statementPath), 'variables')
-          )
-        ])
-      ),
-      softline
-    ])
-  );
 
 const initialValue = (node, path, print) =>
   node.initialValue ? concat([' = ', path.call(print, 'initialValue')]) : '';
@@ -34,7 +20,7 @@ const VariableDeclarationStatement = {
     return concat([
       startsWithVar ? 'var ' : '',
       embraceVariables(
-        variables(node, path, print),
+        printList(path.map(print, 'variables')),
         node.variables.length > 1 || startsWithVar
       ),
       initialValue(node, path, print),

--- a/src/nodes/print-list.js
+++ b/src/nodes/print-list.js
@@ -6,9 +6,11 @@ const {
 
 const printList = (
   list,
-  firstSeparator = softline,
-  separator = concat([',', line]),
-  lastSeparator = firstSeparator
+  {
+    firstSeparator = softline,
+    separator = concat([',', line]),
+    lastSeparator = firstSeparator
+  } = {}
 ) =>
   group(
     concat([

--- a/src/nodes/print-list.js
+++ b/src/nodes/print-list.js
@@ -6,13 +6,14 @@ const {
 
 const printList = (
   list,
-  edgeSeparator = softline,
-  separator = concat([',', line])
+  firstSeparator = softline,
+  separator = concat([',', line]),
+  lastSeparator = firstSeparator
 ) =>
   group(
     concat([
-      indent(concat([edgeSeparator, join(separator, list)])),
-      edgeSeparator
+      indent(concat([firstSeparator, join(separator, list)])),
+      lastSeparator
     ])
   );
 

--- a/src/nodes/print-list.js
+++ b/src/nodes/print-list.js
@@ -1,0 +1,19 @@
+const {
+  doc: {
+    builders: { concat, group, indent, join, line, softline }
+  }
+} = require('prettier/standalone');
+
+const printList = (
+  list,
+  edgeSeparator = softline,
+  separator = concat([',', line])
+) =>
+  group(
+    concat([
+      indent(concat([edgeSeparator, join(separator, list)])),
+      edgeSeparator
+    ])
+  );
+
+module.exports = printList;

--- a/tests/Assembly/Assembly.sol
+++ b/tests/Assembly/Assembly.sol
@@ -73,4 +73,31 @@ for { let i := 0 } lt(i, x) { i := add(i, 1) } { y := mul(2, y) }
 			}
   		}
   }
+
+  function assemblyFunctionLongReturnParameters() {
+		assembly {
+			function sum  (a, b, c, d, e)
+      -> thisIs, aFunctionWithVery, veryLongParameterNames, andItAlsoHasALotOfParameters, soItShouldBeSplitInMultipleLines {
+        thisIs := 0
+        aFunctionWithVery := 0
+        veryLongParameterNames := 0
+        andItAlsoHasALotOfParameters := 0
+        soItShouldBeSplitInMultipleLines := 0
+			}
+  		}
+  }
+
+
+    function assemblyFunctionLongParametersAndReturnParameters() {
+  		assembly {
+  			function sum  (a,veryLong, listof, parameters, thatShould,splitForSure)
+        -> thisIs, aFunctionWithVery, veryLongParameterNames, andItAlsoHasALotOfParameters, soItShouldBeSplitInMultipleLines {
+          thisIs := 0
+          aFunctionWithVery := 0
+          veryLongParameterNames := 0
+          andItAlsoHasALotOfParameters := 0
+          soItShouldBeSplitInMultipleLines := 0
+  			}
+    		}
+    }
 }

--- a/tests/Assembly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Assembly/__snapshots__/jsfmt.spec.js.snap
@@ -76,6 +76,33 @@ for { let i := 0 } lt(i, x) { i := add(i, 1) } { y := mul(2, y) }
 			}
   		}
   }
+
+  function assemblyFunctionLongReturnParameters() {
+		assembly {
+			function sum  (a, b, c, d, e)
+      -> thisIs, aFunctionWithVery, veryLongParameterNames, andItAlsoHasALotOfParameters, soItShouldBeSplitInMultipleLines {
+        thisIs := 0
+        aFunctionWithVery := 0
+        veryLongParameterNames := 0
+        andItAlsoHasALotOfParameters := 0
+        soItShouldBeSplitInMultipleLines := 0
+			}
+  		}
+  }
+
+
+    function assemblyFunctionLongParametersAndReturnParameters() {
+  		assembly {
+  			function sum  (a,veryLong, listof, parameters, thatShould,splitForSure)
+        -> thisIs, aFunctionWithVery, veryLongParameterNames, andItAlsoHasALotOfParameters, soItShouldBeSplitInMultipleLines {
+          thisIs := 0
+          aFunctionWithVery := 0
+          veryLongParameterNames := 0
+          andItAlsoHasALotOfParameters := 0
+          soItShouldBeSplitInMultipleLines := 0
+  			}
+    		}
+    }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract Assembly {
@@ -161,6 +188,51 @@ contract Assembly {
                 soItShouldBeSplitInMultipleLines
             ) -> result {
                 result := 0
+            }
+        }
+    }
+
+    function assemblyFunctionLongReturnParameters() {
+        assembly {
+            function sum(a, b, c, d, e)
+                ->
+                    thisIs,
+                    aFunctionWithVery,
+                    veryLongParameterNames,
+                    andItAlsoHasALotOfParameters,
+                    soItShouldBeSplitInMultipleLines
+            {
+                thisIs := 0
+                aFunctionWithVery := 0
+                veryLongParameterNames := 0
+                andItAlsoHasALotOfParameters := 0
+                soItShouldBeSplitInMultipleLines := 0
+            }
+        }
+    }
+
+    function assemblyFunctionLongParametersAndReturnParameters() {
+        assembly {
+            function sum(
+                a,
+                veryLong,
+                listof,
+                parameters,
+                thatShould,
+                splitForSure
+            )
+                ->
+                    thisIs,
+                    aFunctionWithVery,
+                    veryLongParameterNames,
+                    andItAlsoHasALotOfParameters,
+                    soItShouldBeSplitInMultipleLines
+            {
+                thisIs := 0
+                aFunctionWithVery := 0
+                veryLongParameterNames := 0
+                andItAlsoHasALotOfParameters := 0
+                soItShouldBeSplitInMultipleLines := 0
             }
         }
     }

--- a/tests/Etc/Etc.sol
+++ b/tests/Etc/Etc.sol
@@ -9,6 +9,7 @@ pragma solidity ^0.4.24;
 contract Contract {
   struct StructWithFunctionTypes {
     function (uint, uint) returns(bool)a;
+    function (uint, uint) returns(bool,bytes32, bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)a;
     function(bytes32, bytes32)   internal view[]  b;
     function  (bytes32, bytes32)internal[]   c;
     function(bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)   internal view[]  d;

--- a/tests/Etc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Etc/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,7 @@ pragma solidity ^0.4.24;
 contract Contract {
   struct StructWithFunctionTypes {
     function (uint, uint) returns(bool)a;
+    function (uint, uint) returns(bool,bytes32, bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)a;
     function(bytes32, bytes32)   internal view[]  b;
     function  (bytes32, bytes32)internal[]   c;
     function(bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)   internal view[]  d;
@@ -61,6 +62,17 @@ pragma solidity ^0.4.24;
 contract Contract {
     struct StructWithFunctionTypes {
         function(uint256, uint256) returns (bool) a;
+        function(uint256, uint256)
+            returns (
+                bool,
+                bytes32,
+                bytes32,
+                bytes32,
+                bytes32,
+                bytes32,
+                bytes32,
+                bytes32
+            ) a;
         function(bytes32, bytes32) internal view[] b;
         function(bytes32, bytes32) internal[] c;
         function(bytes32, bytes32, bytes32, bytes32, bytes32, bytes32)


### PR DESCRIPTION
just playing with the idea of having a `printList` function (provided by @fvictorio) for most of our splitting and indenting cases.

The function just needs an array, but can also receive a `firstSeparator` (usually a `softline` used to separate from the previous character), a normal `separator` to put between items (usually a `concat([',', line])`), and finally the `lastSeparator` that in most cases is the same as `firstSeparator` with 2 exceptions (`AssemblySwitch` and `StructDefinition`).

```Javascript
const printList = (
  list,
  firstSeparator = softline,
  separator = concat([',', line]),
  lastSeparator = firstSeparator
) =>
  group(
    concat([
      indent(concat([firstSeparator, join(separator, list)])),
      lastSeparator
    ])
  );
```

Please have a look and see if it makes sense to use this pattern.