### PR TITLE
add a note in vscode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,39 @@ You'll notice now that `prettier` is formatting every time the files are saved b
 }
 ```
 
+Note: When you install the npm package `prettier` in your project and create a `.prettierrc` file (which wasn't in your project before this), your VSCode's default settings or rules in `settings.json` are ignored ([prettier/prettier-vscode#1079](https://github.com/prettier/prettier-vscode/issues/1079)).
+
+If that's not a problem for you, you can just ignore adding this part. You can add more overrides to `.prettierrc` based on rest of the types of files in your project. Below is an example of adding override for `.js` files.
+
+```json
+{
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "printWidth": 80,
+        "tabWidth": 4,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": false,
+        "explicitTypes": "always"
+      }
+    },
+    {
+      "files": "*.js",
+      "options": {
+        "printWidth": 80,
+        "tabWidth": 2,
+        "useTabs": false,
+        "singleQuote": true,
+        "bracketSpacing": true
+      }
+    }
+  ]
+}
+```
+For more customization, you can refer [prettier options docs](https://prettier.io/docs/en/options.html).
+
 ## Contributing
 
 1. [Fork it](https://github.com/prettier-solidity/prettier-plugin-solidity/fork)

--- a/README.md
+++ b/README.md
@@ -118,36 +118,7 @@ You'll notice now that `prettier` is formatting every time the files are saved b
 
 Note: When you install the npm package `prettier` in your project and create a `.prettierrc` file (which wasn't in your project before this), your VSCode's default settings or rules in `settings.json` are ignored ([prettier/prettier-vscode#1079](https://github.com/prettier/prettier-vscode/issues/1079)).
 
-If that's not a problem for you, you can just ignore adding this part. You can add more overrides to `.prettierrc` based on rest of the types of files in your project. Below is an example of adding override for `.js` files.
-
-```json
-{
-  "overrides": [
-    {
-      "files": "*.sol",
-      "options": {
-        "printWidth": 80,
-        "tabWidth": 4,
-        "useTabs": false,
-        "singleQuote": false,
-        "bracketSpacing": false,
-        "explicitTypes": "always"
-      }
-    },
-    {
-      "files": "*.js",
-      "options": {
-        "printWidth": 80,
-        "tabWidth": 2,
-        "useTabs": false,
-        "singleQuote": true,
-        "bracketSpacing": true
-      }
-    }
-  ]
-}
-```
-For more customization, you can refer [prettier options docs](https://prettier.io/docs/en/options.html).
+If you want a different configuration for your javascript and solidity files, you can add an [overrides property](https://prettier.io/docs/en/configuration.html#configuration-overrides) to your `.prettierrc`.
 
 ## Contributing
 


### PR DESCRIPTION
This node is regarding a fix introduced in prettier-vscode 3.8.0 around Nov 2019 causing vscode settings to be ignored (prettier/prettier-vscode#1079). Looks like many people around the world faced a trivial looking problem (prettier/prettier-vscode#1085).

Please let me know if any changes are required.