### PR TITLE
Adjust stateMutability in function modifier order

### DIFF
--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -89,9 +89,9 @@ const FunctionDefinition = {
         group(
           concat([
             visibility(node),
+            stateMutability(node),
             virtual(node),
             override(node, path, print),
-            stateMutability(node),
             modifiers(node, path, print),
             returnParameters(node, path, print),
             signatureEnd(node)

--- a/tests/FunctionDefinitions/FunctionDefinitions.sol
+++ b/tests/FunctionDefinitions/FunctionDefinitions.sol
@@ -34,6 +34,22 @@ interface FunctionInterfaces {
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
 
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
+
+  function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint);
+
+  function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string);
+
+  function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address);
+
+  function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint);
+
+  function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint);
+
+  function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint);
+
+  function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint);
+
+  function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint);
 }
 
 contract FunctionDefinitions {
@@ -113,6 +129,38 @@ contract FunctionDefinitions {
   }
 
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint) {
     a = 1;
   }
 }

--- a/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -37,6 +37,22 @@ interface FunctionInterfaces {
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
 
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
+
+  function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint);
+
+  function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string);
+
+  function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address);
+
+  function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint);
+
+  function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint);
+
+  function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint);
+
+  function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint);
+
+  function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint);
 }
 
 contract FunctionDefinitions {
@@ -116,6 +132,38 @@ contract FunctionDefinitions {
   }
 
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address) {
+    a = 1;
+  }
+
+  function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint) {
+    a = 1;
+  }
+
+  function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint) {
     a = 1;
   }
 }
@@ -356,6 +404,72 @@ interface FunctionInterfaces {
             uint256 y9,
             uint256 y10
         );
+
+    function modifierOrderCorrect01()
+        public
+        view
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256);
+
+    function modifierOrderCorrect02()
+        private
+        pure
+        virtual
+        modifier1
+        modifier2
+        returns (string);
+
+    function modifierOrderCorrect03()
+        external
+        payable
+        override
+        modifier1
+        modifier2
+        returns (address);
+
+    function modifierOrderCorrect04()
+        internal
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256);
+
+    function modifierOrderIncorrect01()
+        public
+        view
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256);
+
+    function modifierOrderIncorrect02()
+        external
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256);
+
+    function modifierOrderIncorrect03()
+        internal
+        pure
+        virtual
+        modifier1
+        modifier2
+        returns (uint256);
+
+    function modifierOrderIncorrect04()
+        external
+        payable
+        override
+        modifier1
+        modifier2
+        returns (uint256);
 }
 
 contract FunctionDefinitions {
@@ -649,6 +763,96 @@ contract FunctionDefinitions {
             uint256 y9,
             uint256 y10
         )
+    {
+        a = 1;
+    }
+
+    function modifierOrderCorrect01()
+        public
+        view
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256)
+    {
+        a = 1;
+    }
+
+    function modifierOrderCorrect02()
+        private
+        pure
+        virtual
+        modifier1
+        modifier2
+        returns (string)
+    {
+        a = 1;
+    }
+
+    function modifierOrderCorrect03()
+        external
+        payable
+        override
+        modifier1
+        modifier2
+        returns (address)
+    {
+        a = 1;
+    }
+
+    function modifierOrderCorrect04()
+        internal
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256)
+    {
+        a = 1;
+    }
+
+    function modifierOrderIncorrect01()
+        public
+        view
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256)
+    {
+        a = 1;
+    }
+
+    function modifierOrderIncorrect02()
+        external
+        virtual
+        override
+        modifier1
+        modifier2
+        returns (uint256)
+    {
+        a = 1;
+    }
+
+    function modifierOrderIncorrect03()
+        internal
+        pure
+        virtual
+        modifier1
+        modifier2
+        returns (uint256)
+    {
+        a = 1;
+    }
+
+    function modifierOrderIncorrect04()
+        external
+        payable
+        override
+        modifier1
+        modifier2
+        returns (uint256)
     {
         a = 1;
     }


### PR DESCRIPTION
Not sure if you want this, but it would follow the Solidity style guide.
https://solidity.readthedocs.io/en/v0.7.2/style-guide.html#function-declaration

Specifically:
The modifier order for a function should be:

1. Visibility
2. Mutability
3. Virtual
4. Override
5. Custom modifiers