### PR TITLE
Fix how variable declarations are handled

### DIFF
--- a/src/nodes/VariableDeclarationStatement.js
+++ b/src/nodes/VariableDeclarationStatement.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { concat }
+    builders: { concat, group, indent, line }
   }
 } = require('prettier/standalone');
 
@@ -10,22 +10,28 @@ const embraceVariables = (doc, embrace) =>
   embrace ? concat(['(', doc, ')']) : doc;
 
 const initialValue = (node, path, print) =>
-  node.initialValue ? concat([' = ', path.call(print, 'initialValue')]) : '';
+  node.initialValue
+    ? group(
+        concat([' =', indent(concat([line, path.call(print, 'initialValue')]))])
+      )
+    : '';
 
 const VariableDeclarationStatement = {
   print: ({ node, path, print }) => {
     const startsWithVar =
       node.variables.filter((x) => x && x.typeName).length === 0;
 
-    return concat([
-      startsWithVar ? 'var ' : '',
-      embraceVariables(
-        printSeparatedList(path.map(print, 'variables')),
-        node.variables.length > 1 || startsWithVar
-      ),
-      initialValue(node, path, print),
-      node.omitSemicolon ? '' : ';'
-    ]);
+    return group(
+      concat([
+        startsWithVar ? 'var ' : '',
+        embraceVariables(
+          printSeparatedList(path.map(print, 'variables')),
+          node.variables.length > 1 || startsWithVar
+        ),
+        initialValue(node, path, print),
+        node.omitSemicolon ? '' : ';'
+      ])
+    );
   }
 };
 

--- a/tests/Arrays/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Arrays/__snapshots__/jsfmt.spec.js.snap
@@ -30,10 +30,8 @@ contract Arrays {
     ];
 
     function a() {
-        Outcome.OutcomeItem[] memory outcomeFrom = abi.decode(
-            fromPart.outcome,
-            (Outcome.OutcomeItem[])
-        );
+        Outcome.OutcomeItem[] memory outcomeFrom =
+            abi.decode(fromPart.outcome, (Outcome.OutcomeItem[]));
     }
 }
 

--- a/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Conditional/__snapshots__/jsfmt.spec.js.snap
@@ -32,9 +32,8 @@ pragma solidity ^0.4.24;
 
 contract Conditional {
     function foo() {
-        address contextAddress = longAddress_ == address(0)
-            ? msg.sender
-            : currentContextAddress_;
+        address contextAddress =
+            longAddress_ == address(0) ? msg.sender : currentContextAddress_;
         asset == ETH
             ? require(
                 address(uint160(msg.sender)).send(quantity),

--- a/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -23,8 +23,8 @@ contract FunctionCalls {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract FunctionCalls {
     function foo() {
-        address veryLongValidatorAddress = veryVeryVeryLongSignature
-            .popLast20Bytes();
+        address veryLongValidatorAddress =
+            veryVeryVeryLongSignature.popLast20Bytes();
     }
 
     function foo() {
@@ -61,8 +61,8 @@ contract FunctionCalls {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 contract FunctionCalls {
     function foo() {
-        address veryLongValidatorAddress = veryVeryVeryLongSignature
-            .popLast20Bytes();
+        address veryLongValidatorAddress =
+            veryVeryVeryLongSignature.popLast20Bytes();
     }
 
     function foo() {

--- a/tests/Issues/Issue289.sol
+++ b/tests/Issues/Issue289.sol
@@ -1,0 +1,6 @@
+contract Issue289 {
+  function f() {
+	address[] storage proposalValidators
+ = ethProposals[_blockNumber][_proposalId].proposalValidators;
+  }
+}

--- a/tests/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Issue289.sol 1`] = `
+contract Issue289 {
+  function f() {
+	address[] storage proposalValidators
+ = ethProposals[_blockNumber][_proposalId].proposalValidators;
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract Issue289 {
+    function f() {
+        address[] storage proposalValidators =
+            ethProposals[_blockNumber][_proposalId].proposalValidators;
+    }
+}
+
+`;

--- a/tests/Issues/jsfmt.spec.js
+++ b/tests/Issues/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
@@ -81,8 +81,8 @@ contract SplittableCommodity is MintableCommodity {
         address _to,
         uint256 _amount
     ) public whenNotPaused {
-        address supplierProxy = IContractRegistry(contractRegistry)
-            .getLatestProxyAddr("Supplier");
+        address supplierProxy =
+            IContractRegistry(contractRegistry).getLatestProxyAddr("Supplier");
         require(
             msg.sender ==
                 IContractRegistry(contractRegistry).getLatestProxyAddr(
@@ -94,14 +94,15 @@ contract SplittableCommodity is MintableCommodity {
 
         commodities[_tokenId].value = commodities[_tokenId].value.sub(_amount);
 
-        CommodityLib.Commodity memory _commodity = CommodityLib.Commodity({
-            category: uint64(1),
-            timeRegistered: uint64(now), // solium-disable-line
-            parentId: _tokenId,
-            value: _amount,
-            locked: false,
-            misc: commodities[_tokenId].misc
-        });
+        CommodityLib.Commodity memory _commodity =
+            CommodityLib.Commodity({
+                category: uint64(1),
+                timeRegistered: uint64(now), // solium-disable-line
+                parentId: _tokenId,
+                value: _amount,
+                locked: false,
+                misc: commodities[_tokenId].misc
+            });
         uint256 newCRCId = commodities.push(_commodity).sub(1);
         require(
             newCRCId <= 18446744073709551616,

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1477,8 +1477,9 @@ library strings {
         pure
         returns (uint256 cnt)
     {
-        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) +
-            needle._len;
+        uint256 ptr =
+            findPtr(self._len, self._ptr, needle._len, needle._ptr) +
+                needle._len;
         while (ptr <= self._ptr + self._len) {
             cnt++;
             ptr =


### PR DESCRIPTION
Closes #267.
Closes #289.

This changes some tests (see the modified snapshots), but it also fixes a couple of issues, so I think it's worth it. Plus, I kind of prefer the new way those are formatted, except for this one:

```diff
-        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) +
-            needle._len;
+        uint256 ptr =
+            findPtr(self._len, self._ptr, needle._len, needle._ptr) +
+                needle._len;
```

but I'd rather fix that in a different PR.