### PR TITLE
Use solidity-comments-extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7972,9 +7972,9 @@
       }
     },
     "solidity-comments-extractor": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.2.tgz",
-      "integrity": "sha512-8twZSUh6oHpHrdq2DxXTd646Vjh3V7SwLGL91UEnBFM5ru4RxnaH9A536VUdVG+u/y9W2WyFNE62Pr+8Qnk4uA=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.4.tgz",
+      "integrity": "sha512-58glBODwXIKMaQ7rfcJOrWtFQMMOK28tJ0/LcB5Xhu7WtAxk4UX2fpgKPuaL41XjMp/y0gAa1MTLqk018wuSzA=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "1.0.0-alpha.59",
+  "version": "1.0.0-alpha.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3099,15 +3099,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "esprima-extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esprima-extract-comments/-/esprima-extract-comments-1.1.0.tgz",
-      "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
-      "requires": {
-        "esprima": "^4.0.0"
-      }
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.3.1",
@@ -3423,15 +3416,6 @@
             "kind-of": "^6.0.2"
           }
         }
-      }
-    },
-    "extract-comments": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/extract-comments/-/extract-comments-1.1.0.tgz",
-      "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
-      "requires": {
-        "esprima-extract-comments": "^1.1.0",
-        "parse-code-context": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -7166,11 +7150,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-code-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-code-context/-/parse-code-context-1.0.0.tgz",
-      "integrity": "sha512-OZQaqKaQnR21iqhlnPfVisFjBWjhnMl5J9MgbP8xC+EwoVqbXrq78lp+9Zb3ahmLzrIX5Us/qbvBnaS3hkH6OA=="
-    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -7991,6 +7970,11 @@
           }
         }
       }
+    },
+    "solidity-comments-extractor": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.2.tgz",
+      "integrity": "sha512-8twZSUh6oHpHrdq2DxXTd646Vjh3V7SwLGL91UEnBFM5ru4RxnaH9A536VUdVG+u/y9W2WyFNE62Pr+8Qnk4uA=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "escape-string-regexp": "^4.0.0",
     "prettier": "^2.0.5",
     "semver": "^7.3.2",
-    "solidity-comments-extractor": "^0.0.2",
+    "solidity-comments-extractor": "^0.0.4",
     "string-width": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "dir-to-object": "^2.0.0",
     "emoji-regex": "^9.0.0",
     "escape-string-regexp": "^4.0.0",
-    "extract-comments": "^1.1.0",
     "prettier": "^2.0.5",
     "semver": "^7.3.2",
+    "solidity-comments-extractor": "^0.0.2",
     "string-width": "^4.2.0"
   }
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,4 +1,4 @@
-const extract = require('extract-comments');
+const extractComments = require('solidity-comments-extractor');
 // https://prettier.io/docs/en/plugins.html#parsers
 const parser = require('@solidity-parser/parser');
 
@@ -14,7 +14,7 @@ const tryHug = (node, operators) => {
 
 function parse(text, parsers, options) {
   const parsed = parser.parse(text, { loc: true, range: true });
-  parsed.comments = extract(text);
+  parsed.comments = extractComments(text);
 
   parser.visit(parsed, {
     ForStatement(ctx) {

--- a/tests/Issues/Issue355.sol
+++ b/tests/Issues/Issue355.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.6.12;
+
+contract Bug {
+  // This is a comment
+  uint public hello;
+
+  // Another comment
+  uint public bigNum = 100_000;
+
+  // This will disappear
+  uint public magic;
+}

--- a/tests/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -51,6 +51,35 @@ contract Issue289 {
 
 `;
 
+exports[`Issue355.sol 1`] = `
+pragma solidity 0.6.12;
+
+contract Bug {
+  // This is a comment
+  uint public hello;
+
+  // Another comment
+  uint public bigNum = 100_000;
+
+  // This will disappear
+  uint public magic;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pragma solidity 0.6.12;
+
+contract Bug {
+    // This is a comment
+    uint256 public hello;
+
+    // Another comment
+    uint256 public bigNum = 100_000;
+
+    // This will disappear
+    uint256 public magic;
+}
+
+`;
+
 exports[`Issue385.sol 1`] = `
 contract Issue385 {
   function emptyTryCatch() {


### PR DESCRIPTION
Closes #355.

This PR replaces the `extract-comments` package with `solidity-comments-extractor`, that I wrote (you can check it out [here](https://github.com/fvictorio/solidity-comments-extractor), but beware: the code is awful).

This not only closes the linked issue, it should also be more robust, since using a javascript parser to extract comments in solidity is bound to give us more issues in the future.

Plus, I think it should make the plugin faster. Maybe. I'm not sure.