### PR TITLE
Don't join multi-part literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,9 +1592,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.9.0.tgz",
-      "integrity": "sha512-u1WzZgzOBFsGAcUhyj8DN/kop1SvrsaRT2ZVvDpVYnFI86YwbLrXCTGxefJzYGnA5Vajbbhi4aRtlxxFh69dfA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.9.1.tgz",
+      "integrity": "sha512-ewNo+ZEQX8mFUOlTK6+0IYvM++6+iEeRBIBg4Mh8ghgRX72bkXJh6AWLWe/SG5+3WPdDL84MSsAlrvWFsGRdFw==",
       "requires": {
         "antlr4": "^4.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jest-watch-typeahead": "^0.6.0"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.9.0",
+    "@solidity-parser/parser": "^0.9.1",
     "dir-to-object": "^2.0.0",
     "emoji-regex": "^9.0.0",
     "escape-string-regexp": "^4.0.0",

--- a/src/nodes/HexLiteral.js
+++ b/src/nodes/HexLiteral.js
@@ -1,5 +1,16 @@
+const {
+  doc: {
+    builders: { join, line }
+  }
+} = require('prettier/standalone');
+
+const { printString } = require('../prettier-comments/common/util');
+
 const HexLiteral = {
-  print: ({ node }) => node.value
+  print: ({ node, options }) => {
+    const list = node.parts.map((part) => `hex${printString(part, options)}`);
+    return join(line, list);
+  }
 };
 
 module.exports = HexLiteral;

--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -1,7 +1,15 @@
+const {
+  doc: {
+    builders: { join, line }
+  }
+} = require('prettier/standalone');
 const { printString } = require('../prettier-comments/common/util');
 
 const StringLiteral = {
-  print: ({ node, options }) => printString(node.value, options)
+  print: ({ node, options }) => {
+    const list = node.parts.map((part) => printString(part, options));
+    return join(line, list);
+  }
 };
 
 module.exports = StringLiteral;

--- a/tests/MultipartStrings/MultipartStrings.sol
+++ b/tests/MultipartStrings/MultipartStrings.sol
@@ -1,0 +1,10 @@
+contract MultipartStrings {
+  bytes b1 = hex'beef';
+  bytes b2 = hex"beef";
+  bytes b3 = hex"beef" hex"c0ffee";
+  bytes b4 = hex"beeeeeeeeeeeeeeeeeeeeeef" hex"c0000000000ffeeeeeeeeeeeeeeeeeee";
+
+  string s1 = "foo";
+  string s2 = "foo" "bar";
+  string s3 = "foofoofoofooofoofoofofoooofofoo" "barbarbrabrbarbarbabrabrbabr";
+}

--- a/tests/MultipartStrings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/MultipartStrings/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultipartStrings.sol 1`] = `
+contract MultipartStrings {
+  bytes b1 = hex'beef';
+  bytes b2 = hex"beef";
+  bytes b3 = hex"beef" hex"c0ffee";
+  bytes b4 = hex"beeeeeeeeeeeeeeeeeeeeeef" hex"c0000000000ffeeeeeeeeeeeeeeeeeee";
+
+  string s1 = "foo";
+  string s2 = "foo" "bar";
+  string s3 = "foofoofoofooofoofoofofoooofofoo" "barbarbrabrbarbarbabrabrbabr";
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+contract MultipartStrings {
+    bytes b1 = hex"beef";
+    bytes b2 = hex"beef";
+    bytes b3 = hex"beef" hex"c0ffee";
+    bytes b4 =
+        hex"beeeeeeeeeeeeeeeeeeeeeef"
+        hex"c0000000000ffeeeeeeeeeeeeeeeeeee";
+
+    string s1 = "foo";
+    string s2 = "foo" "bar";
+    string s3 =
+        "foofoofoofooofoofoofofoooofofoo"
+        "barbarbrabrbarbarbabrabrbabr";
+}
+
+`;

--- a/tests/MultipartStrings/jsfmt.spec.js
+++ b/tests/MultipartStrings/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
Closes #391

This PR prevents prettier from joining multi-part strings and hex literals. It also prints each one in a separate line when the line is too long.