### PR TITLE
Upgrade solidity parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,12 +1592,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.9.1.tgz",
-      "integrity": "sha512-ewNo+ZEQX8mFUOlTK6+0IYvM++6+iEeRBIBg4Mh8ghgRX72bkXJh6AWLWe/SG5+3WPdDL84MSsAlrvWFsGRdFw==",
-      "requires": {
-        "antlr4": "^4.8.0"
-      }
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.10.1.tgz",
+      "integrity": "sha512-tHDPCRMEBFDxBz5rioQRoKgOQGa/K2digdfR68cd5vO6IufAqoNt1sfjssQDf2KPqHPftICBQOqlcu0w5/Jisg=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -1821,11 +1818,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "antlr4": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "anymatch": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jest-watch-typeahead": "^0.6.0"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.9.1",
+    "@solidity-parser/parser": "^0.10.1",
     "dir-to-object": "^2.0.0",
     "emoji-regex": "^9.0.0",
     "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
The parser is now bundled, because the antlr dependency requires node 14
and that could cause issues with yarn (although I don't quite understand
why yarn sometimes complains and sometimes it doesn't).