### PR TITLE
We use Prettier's FastPath strategy to avoid modifying parameters.

### DIFF
--- a/src/comments/ignore.js
+++ b/src/comments/ignore.js
@@ -1,16 +1,31 @@
-function ignoreComments(node) {
-  if (node === undefined || node === null) return;
+function ignoreComments(path) {
+  const node = path.getValue();
+  // We ignore anything that is not an object
+  if (node === null || typeof node !== 'object') return;
+
   const keys = Object.keys(node);
   keys.forEach((key) => {
-    if (key === 'comments') {
-      node.comments.forEach((comment) => {
-        // eslint-disable-next-line no-param-reassign
-        comment.printed = true;
-      });
-      return;
-    }
-    if (typeof node[key] === 'object') {
-      ignoreComments(node[key]);
+    switch (key) {
+      // We ignore `loc` and `range` since these are added by the parser
+      case 'loc':
+      case 'range':
+        break;
+      // The key `comments` will contain every comment for this node
+      case 'comments':
+        path.each((commentPath) => {
+          const comment = commentPath.getValue();
+          comment.printed = true;
+        }, 'comments');
+        break;
+      default:
+        // If the value for that key is an Array or an Object we go deeper.
+        if (typeof node[key] === 'object') {
+          if (Array.isArray(node[key])) {
+            path.each(ignoreComments, key);
+            return;
+          }
+          path.call(ignoreComments, key);
+        }
     }
   });
 }

--- a/src/printer.js
+++ b/src/printer.js
@@ -13,7 +13,7 @@ function genericPrint(path, options, print) {
   }
 
   if (hasNodeIgnoreComment(node)) {
-    ignoreComments(node);
+    ignoreComments(path);
 
     return options.originalText.slice(
       options.locStart(node),

--- a/tests/PrettierIgnore/PrettierIgnore.sol
+++ b/tests/PrettierIgnore/PrettierIgnore.sol
@@ -21,15 +21,19 @@ contract PrettierIgnore {
 contract Example {
 // Test comment
     function() public payable {        
-        // this should be marked as printed
+        // This should be marked as printed
         // Everything inside is also ignored
         matrix(
             1, 0, 0,
             0, 1, 0,
             0, 0, 1
         );
-        if (true) {
-            // comments of children should be marked as printed
-        }
+        // Comments for members of an Array are marked as printed
+        if (true)
+            // Comments of single child Objects are marked as printed
+            return;
+        else
+            // Comments of children should be marked as printed
+            return;
     }
 }

--- a/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/PrettierIgnore/__snapshots__/jsfmt.spec.js.snap
@@ -24,16 +24,20 @@ contract PrettierIgnore {
 contract Example {
 // Test comment
     function() public payable {        
-        // this should be marked as printed
+        // This should be marked as printed
         // Everything inside is also ignored
         matrix(
             1, 0, 0,
             0, 1, 0,
             0, 0, 1
         );
-        if (true) {
-            // comments of children should be marked as printed
-        }
+        // Comments for members of an Array are marked as printed
+        if (true)
+            // Comments of single child Objects are marked as printed
+            return;
+        else
+            // Comments of children should be marked as printed
+            return;
     }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -56,16 +60,20 @@ contract PrettierIgnore {
 contract Example {
 // Test comment
     function() public payable {        
-        // this should be marked as printed
+        // This should be marked as printed
         // Everything inside is also ignored
         matrix(
             1, 0, 0,
             0, 1, 0,
             0, 0, 1
         );
-        if (true) {
-            // comments of children should be marked as printed
-        }
+        // Comments for members of an Array are marked as printed
+        if (true)
+            // Comments of single child Objects are marked as printed
+            return;
+        else
+            // Comments of children should be marked as printed
+            return;
     }
 }
 


### PR DESCRIPTION
This way we get rid of having to get rid of eslint's rule `no-param-reassign`