### PR TITLE
Upgrade parser, unicode strings, catch Panic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - '13'
 script:
   - npm run lint
-  - npm test
+  - npm run test:all

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,14 @@ module.exports = {
     '!src/prettier-comments/**/*.js'
   ],
   coverageDirectory: './coverage/',
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100
+    }
+  },
   setupFiles: ['<rootDir>/tests_config/run_spec.js'],
   snapshotSerializers: ['<rootDir>/tests_config/raw-serializer.js'],
   testEnvironment: 'node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,9 +687,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.11.1.tgz",
-      "integrity": "sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.12.0.tgz",
+      "integrity": "sha512-DT3f/Aa4tQysZwUsuqBwvr8YRJzKkvPUKV/9o2/o5EVw3xqlbzmtx4O60lTUcZdCawL+N8bBLNUyOGpHjGlJVQ=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jest-watch-typeahead": "^0.6.1"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.11.0",
+    "@solidity-parser/parser": "^0.12.0",
     "dir-to-object": "^2.0.0",
     "emoji-regex": "^9.2.1",
     "escape-string-regexp": "^4.0.0",

--- a/src/nodes/CatchClause.js
+++ b/src/nodes/CatchClause.js
@@ -9,7 +9,7 @@ const printSeparatedList = require('./print-separated-list');
 const parameters = (node, path, print) =>
   node.parameters
     ? concat([
-        node.isReasonStringType ? 'Error' : '',
+        node.kind || '',
         '(',
         printSeparatedList(path.map(print, 'parameters')),
         ') '

--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -7,7 +7,15 @@ const { printString } = require('../prettier-comments/common/util');
 
 const StringLiteral = {
   print: ({ node, options }) => {
-    const list = node.parts.map((part) => printString(part, options));
+    const list = node.parts.map((part, index) =>
+      printString(part, {
+        ...options,
+        // node.isUnicode is an array of the same length as node.parts
+        // that indicates if that string fragment has the unicode prefix
+        isUnicode: node.isUnicode[index]
+      })
+    );
+
     return join(line, list);
   }
 };

--- a/src/prettier-comments/common/util.js
+++ b/src/prettier-comments/common/util.js
@@ -475,11 +475,12 @@ function printString(rawContent, options) {
       options.parser === "css" ||
       options.parser === "less" ||
       options.parser === "scss"
-    )
+    ),
+    options.isUnicode
   );
 }
 
-function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes) {
+function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes, isUnicode) {
   const otherQuote = enclosingQuote === '"' ? "'" : '"';
 
   // Matches _any_ escape and unescaped quotes (both single and double).
@@ -514,7 +515,7 @@ function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes) {
       : "\\" + escaped;
   });
 
-  return enclosingQuote + newContent + enclosingQuote;
+  return (isUnicode ? "unicode" : "") + enclosingQuote + newContent + enclosingQuote;
 }
 
 function printNumber(rawNumber) {

--- a/tests/TryCatch/TryCatch.sol
+++ b/tests/TryCatch/TryCatch.sol
@@ -74,4 +74,30 @@ contract FeedConsumer {
                 errorCount++;
                 return (0, false);
               } }
+
+    function rate4(address token) public returns (uint value, bool success) {
+        // Permanently disable the mechanism if there are
+        // more than 10 errors.
+        require(errorCount < 10);
+        try feed.getData(token) returns (uint v) {
+            return (v, true);
+        } catch Error(string memory /*reason*/) {
+            // This is executed in case
+            // revert was called inside getData
+            // and a reason string was provided.
+            errorCount++;
+            return (0, false);
+        } catch Panic(uint /*errorCode*/) {
+            // This is executed in case of a panic,
+            // i.e. a serious error like division by zero
+            // or overflow. The error code can be used
+            // to determine the kind of error.
+            errorCount++;
+            return (0, false);
+        } catch (bytes memory /*lowLevelData*/) {
+            // This is executed in case revert() was used.
+            errorCount++;
+            return (0, false);
+        }
+    }
 }

--- a/tests/TryCatch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/TryCatch/__snapshots__/jsfmt.spec.js.snap
@@ -77,6 +77,32 @@ contract FeedConsumer {
                 errorCount++;
                 return (0, false);
               } }
+
+    function rate4(address token) public returns (uint value, bool success) {
+        // Permanently disable the mechanism if there are
+        // more than 10 errors.
+        require(errorCount < 10);
+        try feed.getData(token) returns (uint v) {
+            return (v, true);
+        } catch Error(string memory /*reason*/) {
+            // This is executed in case
+            // revert was called inside getData
+            // and a reason string was provided.
+            errorCount++;
+            return (0, false);
+        } catch Panic(uint /*errorCode*/) {
+            // This is executed in case of a panic,
+            // i.e. a serious error like division by zero
+            // or overflow. The error code can be used
+            // to determine the kind of error.
+            errorCount++;
+            return (0, false);
+        } catch (bytes memory /*lowLevelData*/) {
+            // This is executed in case revert() was used.
+            errorCount++;
+            return (0, false);
+        }
+    }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pragma solidity ^0.6.0;
@@ -167,6 +193,38 @@ contract FeedConsumer {
             // This is executed in case revert() was used
             // or there was a failing assertion, division
             // by zero, etc. inside getData.
+            errorCount++;
+            return (0, false);
+        }
+    }
+
+    function rate4(address token) public returns (uint256 value, bool success) {
+        // Permanently disable the mechanism if there are
+        // more than 10 errors.
+        require(errorCount < 10);
+        try feed.getData(token) returns (uint256 v) {
+            return (v, true);
+        } catch Error(
+            string memory /*reason*/
+        ) {
+            // This is executed in case
+            // revert was called inside getData
+            // and a reason string was provided.
+            errorCount++;
+            return (0, false);
+        } catch Panic(
+            uint256 /*errorCode*/
+        ) {
+            // This is executed in case of a panic,
+            // i.e. a serious error like division by zero
+            // or overflow. The error code can be used
+            // to determine the kind of error.
+            errorCount++;
+            return (0, false);
+        } catch (
+            bytes memory /*lowLevelData*/
+        ) {
+            // This is executed in case revert() was used.
             errorCount++;
             return (0, false);
         }

--- a/tests/quotes/Quotes.sol
+++ b/tests/quotes/Quotes.sol
@@ -16,4 +16,9 @@ contract Foo {
   string escapeDoubleQuotes = "The \"quick\" brown fox";
   string hex1 = hex'DeadBeef';
   string hex2 = hex"DeadBeef";
+  string withUnicode1 = unicode'hello 🦄 world';
+  string withUnicode2 = unicode"hello 🦄 world";
+  string multiPartAndUnicode1 = unicode'hello 🦄' ' world';
+  string multiPartAndUnicode2 = 'hello ' unicode' 🦄world';
+  string multiPartAndUnicode3 = unicode'hello 🦄' unicode' world 🦄';
 }

--- a/tests/quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/quotes/__snapshots__/jsfmt.spec.js.snap
@@ -19,6 +19,11 @@ contract Foo {
   string escapeDoubleQuotes = "The \\"quick\\" brown fox";
   string hex1 = hex'DeadBeef';
   string hex2 = hex"DeadBeef";
+  string withUnicode1 = unicode'hello 🦄 world';
+  string withUnicode2 = unicode"hello 🦄 world";
+  string multiPartAndUnicode1 = unicode'hello 🦄' ' world';
+  string multiPartAndUnicode2 = 'hello ' unicode' 🦄world';
+  string multiPartAndUnicode3 = unicode'hello 🦄' unicode' world 🦄';
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import 'someContract.sol';
@@ -39,6 +44,11 @@ contract Foo {
     string escapeDoubleQuotes = 'The "quick" brown fox';
     string hex1 = hex'DeadBeef';
     string hex2 = hex'DeadBeef';
+    string withUnicode1 = unicode'hello 🦄 world';
+    string withUnicode2 = unicode'hello 🦄 world';
+    string multiPartAndUnicode1 = unicode'hello 🦄' ' world';
+    string multiPartAndUnicode2 = 'hello ' unicode' 🦄world';
+    string multiPartAndUnicode3 = unicode'hello 🦄' unicode' world 🦄';
 }
 
 `;
@@ -62,6 +72,11 @@ contract Foo {
   string escapeDoubleQuotes = "The \\"quick\\" brown fox";
   string hex1 = hex'DeadBeef';
   string hex2 = hex"DeadBeef";
+  string withUnicode1 = unicode'hello 🦄 world';
+  string withUnicode2 = unicode"hello 🦄 world";
+  string multiPartAndUnicode1 = unicode'hello 🦄' ' world';
+  string multiPartAndUnicode2 = 'hello ' unicode' 🦄world';
+  string multiPartAndUnicode3 = unicode'hello 🦄' unicode' world 🦄';
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import "someContract.sol";
@@ -82,6 +97,11 @@ contract Foo {
     string escapeDoubleQuotes = 'The "quick" brown fox';
     string hex1 = hex"DeadBeef";
     string hex2 = hex"DeadBeef";
+    string withUnicode1 = unicode"hello 🦄 world";
+    string withUnicode2 = unicode"hello 🦄 world";
+    string multiPartAndUnicode1 = unicode"hello 🦄" " world";
+    string multiPartAndUnicode2 = "hello " unicode" 🦄world";
+    string multiPartAndUnicode3 = unicode"hello 🦄" unicode" world 🦄";
 }
 
 `;


### PR DESCRIPTION
This PR upgrades the parser and adds support for its two new features:

- Caught `Panic` errors are properly printed
- Unicode strings are handled