### PR TITLE
We avoid prepending a hardline before a LabelDefinition

### DIFF
--- a/src/nodes/print-preserving-empty-lines.js
+++ b/src/nodes/print-preserving-empty-lines.js
@@ -11,7 +11,13 @@ function printPreservingEmptyLines(path, key, options, print) {
     const node = childPath.getValue();
     const nodeType = node.type;
 
-    if (parts.length !== 0) {
+    if (
+      // Avoid adding a hardline at the beggining of the document.
+      parts.length !== 0 &&
+      // LabelDefinition adds a dedented line so we have to avoid prepending
+      // a hardline.
+      nodeType !== 'LabelDefinition'
+    ) {
       parts.push(hardline);
     }
 

--- a/tests/Assembly/Assembly.sol
+++ b/tests/Assembly/Assembly.sol
@@ -117,6 +117,7 @@ loop:
     a add swap1
     n := sub(n, 1)
     jump(loop)
+
 loopend:
     mstore(0, a)
     return(0, 0x20)

--- a/tests/Assembly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Assembly/__snapshots__/jsfmt.spec.js.snap
@@ -125,6 +125,7 @@ loop:
     a add swap1
     n := sub(n, 1)
     jump(loop)
+
 loopend:
     mstore(0, a)
     return(0, 0x20)
@@ -322,7 +323,6 @@ contract Assembly {
             let n := calldataload(4)
             let a := 1
             let b := a
-
         loop:
             jumpi(loopend, eq(n, 0))
             a
@@ -339,7 +339,6 @@ contract Assembly {
         assembly {
             let x := 8
             jump(two)
-
         one:
             // Here the stack height is 2 (because we pushed x and 7),
             // but the assembler thinks it is 1 because it reads
@@ -347,11 +346,9 @@ contract Assembly {
             // Accessing the stack variable x here will lead to errors.
             x := 9
             jump(three)
-
         two:
             7 // push something onto the stack
             jump(one)
-
         three:
         }
     }

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -18,9 +18,9 @@ const CURSOR_PLACEHOLDER = '<|>';
 const RANGE_START_PLACEHOLDER = '<<<PRETTIER_RANGE_START>>>';
 const RANGE_END_PLACEHOLDER = '<<<PRETTIER_RANGE_END>>>';
 
-// TODO: these test files need fix
+// Here we add files that will not be the same when formating a second time.
 const unstableTests = new Map(
-  ['Assembly/Assembly.sol'].map((fixture) => {
+  [].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)
       ? fixture
       : [fixture];
@@ -28,7 +28,15 @@ const unstableTests = new Map(
   })
 );
 
-const unstableAstTests = new Map();
+// Here we add files that will not have the same AST after being formated.
+const unstableAstTests = new Map(
+  [].map((fixture) => {
+    const [file, isAstUnstable = () => true] = Array.isArray(fixture)
+      ? fixture
+      : [fixture];
+    return [path.join(__dirname, '../tests/', file), isAstUnstable];
+  })
+);
 
 const isUnstable = (filename, options) => {
   const testFunction = unstableTests.get(filename);


### PR DESCRIPTION
`LabelDefinition` uses a dedented first line.
This caused a side effect where all Labels would have an empty line before them, this looked a bit quirky but there wasn't anything wrong with it.

After adding the new in depth testing, we recognised that, on the second format, this empty line would be registered as an empty line added by the developer to space out code, and we would preserve this line in `printPreservingEmptyLines`, and we would end up with 2 empty lines instead of one.

This fix might look a bit hacky but it's an edge case given the particular way of printing assembly labels.