### PR TITLE
Breaking changes in v0.8.0

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -29,14 +29,18 @@ function parse(text, parsers, options) {
         : `hex"${ctx.value.slice(4, -1)}"`;
     },
     ElementaryTypeName(ctx) {
+      // We avoid making changes for bytes1 since the type 'byte' was removed
+      // in v0.8.0
+      // See the breaking changes in https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html#silent-changes-of-the-semantics
+      // The type byte has been removed. It was an alias of bytes1.
+      // TODO once we decide to keep track of the pragma, we can implement this again.
+
       if (options.explicitTypes === 'always') {
         if (ctx.name === 'uint') ctx.name = 'uint256';
         if (ctx.name === 'int') ctx.name = 'int256';
-        if (ctx.name === 'byte') ctx.name = 'bytes1';
       } else if (options.explicitTypes === 'never') {
         if (ctx.name === 'uint256') ctx.name = 'uint';
         if (ctx.name === 'int256') ctx.name = 'int';
-        if (ctx.name === 'bytes1') ctx.name = 'byte';
       }
     },
     BinaryOperation(ctx) {
@@ -56,7 +60,12 @@ function parse(text, parsers, options) {
           ctx.left = tryHug(ctx.left, ['*', '/', '%']);
           break;
         case '**':
-          ctx.left = tryHug(ctx.left, ['**']);
+          // We avoid making changes here since the order of precedence of the
+          // operators for ** changed in v0.8.0
+          // See the breaking changes in https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html#silent-changes-of-the-semantics
+          // Exponentiation is right associative, i.e., the expression a**b**c
+          // is parsed as a**(b**c). Before 0.8.0, it was parsed as (a**b)**c.
+          // TODO once we decide to keep track of the pragma, we can implement this again.
           break;
         case '<<':
         case '>>':

--- a/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/BinaryOperators/__snapshots__/jsfmt.spec.js.snap
@@ -880,7 +880,7 @@ contract Parentheses {
         a**b * c;
         a**b / c;
         a**b % c;
-        (a**b)**c;
+        a**b**c;
         (a**b) << c;
         (a**b) >> c;
         (a**b) & c;

--- a/tests/ExplicitVariableTypes/ExplicitVariableTypes.sol
+++ b/tests/ExplicitVariableTypes/ExplicitVariableTypes.sol
@@ -1,30 +1,36 @@
-pragma solidity 0.5.8;
-
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
 
 contract VariableTypesMixed {
     uint256 public a;
     int256 public b;
-    bytes1 public c;
     uint public e;
     int public f;
-    byte public g;
 
     struct S {
         uint a;
         int b;
-        byte c;
         uint256 e;
         int256 f;
-        bytes1 g;
     }
 
-    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+    event Event(uint _a, int256 _b, uint256 _e, int _f);
 
-    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+    function func(
+        uint256 _a,
+        int256 _b,
+        uint _e,
+        int _f
+    )
         public
-        returns (uint, int256, byte, uint256, int, bytes1)
+        returns (
+            uint,
+            int256,
+            uint256,
+            int
+        )
     {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
     }
 }

--- a/tests/ExplicitVariableTypes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ExplicitVariableTypes/__snapshots__/jsfmt.spec.js.snap
@@ -7,79 +7,78 @@ parsers: ["solidity-parse"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-pragma solidity 0.5.8;
-
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
 
 contract VariableTypesMixed {
     uint256 public a;
     int256 public b;
-    bytes1 public c;
     uint public e;
     int public f;
-    byte public g;
 
     struct S {
         uint a;
         int b;
-        byte c;
         uint256 e;
         int256 f;
-        bytes1 g;
     }
 
-    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+    event Event(uint _a, int256 _b, uint256 _e, int _f);
 
-    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
+    function func(
+        uint256 _a,
+        int256 _b,
+        uint _e,
+        int _f
+    )
         public
-        returns (uint, int256, byte, uint256, int, bytes1)
+        returns (
+            uint,
+            int256,
+            uint256,
+            int
+        )
     {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
     }
 }
 
 =====================================output=====================================
-pragma solidity 0.5.8;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
 
 contract VariableTypesMixed {
     uint public a;
     int public b;
-    byte public c;
     uint public e;
     int public f;
-    byte public g;
 
     struct S {
         uint a;
         int b;
-        byte c;
         uint e;
         int f;
-        byte g;
     }
 
-    event Event(uint _a, int _b, byte _c, uint _e, int _f, byte _g);
+    event Event(uint _a, int _b, uint _e, int _f);
 
     function func(
         uint _a,
         int _b,
-        byte _c,
         uint _e,
-        int _f,
-        byte _g
+        int _f
     )
         public
         returns (
             uint,
             int,
-            byte,
             uint,
-            int,
-            byte
+            int
         )
     {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
     }
 }
 
@@ -93,79 +92,78 @@ parsers: ["solidity-parse"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-pragma solidity 0.5.8;
-
-
-contract VariableTypesMixed {
-    uint256 public a;
-    int256 public b;
-    bytes1 public c;
-    uint public e;
-    int public f;
-    byte public g;
-
-    struct S {
-        uint a;
-        int b;
-        byte c;
-        uint256 e;
-        int256 f;
-        bytes1 g;
-    }
-
-    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
-
-    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
-        public
-        returns (uint, int256, byte, uint256, int, bytes1)
-    {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
-    }
-}
-
-=====================================output=====================================
-pragma solidity 0.5.8;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
 
 contract VariableTypesMixed {
     uint256 public a;
     int256 public b;
-    bytes1 public c;
     uint public e;
     int public f;
-    byte public g;
 
     struct S {
         uint a;
         int b;
-        byte c;
         uint256 e;
         int256 f;
-        bytes1 g;
     }
 
-    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
+    event Event(uint _a, int256 _b, uint256 _e, int _f);
 
     function func(
         uint256 _a,
         int256 _b,
-        byte _c,
         uint _e,
-        int _f,
-        bytes1 _g
+        int _f
     )
         public
         returns (
             uint,
             int256,
-            byte,
             uint256,
-            int,
-            bytes1
+            int
         )
     {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
+    }
+}
+
+=====================================output=====================================
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    uint public e;
+    int public f;
+
+    struct S {
+        uint a;
+        int b;
+        uint256 e;
+        int256 f;
+    }
+
+    event Event(uint _a, int256 _b, uint256 _e, int _f);
+
+    function func(
+        uint256 _a,
+        int256 _b,
+        uint _e,
+        int _f
+    )
+        public
+        returns (
+            uint,
+            int256,
+            uint256,
+            int
+        )
+    {
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
     }
 }
 
@@ -178,86 +176,78 @@ parsers: ["solidity-parse"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-pragma solidity 0.5.8;
-
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
 
 contract VariableTypesMixed {
     uint256 public a;
     int256 public b;
-    bytes1 public c;
     uint public e;
     int public f;
-    byte public g;
 
     struct S {
         uint a;
         int b;
-        byte c;
         uint256 e;
         int256 f;
-        bytes1 g;
     }
 
-    event Event(uint _a, int256 _b, bytes1 _c, uint256 _e, int _f, byte _g);
-
-    function func(uint256 _a, int256 _b, byte _c, uint _e, int _f, bytes1 _g)
-        public
-        returns (uint, int256, byte, uint256, int, bytes1)
-    {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
-    }
-}
-
-=====================================output=====================================
-pragma solidity 0.5.8;
-
-contract VariableTypesMixed {
-    uint256 public a;
-    int256 public b;
-    bytes1 public c;
-    uint256 public e;
-    int256 public f;
-    bytes1 public g;
-
-    struct S {
-        uint256 a;
-        int256 b;
-        bytes1 c;
-        uint256 e;
-        int256 f;
-        bytes1 g;
-    }
-
-    event Event(
-        uint256 _a,
-        int256 _b,
-        bytes1 _c,
-        uint256 _e,
-        int256 _f,
-        bytes1 _g
-    );
+    event Event(uint _a, int256 _b, uint256 _e, int _f);
 
     function func(
         uint256 _a,
         int256 _b,
-        bytes1 _c,
+        uint _e,
+        int _f
+    )
+        public
+        returns (
+            uint,
+            int256,
+            uint256,
+            int
+        )
+    {
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
+    }
+}
+
+=====================================output=====================================
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
+
+contract VariableTypesMixed {
+    uint256 public a;
+    int256 public b;
+    uint256 public e;
+    int256 public f;
+
+    struct S {
+        uint256 a;
+        int256 b;
+        uint256 e;
+        int256 f;
+    }
+
+    event Event(uint256 _a, int256 _b, uint256 _e, int256 _f);
+
+    function func(
+        uint256 _a,
+        int256 _b,
         uint256 _e,
-        int256 _f,
-        bytes1 _g
+        int256 _f
     )
         public
         returns (
             uint256,
             int256,
-            bytes1,
             uint256,
-            int256,
-            bytes1
+            int256
         )
     {
-        emit Event(_a, _b, _c, _e, _f, _g);
-        return (_a, _b, _c, _e, _f, _g);
+        emit Event(_a, _b, _e, _f);
+        return (_a, _b, _e, _f);
     }
 }
 


### PR DESCRIPTION
v0.8.0 added [breaking changes](https://docs.soliditylang.org/en/v0.8.0/080-breaking-changes.html#silent-changes-of-the-semantics) that conflicted with some desicions we made while formatting.

The ones affecting us are mainly:
  - The type `byte` has been removed. It was an alias of `bytes1`.
  - Exponentiation is right associative, i.e., the expression `a**b**c` is parsed as `a**(b**c)`. Before 0.8.0, it was parsed as `(a**b)**c`.

Since we are not tracking the pragma of the file, we should simply avoid special formatting of these.