### PR TITLE
group unchecked blocks

### DIFF
--- a/src/nodes/UncheckedStatement.js
+++ b/src/nodes/UncheckedStatement.js
@@ -1,11 +1,12 @@
 const {
   doc: {
-    builders: { concat }
+    builders: { concat, group }
   }
 } = require('prettier/standalone');
 
 const UncheckedStatement = {
-  print: ({ path, print }) => concat(['unchecked ', path.call(print, 'block')])
+  print: ({ path, print }) =>
+    group(concat(['unchecked ', path.call(print, 'block')]))
 };
 
 module.exports = UncheckedStatement;

--- a/tests/AllSolidityFeatures/AllSolidityFeatures.sol
+++ b/tests/AllSolidityFeatures/AllSolidityFeatures.sol
@@ -520,4 +520,13 @@ contract WithUncheckedBlock {
     unchecked   {   x--;   }
     return x;
   }
+  
+  function g() public pure returns (uint) {
+    uint x = 0;
+    unchecked   {   x--; return x; }
+  }
+
+  function mul(uint256 x, uint256 y) internal pure returns (uint256) {
+    unchecked { return x * y; }
+  }
 }

--- a/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -528,8 +528,16 @@ contract WithUncheckedBlock {
     unchecked   {   x--;   }
     return x;
   }
-}
+  
+  function g() public pure returns (uint) {
+    uint x = 0;
+    unchecked   {   x--; return x; }
+  }
 
+  function mul(uint256 x, uint256 y) internal pure returns (uint256) {
+    unchecked { return x * y; }
+  }
+}
 =====================================output=====================================
 // Examples taken from the Solidity documentation online.
 
@@ -1099,10 +1107,20 @@ uint256 constant MULTIPLIER = 2**EXPONENT;
 contract WithUncheckedBlock {
     function f() public pure returns (uint256) {
         uint256 x = 0;
+        unchecked {x--;}
+        return x;
+    }
+
+    function g() public pure returns (uint256) {
+        uint256 x = 0;
         unchecked {
             x--;
+            return x;
         }
-        return x;
+    }
+
+    function mul(uint256 x, uint256 y) internal pure returns (uint256) {
+        unchecked {return x * y;}
     }
 }
 


### PR DESCRIPTION
Having a look at the `unchecked` statement in the wild, it's usually applied to a single statement and unlikely to be broken into multiple lines, so I decided to `group` it so it only breaks into multiple lines if the content of the block breaks.