### PR TITLE
keeping prettier-comments files as close to the source

### DIFF
--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -7,13 +7,11 @@ const { printString } = require('../prettier-comments/common/util');
 
 const StringLiteral = {
   print: ({ node, options }) => {
-    const list = node.parts.map((part, index) =>
-      printString(part, {
-        ...options,
+    const list = node.parts.map(
+      (part, index) =>
         // node.isUnicode is an array of the same length as node.parts
         // that indicates if that string fragment has the unicode prefix
-        isUnicode: node.isUnicode[index]
-      })
+        (node.isUnicode[index] ? 'unicode' : '') + printString(part, options)
     );
 
     return join(line, list);

--- a/src/prettier-comments/common/util.js
+++ b/src/prettier-comments/common/util.js
@@ -475,12 +475,11 @@ function printString(rawContent, options) {
       options.parser === "css" ||
       options.parser === "less" ||
       options.parser === "scss"
-    ),
-    options.isUnicode
+    )
   );
 }
 
-function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes, isUnicode) {
+function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes) {
   const otherQuote = enclosingQuote === '"' ? "'" : '"';
 
   // Matches _any_ escape and unescaped quotes (both single and double).
@@ -515,7 +514,7 @@ function makeString(rawContent, enclosingQuote, unescapeUnnecessaryEscapes, isUn
       : "\\" + escaped;
   });
 
-  return (isUnicode ? "unicode" : "") + enclosingQuote + newContent + enclosingQuote;
+  return enclosingQuote + newContent + enclosingQuote;
 }
 
 function printNumber(rawNumber) {


### PR DESCRIPTION
Just moving back the responsibility of printing the `unicode` keyword to the solidity printer and not to the files taken from the prettier utils.