### PR TITLE
Handle escaped backslashes before closing quote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5178,9 +5178,9 @@
       }
     },
     "solidity-comments-extractor": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.6.tgz",
-      "integrity": "sha512-5GRv062LXC+8sJZS3wlY4ZptKFODf+jTDqxB64DWf/uyAL5ZJEvmr8wW3Kd/V+e5roBShcC15+ThfGMerF2Yxw=="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "escape-string-regexp": "^4.0.0",
     "prettier": "^2.2.1",
     "semver": "^7.3.5",
-    "solidity-comments-extractor": "^0.0.6",
+    "solidity-comments-extractor": "^0.0.7",
     "string-width": "^4.2.2"
   }
 }

--- a/tests/Comments/Comments.sol
+++ b/tests/Comments/Comments.sol
@@ -93,3 +93,12 @@ interface Comments10 {
 
   function someOtherFunction(/* checking for Block comment */) external;
 }
+
+contract Comments11 {
+  string a = "\\";
+  string b = '\\';
+
+  function f() public {
+    // this should not be removed
+  }
+}

--- a/tests/Comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Comments/__snapshots__/jsfmt.spec.js.snap
@@ -101,6 +101,16 @@ interface Comments10 {
 
   function someOtherFunction(/* checking for Block comment */) external;
 }
+
+contract Comments11 {
+  string a = "\\\\";
+  string b = '\\\\';
+
+  function f() public {
+    // this should not be removed
+  }
+}
+
 =====================================output=====================================
 pragma solidity ^0.4.24;
 
@@ -219,6 +229,15 @@ interface Comments10 {
     function someOtherFunction(
         /* checking for Block comment */
     ) external;
+}
+
+contract Comments11 {
+    string a = "\\\\";
+    string b = "\\\\";
+
+    function f() public {
+        // this should not be removed
+    }
 }
 
 ================================================================================


### PR DESCRIPTION
I upgraded `solidity-comments-extractor` to the latest version, which fixes an edge case when a file has something like this:

```solidity
string a = "\\"
```

You can check that fix here: https://github.com/prettier-solidity/solidity-comments-extractor/commit/b33b52007a3de31c40d49fa4323b49cfde0808fb