### PR TITLE
chaining function calls: fixing undesirable indents

### DIFF
--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -16,11 +16,28 @@ const isBeginnigOfChain = (path) => {
   return true;
 };
 
+const shallIndent = (path) => {
+  let i = 0;
+  let elderNode = path.getParentNode(i);
+  while (elderNode) {
+    if (
+      elderNode.type === 'VariableDeclarationStatement' ||
+      elderNode.type === 'BinaryOperation'
+    )
+      return false;
+    i += 1;
+    elderNode = path.getParentNode(i);
+  }
+  return true;
+};
+
 const MemberAccess = {
   print: ({ node, path, print }) => {
     const doc = [
       path.call(print, 'expression'),
-      indent([softline, '.', node.memberName])
+      shallIndent(path)
+        ? indent([softline, '.', node.memberName])
+        : [softline, '.', node.memberName]
     ];
 
     return isBeginnigOfChain(path) ? group(doc) : doc;

--- a/tests/FunctionCalls/FunctionCalls.sol
+++ b/tests/FunctionCalls/FunctionCalls.sol
@@ -16,4 +16,25 @@ contract FunctionCalls {
         voted: true,
       });
     }
+    function verify(ForwardRequest calldata req, bytes calldata signature) public view returns (bool) {
+    address signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    return _nonces[req.from] == req.nonce && signer == req.from;
+}
 }

--- a/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,27 @@ contract FunctionCalls {
         voted: true,
       });
     }
+    function verify(ForwardRequest calldata req, bytes calldata signature) public view returns (bool) {
+    address signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    return _nonces[req.from] == req.nonce && signer == req.from;
+}
 }
 
 =====================================output=====================================
@@ -40,6 +61,95 @@ contract FunctionCalls {
         Voter me = Voter({ weight: 2, voted: abstain() });
 
         Voter airbnb = Voter({ weight: 2, voted: true });
+    }
+
+    function verify(ForwardRequest calldata req, bytes calldata signature)
+        public
+        view
+        returns (bool)
+    {
+        address signer =
+            _hashTypedDataV1(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            ._hashTypedDataV2(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            ._hashTypedDataV3(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            .recover(signature);
+        signer = _hashTypedDataV1(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        ._hashTypedDataV2(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        ._hashTypedDataV3(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        .recover(signature);
+        return _nonces[req.from] == req.nonce && signer == req.from;
     }
 }
 
@@ -70,6 +180,27 @@ contract FunctionCalls {
         voted: true,
       });
     }
+    function verify(ForwardRequest calldata req, bytes calldata signature) public view returns (bool) {
+    address signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    signer =
+        _hashTypedDataV1(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )
+            ._hashTypedDataV2(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )._hashTypedDataV3(
+            keccak256(abi.encode(TYPEHASH, req.from, req.to, req.value, req.gas, req.nonce, keccak256(req.data)))
+        )                .recover(signature);
+    return _nonces[req.from] == req.nonce && signer == req.from;
+}
 }
 
 =====================================output=====================================
@@ -85,6 +216,95 @@ contract FunctionCalls {
         Voter me = Voter({weight: 2, voted: abstain()});
 
         Voter airbnb = Voter({weight: 2, voted: true});
+    }
+
+    function verify(ForwardRequest calldata req, bytes calldata signature)
+        public
+        view
+        returns (bool)
+    {
+        address signer =
+            _hashTypedDataV1(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            ._hashTypedDataV2(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            ._hashTypedDataV3(
+                keccak256(
+                    abi.encode(
+                        TYPEHASH,
+                        req.from,
+                        req.to,
+                        req.value,
+                        req.gas,
+                        req.nonce,
+                        keccak256(req.data)
+                    )
+                )
+            )
+            .recover(signature);
+        signer = _hashTypedDataV1(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        ._hashTypedDataV2(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        ._hashTypedDataV3(
+            keccak256(
+                abi.encode(
+                    TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        )
+        .recover(signature);
+        return _nonces[req.from] == req.nonce && signer == req.from;
     }
 }
 

--- a/tests/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -33,8 +33,8 @@ contract Example {
         balanceStates[msg.sender][token].balance = balanceStates[msg.sender][
             token
         ]
-            .balance
-            .sub(amount);
+        .balance
+        .sub(amount);
     }
 }
 


### PR DESCRIPTION
We indent only if the chain doesn't belong to a variable declaration or a binary operation