### PR TITLE
End of chain

### DIFF
--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -4,7 +4,6 @@ const {
   }
 } = require('prettier/standalone');
 
-
 const isEndOfChain = (node, path) => {
   let i = 0;
   let currentNode = node;
@@ -19,12 +18,23 @@ const isEndOfChain = (node, path) => {
       parentNode.type === 'FunctionCall' &&
       currentNode !== parentNode.expression
     )
-      return true;
+      break;
 
     // If direct ParentNode is an IndexAccess and currentNode is not the base
     // then it must be the index in which case it is the end of the chain.
     if (parentNode.type === 'IndexAccess' && currentNode !== parentNode.base)
-      return true;
+      break;
+
+    if (
+      parentNode.type === 'BinaryOperation' ||
+      parentNode.type === 'UnaryOperation' ||
+      parentNode.type === 'IfStatement' ||
+      parentNode.type === 'WhileStatement' ||
+      parentNode.type === 'ForStatement' ||
+      parentNode.type === 'VariableDeclarationStatement' ||
+      parentNode.type === 'ExpressionStatement'
+    )
+      break;
 
     i += 1;
     currentNode = parentNode;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -26,19 +26,19 @@ const isEndOfChain = (node, path) => {
       break;
 
     if (parentNode.type === 'BinaryOperation') break;
-    if (parentNode.type === 'UnaryOperation') break;
-    if (parentNode.type === 'IfStatement') break;
-    if (parentNode.type === 'WhileStatement') break;
-    if (parentNode.type === 'ForStatement') break;
-    if (parentNode.type === 'VariableDeclarationStatement') break;
-    if (parentNode.type === 'ExpressionStatement') break;
-    if (parentNode.type === 'TupleExpression') break;
-    if (parentNode.type === 'ReturnStatement') break;
-    if (parentNode.type === 'ModifierInvocation') break;
     if (parentNode.type === 'Conditional') break;
+    if (parentNode.type === 'ExpressionStatement') break;
+    if (parentNode.type === 'ForStatement') break;
+    if (parentNode.type === 'IfStatement') break;
     if (parentNode.type === 'NameValueList') break;
+    if (parentNode.type === 'ModifierInvocation') break;
+    if (parentNode.type === 'ReturnStatement') break;
     if (parentNode.type === 'StateVariableDeclaration') break;
     if (parentNode.type === 'TryStatement') break;
+    if (parentNode.type === 'TupleExpression') break;
+    if (parentNode.type === 'UnaryOperation') break;
+    if (parentNode.type === 'VariableDeclarationStatement') break;
+    if (parentNode.type === 'WhileStatement') break;
 
     i += 1;
     currentNode = parentNode;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -32,6 +32,13 @@ const isEndOfChain = (node, path) => {
     if (parentNode.type === 'ForStatement') break;
     if (parentNode.type === 'VariableDeclarationStatement') break;
     if (parentNode.type === 'ExpressionStatement') break;
+    if (parentNode.type === 'TupleExpression') break;
+    if (parentNode.type === 'ReturnStatement') break;
+    if (parentNode.type === 'ModifierInvocation') break;
+    if (parentNode.type === 'Conditional') break;
+    if (parentNode.type === 'NameValueList') break;
+    if (parentNode.type === 'StateVariableDeclaration') break;
+    if (parentNode.type === 'TryStatement') break;
 
     i += 1;
     currentNode = parentNode;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -8,37 +8,35 @@ const isEndOfChain = (node, path) => {
   let i = 0;
   let currentNode = node;
   let parentNode = path.getParentNode(i);
-  while (parentNode) {
-    // If direct ParentNode is a MemberAcces we are not at the end of the chain
-    if (parentNode.type === 'MemberAccess') return false;
+  while (
+    parentNode &&
+    [
+      'FunctionCall',
+      'IndexAccess',
+      'NameValueExpression',
+      'MemberAccess'
+    ].includes(parentNode.type)
+  ) {
+    switch (parentNode.type) {
+      case 'MemberAccess':
+        // If direct ParentNode is a MemberAcces we are not at the end of the chain
+        return false;
 
-    // If direct ParentNode is a FunctionCall and currentNode is not the expression
-    // then it must be and argument in which case it is the end of the chain.
-    if (
-      parentNode.type === 'FunctionCall' &&
-      currentNode !== parentNode.expression
-    )
-      break;
+      case 'IndexAccess':
+        // If direct ParentNode is an IndexAccess and currentNode is not the base
+        // then it must be the index in which case it is the end of the chain.
+        if (currentNode !== parentNode.base) return true;
+        break;
 
-    // If direct ParentNode is an IndexAccess and currentNode is not the base
-    // then it must be the index in which case it is the end of the chain.
-    if (parentNode.type === 'IndexAccess' && currentNode !== parentNode.base)
-      break;
+      case 'FunctionCall':
+        // If direct ParentNode is a FunctionCall and currentNode is not the expression
+        // then it must be and argument in which case it is the end of the chain.
+        if (currentNode !== parentNode.expression) return true;
+        break;
 
-    if (parentNode.type === 'BinaryOperation') break;
-    if (parentNode.type === 'Conditional') break;
-    if (parentNode.type === 'ExpressionStatement') break;
-    if (parentNode.type === 'ForStatement') break;
-    if (parentNode.type === 'IfStatement') break;
-    if (parentNode.type === 'NameValueList') break;
-    if (parentNode.type === 'ModifierInvocation') break;
-    if (parentNode.type === 'ReturnStatement') break;
-    if (parentNode.type === 'StateVariableDeclaration') break;
-    if (parentNode.type === 'TryStatement') break;
-    if (parentNode.type === 'TupleExpression') break;
-    if (parentNode.type === 'UnaryOperation') break;
-    if (parentNode.type === 'VariableDeclarationStatement') break;
-    if (parentNode.type === 'WhileStatement') break;
+      default:
+        break;
+    }
 
     i += 1;
     currentNode = parentNode;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -25,16 +25,13 @@ const isEndOfChain = (node, path) => {
     if (parentNode.type === 'IndexAccess' && currentNode !== parentNode.base)
       break;
 
-    if (
-      parentNode.type === 'BinaryOperation' ||
-      parentNode.type === 'UnaryOperation' ||
-      parentNode.type === 'IfStatement' ||
-      parentNode.type === 'WhileStatement' ||
-      parentNode.type === 'ForStatement' ||
-      parentNode.type === 'VariableDeclarationStatement' ||
-      parentNode.type === 'ExpressionStatement'
-    )
-      break;
+    if (parentNode.type === 'BinaryOperation') break;
+    if (parentNode.type === 'UnaryOperation') break;
+    if (parentNode.type === 'IfStatement') break;
+    if (parentNode.type === 'WhileStatement') break;
+    if (parentNode.type === 'ForStatement') break;
+    if (parentNode.type === 'VariableDeclarationStatement') break;
+    if (parentNode.type === 'ExpressionStatement') break;
 
     i += 1;
     currentNode = parentNode;

--- a/tests/MemberAccess/MemberAccess.sol
+++ b/tests/MemberAccess/MemberAccess.sol
@@ -13,3 +13,28 @@ contract MemberAccess {
         veryLongVariable.veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute).veryLongCall(veryLongAttribute);
     }
 }
+
+contract MemberAccessIsEndOfChainCases {
+    function() {
+        // break if is an argument of a FunctionCall
+        a(b.c);
+        // break if is an index of an IndexAccess
+        a[b.c];
+        // break if is a part of a BinaryOperation
+        a = b.c;
+        // break if is a part of a UnaryOperation
+        !b.c;
+        // break if is a condition of a IfStatement
+        if (b.c) {}
+        // break if is a condition of a WhileStatement
+        while (b.c) {}
+        // break if is a part of a ForStatement
+        // for (b.c;;) {}
+        for (;b.c;) {}
+        // for (;;b.c) {}
+        // break if is a part of a VariableDeclarationStatement
+        uint a = b.c;
+        // break if is an ExpressionStatement
+        b.c;
+    }
+}

--- a/tests/MemberAccess/MemberAccess.sol
+++ b/tests/MemberAccess/MemberAccess.sol
@@ -15,7 +15,10 @@ contract MemberAccess {
 }
 
 contract MemberAccessIsEndOfChainCases {
-    function() {
+    // break if is an ReturnStatement
+    uint a = b.c;
+
+    function() modifierCase(b.c) {
         // break if is an argument of a FunctionCall
         a(b.c);
         // break if is an index of an IndexAccess
@@ -36,5 +39,20 @@ contract MemberAccessIsEndOfChainCases {
         uint a = b.c;
         // break if is an ExpressionStatement
         b.c;
+        // break if is an TupleExpression
+        [a, b.c];
+        (b.c);
+        // break if is an Conditional
+        a.b ? c : d;
+        a ? b.c : d;
+        a ? b : c.d;
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an TryStatement
+        try a.b() {} catch {}
+        // break if is an ReturnStatement
+        return b.c;
     }
 }

--- a/tests/MemberAccess/MemberAccess.sol
+++ b/tests/MemberAccess/MemberAccess.sol
@@ -47,9 +47,7 @@ contract MemberAccessIsEndOfChainCases {
         a ? b.c : d;
         a ? b : c.d;
         // break if is an NameValueList
-        a{value: b.d};
-        // break if is an NameValueList
-        a{value: b.d};
+        a.b{value: c.d}();
         // break if is an TryStatement
         try a.b() {} catch {}
         // break if is an ReturnStatement

--- a/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -23,7 +23,10 @@ contract MemberAccess {
 }
 
 contract MemberAccessIsEndOfChainCases {
-    function() {
+    // break if is an ReturnStatement
+    uint a = b.c;
+
+    function() modifierCase(b.c) {
         // break if is an argument of a FunctionCall
         a(b.c);
         // break if is an index of an IndexAccess
@@ -44,6 +47,21 @@ contract MemberAccessIsEndOfChainCases {
         uint a = b.c;
         // break if is an ExpressionStatement
         b.c;
+        // break if is an TupleExpression
+        [a, b.c];
+        (b.c);
+        // break if is an Conditional
+        a.b ? c : d;
+        a ? b.c : d;
+        a ? b : c.d;
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an TryStatement
+        try a.b() {} catch {}
+        // break if is an ReturnStatement
+        return b.c;
     }
 }
 =====================================output=====================================
@@ -84,7 +102,10 @@ contract MemberAccess {
 }
 
 contract MemberAccessIsEndOfChainCases {
-    function() {
+    // break if is an ReturnStatement
+    uint256 a = b.c;
+
+    function() modifierCase(b.c) {
         // break if is an argument of a FunctionCall
         a(b.c);
         // break if is an index of an IndexAccess
@@ -105,6 +126,21 @@ contract MemberAccessIsEndOfChainCases {
         uint256 a = b.c;
         // break if is an ExpressionStatement
         b.c;
+        // break if is an TupleExpression
+        [a, b.c];
+        (b.c);
+        // break if is an Conditional
+        a.b ? c : d;
+        a ? b.c : d;
+        a ? b : c.d;
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an NameValueList
+        a{value: b.d};
+        // break if is an TryStatement
+        try a.b() {} catch {}
+        // break if is an ReturnStatement
+        return b.c;
     }
 }
 

--- a/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,30 @@ contract MemberAccess {
     }
 }
 
+contract MemberAccessIsEndOfChainCases {
+    function() {
+        // break if is an argument of a FunctionCall
+        a(b.c);
+        // break if is an index of an IndexAccess
+        a[b.c];
+        // break if is a part of a BinaryOperation
+        a = b.c;
+        // break if is a part of a UnaryOperation
+        !b.c;
+        // break if is a condition of a IfStatement
+        if (b.c) {}
+        // break if is a condition of a WhileStatement
+        while (b.c) {}
+        // break if is a part of a ForStatement
+        // for (b.c;;) {}
+        for (;b.c;) {}
+        // for (;;b.c) {}
+        // break if is a part of a VariableDeclarationStatement
+        uint a = b.c;
+        // break if is an ExpressionStatement
+        b.c;
+    }
+}
 =====================================output=====================================
 pragma solidity ^0.5.0;
 
@@ -56,6 +80,31 @@ contract MemberAccess {
             .veryLongCall(veryLongAttribute)
             .veryLongCall(veryLongAttribute)
             .veryLongCall(veryLongAttribute);
+    }
+}
+
+contract MemberAccessIsEndOfChainCases {
+    function() {
+        // break if is an argument of a FunctionCall
+        a(b.c);
+        // break if is an index of an IndexAccess
+        a[b.c];
+        // break if is a part of a BinaryOperation
+        a = b.c;
+        // break if is a part of a UnaryOperation
+        !b.c;
+        // break if is a condition of a IfStatement
+        if (b.c) {}
+        // break if is a condition of a WhileStatement
+        while (b.c) {}
+        // break if is a part of a ForStatement
+        // for (b.c;;) {}
+        for (; b.c; ) {}
+        // for (;;b.c) {}
+        // break if is a part of a VariableDeclarationStatement
+        uint256 a = b.c;
+        // break if is an ExpressionStatement
+        b.c;
     }
 }
 

--- a/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -55,9 +55,7 @@ contract MemberAccessIsEndOfChainCases {
         a ? b.c : d;
         a ? b : c.d;
         // break if is an NameValueList
-        a{value: b.d};
-        // break if is an NameValueList
-        a{value: b.d};
+        a.b{value: c.d}();
         // break if is an TryStatement
         try a.b() {} catch {}
         // break if is an ReturnStatement
@@ -134,9 +132,7 @@ contract MemberAccessIsEndOfChainCases {
         a ? b.c : d;
         a ? b : c.d;
         // break if is an NameValueList
-        a{value: b.d};
-        // break if is an NameValueList
-        a{value: b.d};
+        a.b{value: c.d}();
         // break if is an TryStatement
         try a.b() {} catch {}
         // break if is an ReturnStatement


### PR DESCRIPTION
A redesign of the `isBeginnigOfChain` method now considering cases like:

```Solidity
a()().b
c[1][2].d
```

While the previous would return false positives since it only cared about
```Solidity
a().b
c.d
```