### PR TITLE
Never break imports

### DIFF
--- a/tests/ImportDirective/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ImportDirective/__snapshots__/jsfmt.spec.js.snap
@@ -18,12 +18,7 @@ import "SomeFile.sol";
 import "SomeFile.sol" as SomeOtherFile;
 import "AnotherFile.sol" as SomeSymbol;
 import { symbol1 as alias, symbol2 } from "File.sol";
-import {
-    symbol1 as alias1,
-    symbol2 as alias2,
-    symbol3 as alias3,
-    symbol4
-} from "File2.sol";
+import { symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4 } from "File2.sol";
 
 ================================================================================
 `;
@@ -45,12 +40,7 @@ import "SomeFile.sol";
 import "SomeFile.sol" as SomeOtherFile;
 import "AnotherFile.sol" as SomeSymbol;
 import {symbol1 as alias, symbol2} from "File.sol";
-import {
-    symbol1 as alias1,
-    symbol2 as alias2,
-    symbol3 as alias3,
-    symbol4
-} from "File2.sol";
+import {symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4} from "File2.sol";
 
 ================================================================================
 `;


### PR DESCRIPTION
Closes #331.

See the issue for the whole discussion. The tl;dr is: some older (but not _that_ old) versions of solc don't support multi-line imports, so we should err on the side of compatibility and never break them.