### PR TITLE
using Prettier's utils and ignoring our old implementation for these

### DIFF
--- a/src/comments/handlers/ContractDefinition.js
+++ b/src/comments/handlers/ContractDefinition.js
@@ -1,7 +1,11 @@
 const {
-  util: { addLeadingComment, addTrailingComment, addDanglingComment }
+  util: {
+    addLeadingComment,
+    addTrailingComment,
+    addDanglingComment,
+    getNextNonSpaceNonCommentCharacterIndex
+  }
 } = require('prettier');
-const privateUtil = require('../../prettier-comments/common/util');
 
 function handleContractDefinitionComments(
   text,
@@ -20,10 +24,8 @@ function handleContractDefinitionComments(
   //   contract a is abc /* comment */ {}
   // The only workaround I found is to look at the next character to see if
   // it is a {}.
-  const nextCharacter = privateUtil.getNextNonSpaceNonCommentCharacter(
-    text,
-    comment,
-    options.locEnd
+  const nextCharacter = text.charAt(
+    getNextNonSpaceNonCommentCharacterIndex(text, comment, options.locEnd)
   );
 
   // The comment is behind the start of the Block `{}` or behind a base contract

--- a/src/comments/printer.js
+++ b/src/comments/printer.js
@@ -1,9 +1,9 @@
 const {
   doc: {
     builders: { hardline, join }
-  }
+  },
+  util: { hasNewline }
 } = require('prettier');
-const { hasNewline } = require('../prettier-comments/common/util');
 
 function isIndentableBlockComment(comment) {
   // If the comment has multiple lines and every line starts with a star

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -1,10 +1,10 @@
 const {
   doc: {
     builders: { dedent, group, hardline, indent, join, line }
-  }
+  },
+  util: { getNextNonSpaceNonCommentCharacterIndex }
 } = require('prettier/standalone');
 
-const privateUtil = require('../prettier-comments/common/util');
 const printSeparatedList = require('./print-separated-list');
 const printSeparatedItem = require('./print-separated-item');
 const printComments = require('./print-comments');
@@ -45,10 +45,12 @@ const parameters = (parametersType, node, path, print, options) => {
       path,
       options,
       (comment) =>
-        privateUtil.getNextNonSpaceNonCommentCharacter(
-          options.originalText,
-          comment,
-          options.locEnd
+        options.originalText.charAt(
+          getNextNonSpaceNonCommentCharacterIndex(
+            options.originalText,
+            comment,
+            options.locEnd
+          )
         ) === ')'
     );
     return paremeterComments.parts.length > 0


### PR DESCRIPTION
Had a look at the code as well and they are equivalent, though prettier's has more comments and documentation.