### PR TITLE
Using prettier instead of prettier/standalone and let webpack decide which to use

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 const FULL_TEST = Boolean(process.env.FULL_TEST);
+const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 
 module.exports = {
   collectCoverage: FULL_TEST,
@@ -18,6 +19,11 @@ module.exports = {
       lines: 100,
       statements: 100
     }
+  },
+  moduleNameMapper: {
+    '^prettier$': TEST_STANDALONE
+      ? '<rootDir>/node_modules/prettier/standalone'
+      : '<rootDir>/node_modules/prettier'
   },
   setupFiles: ['<rootDir>/tests/config/setup.js'],
   snapshotSerializers: [

--- a/src/binary-operator-printers/arithmetic.js
+++ b/src/binary-operator-printers/arithmetic.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line, indent }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line, indent }
+  }
+} = require('prettier');
 const comparison = require('./comparison');
 
 const groupIfNecessaryBuilder = (path) => (doc) => {

--- a/src/binary-operator-printers/arithmetic.js
+++ b/src/binary-operator-printers/arithmetic.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line, indent }
-  }
-} = require('prettier/standalone');
+  builders: { group, line, indent }
+} = require('prettier/doc');
 const comparison = require('./comparison');
 
 const groupIfNecessaryBuilder = (path) => (doc) => {

--- a/src/binary-operator-printers/assignment.js
+++ b/src/binary-operator-printers/assignment.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line, indent }
-  }
-} = require('prettier/standalone');
+  builders: { group, line, indent }
+} = require('prettier/doc');
 
 module.exports = {
   match: (op) =>

--- a/src/binary-operator-printers/assignment.js
+++ b/src/binary-operator-printers/assignment.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line, indent }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line, indent }
+  }
+} = require('prettier');
 
 module.exports = {
   match: (op) =>

--- a/src/binary-operator-printers/comparison.js
+++ b/src/binary-operator-printers/comparison.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line, indent }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line, indent }
+  }
+} = require('prettier');
 
 const indentIfNecessaryBuilder = (path) => (doc) => {
   let node = path.getNode();

--- a/src/binary-operator-printers/comparison.js
+++ b/src/binary-operator-printers/comparison.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line, indent }
-  }
-} = require('prettier/standalone');
+  builders: { group, line, indent }
+} = require('prettier/doc');
 
 const indentIfNecessaryBuilder = (path) => (doc) => {
   let node = path.getNode();

--- a/src/binary-operator-printers/exponentiation.js
+++ b/src/binary-operator-printers/exponentiation.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, ifBreak, indent, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, ifBreak, indent, softline }
+  }
+} = require('prettier');
 
 module.exports = {
   match: (op) => op === '**',

--- a/src/binary-operator-printers/exponentiation.js
+++ b/src/binary-operator-printers/exponentiation.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, ifBreak, indent, softline }
-  }
-} = require('prettier/standalone');
+  builders: { group, ifBreak, indent, softline }
+} = require('prettier/doc');
 
 module.exports = {
   match: (op) => op === '**',

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line, indent }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line, indent }
+  }
+} = require('prettier');
 
 const groupIfNecessaryBuilder = (path) => (doc) =>
   path.getParentNode().type === 'BinaryOperation' ? doc : group(doc);

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line, indent }
-  }
-} = require('prettier/standalone');
+  builders: { group, line, indent }
+} = require('prettier/doc');
 
 const groupIfNecessaryBuilder = (path) => (doc) =>
   path.getParentNode().type === 'BinaryOperation' ? doc : group(doc);

--- a/src/comments/printer.js
+++ b/src/comments/printer.js
@@ -1,9 +1,9 @@
 const {
+  doc: {
+    builders: { hardline, join }
+  },
   util: { hasNewline }
 } = require('prettier');
-const {
-  builders: { hardline, join }
-} = require('prettier/doc');
 
 function isIndentableBlockComment(comment) {
   // If the comment has multiple lines and every line starts with a star

--- a/src/comments/printer.js
+++ b/src/comments/printer.js
@@ -1,9 +1,9 @@
 const {
-  doc: {
-    builders: { hardline, join }
-  },
   util: { hasNewline }
 } = require('prettier');
+const {
+  builders: { hardline, join }
+} = require('prettier/doc');
 
 function isIndentableBlockComment(comment) {
   // If the comment has multiple lines and every line starts with a star

--- a/src/nodes/AssemblyAssignment.js
+++ b/src/nodes/AssemblyAssignment.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join }
-  }
-} = require('prettier/standalone');
+  builders: { join }
+} = require('prettier/doc');
 
 const AssemblyAssignment = {
   print: ({ path, print }) =>

--- a/src/nodes/AssemblyAssignment.js
+++ b/src/nodes/AssemblyAssignment.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join }
-} = require('prettier/doc');
+  doc: {
+    builders: { join }
+  }
+} = require('prettier');
 
 const AssemblyAssignment = {
   print: ({ path, print }) =>

--- a/src/nodes/AssemblyBlock.js
+++ b/src/nodes/AssemblyBlock.js
@@ -1,6 +1,8 @@
 const {
-  builders: { hardline }
-} = require('prettier/doc');
+  doc: {
+    builders: { hardline }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 const printComments = require('./print-comments');

--- a/src/nodes/AssemblyBlock.js
+++ b/src/nodes/AssemblyBlock.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { hardline }
-  }
-} = require('prettier/standalone');
+  builders: { hardline }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 const printComments = require('./print-comments');

--- a/src/nodes/AssemblyFor.js
+++ b/src/nodes/AssemblyFor.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join }
-  }
-} = require('prettier/standalone');
+  builders: { join }
+} = require('prettier/doc');
 
 const AssemblyFor = {
   print: ({ path, print }) =>

--- a/src/nodes/AssemblyFor.js
+++ b/src/nodes/AssemblyFor.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join }
-} = require('prettier/doc');
+  doc: {
+    builders: { join }
+  }
+} = require('prettier');
 
 const AssemblyFor = {
   print: ({ path, print }) =>

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, line }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/AssemblyLocalDefinition.js
+++ b/src/nodes/AssemblyLocalDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { line }
-} = require('prettier/doc');
+  doc: {
+    builders: { line }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/AssemblyLocalDefinition.js
+++ b/src/nodes/AssemblyLocalDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { line }
-  }
-} = require('prettier/standalone');
+  builders: { line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/AssemblySwitch.js
+++ b/src/nodes/AssemblySwitch.js
@@ -1,6 +1,8 @@
 const {
-  builders: { hardline, join }
-} = require('prettier/doc');
+  doc: {
+    builders: { hardline, join }
+  }
+} = require('prettier');
 
 const AssemblySwitch = {
   print: ({ path, print }) => [

--- a/src/nodes/AssemblySwitch.js
+++ b/src/nodes/AssemblySwitch.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { hardline, join }
-  }
-} = require('prettier/standalone');
+  builders: { hardline, join }
+} = require('prettier/doc');
 
 const AssemblySwitch = {
   print: ({ path, print }) => [

--- a/src/nodes/Block.js
+++ b/src/nodes/Block.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { hardline, indent }
-  }
-} = require('prettier/standalone');
+  builders: { hardline, indent }
+} = require('prettier/doc');
 
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 const printComments = require('./print-comments');

--- a/src/nodes/Block.js
+++ b/src/nodes/Block.js
@@ -1,6 +1,8 @@
 const {
-  builders: { hardline, indent }
-} = require('prettier/doc');
+  doc: {
+    builders: { hardline, indent }
+  }
+} = require('prettier');
 
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 const printComments = require('./print-comments');

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const Conditional = {
   print: ({ path, print }) =>

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const Conditional = {
   print: ({ path, print }) =>

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, line, hardline }
-  }
-} = require('prettier/standalone');
+  builders: { group, line, hardline }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, line, hardline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, line, hardline }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/DoWhileStatement.js
+++ b/src/nodes/DoWhileStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 

--- a/src/nodes/DoWhileStatement.js
+++ b/src/nodes/DoWhileStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, hardline }
-  }
-} = require('prettier/standalone');
+  builders: { group, hardline }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, hardline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, hardline }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/ExpressionStatement.js
+++ b/src/nodes/ExpressionStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { hardline }
-  }
-} = require('prettier/standalone');
+  builders: { hardline }
+} = require('prettier/doc');
 
 const printComments = require('./print-comments');
 

--- a/src/nodes/ExpressionStatement.js
+++ b/src/nodes/ExpressionStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { hardline }
-} = require('prettier/doc');
+  doc: {
+    builders: { hardline }
+  }
+} = require('prettier');
 
 const printComments = require('./print-comments');
 

--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { label, line, softline }
-  }
-} = require('prettier/standalone');
+  builders: { label, line, softline }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -1,6 +1,8 @@
 const {
-  builders: { label, line, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { label, line, softline }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -1,9 +1,9 @@
 const {
+  doc: {
+    builders: { dedent, group, hardline, indent, join, line }
+  },
   util: { getNextNonSpaceNonCommentCharacterIndex }
-} = require('prettier/standalone');
-const {
-  builders: { dedent, group, hardline, indent, join, line }
-} = require('prettier/doc');
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 const printSeparatedItem = require('./print-separated-item');

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -1,9 +1,9 @@
 const {
-  doc: {
-    builders: { dedent, group, hardline, indent, join, line }
-  },
   util: { getNextNonSpaceNonCommentCharacterIndex }
 } = require('prettier/standalone');
+const {
+  builders: { dedent, group, hardline, indent, join, line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 const printSeparatedItem = require('./print-separated-item');

--- a/src/nodes/FunctionTypeName.js
+++ b/src/nodes/FunctionTypeName.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/FunctionTypeName.js
+++ b/src/nodes/FunctionTypeName.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/HexLiteral.js
+++ b/src/nodes/HexLiteral.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { join, line }
+  }
+} = require('prettier');
 
 const { printString } = require('../prettier-comments/common/util');
 

--- a/src/nodes/HexLiteral.js
+++ b/src/nodes/HexLiteral.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join, line }
-  }
-} = require('prettier/standalone');
+  builders: { join, line }
+} = require('prettier/doc');
 
 const { printString } = require('../prettier-comments/common/util');
 

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, hardline, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, hardline, indent, line }
+} = require('prettier/doc');
 
 const printComments = require('./print-comments');
 const printSeparatedItem = require('./print-separated-item');

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, hardline, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, hardline, indent, line }
+  }
+} = require('prettier');
 
 const printComments = require('./print-comments');
 const printSeparatedItem = require('./print-separated-item');

--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join }
-} = require('prettier/doc');
+  doc: {
+    builders: { join }
+  }
+} = require('prettier');
 
 const { printString } = require('../prettier-comments/common/util');
 

--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join }
-  }
-} = require('prettier/standalone');
+  builders: { join }
+} = require('prettier/doc');
 
 const { printString } = require('../prettier-comments/common/util');
 

--- a/src/nodes/IndexAccess.js
+++ b/src/nodes/IndexAccess.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, softline }
+  }
+} = require('prettier');
 
 const IndexAccess = {
   print: ({ path, print }) => [

--- a/src/nodes/IndexAccess.js
+++ b/src/nodes/IndexAccess.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, softline }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, softline }
+} = require('prettier/doc');
 
 const IndexAccess = {
   print: ({ path, print }) => [

--- a/src/nodes/LabelDefinition.js
+++ b/src/nodes/LabelDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { dedent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { dedent, line }
+  }
+} = require('prettier');
 
 const LabelDefinition = {
   print: ({ node }) => [dedent(line), node.name, ':']

--- a/src/nodes/LabelDefinition.js
+++ b/src/nodes/LabelDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { dedent, line }
-  }
-} = require('prettier/standalone');
+  builders: { dedent, line }
+} = require('prettier/doc');
 
 const LabelDefinition = {
   print: ({ node }) => [dedent(line), node.name, ':']

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, ifBreak, indent, softline }
-  }
-} = require('prettier/standalone');
+  builders: { group, ifBreak, indent, softline }
+} = require('prettier/doc');
 
 const isEndOfChain = (node, path) => {
   let i = 0;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, ifBreak, indent, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, ifBreak, indent, softline }
+  }
+} = require('prettier');
 
 const isEndOfChain = (node, path) => {
   let i = 0;

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, hardline, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, hardline, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, hardline, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, hardline, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/NameValueList.js
+++ b/src/nodes/NameValueList.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { line, softline }
-  }
-} = require('prettier/standalone');
+  builders: { line, softline }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/NameValueList.js
+++ b/src/nodes/NameValueList.js
@@ -1,6 +1,8 @@
 const {
-  builders: { line, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { line, softline }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/ReturnStatement.js
+++ b/src/nodes/ReturnStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const expression = (node, path, print) => {
   if (node.expression) {

--- a/src/nodes/ReturnStatement.js
+++ b/src/nodes/ReturnStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const expression = (node, path, print) => {
   if (node.expression) {

--- a/src/nodes/SourceUnit.js
+++ b/src/nodes/SourceUnit.js
@@ -1,6 +1,8 @@
 const {
-  builders: { line }
-} = require('prettier/doc');
+  doc: {
+    builders: { line }
+  }
+} = require('prettier');
 
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 

--- a/src/nodes/SourceUnit.js
+++ b/src/nodes/SourceUnit.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { line }
-  }
-} = require('prettier/standalone');
+  builders: { line }
+} = require('prettier/doc');
 
 const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 

--- a/src/nodes/StateVariableDeclaration.js
+++ b/src/nodes/StateVariableDeclaration.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const initialValue = (node, path, print) => {
   if (!node.initialValue) {

--- a/src/nodes/StateVariableDeclaration.js
+++ b/src/nodes/StateVariableDeclaration.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const initialValue = (node, path, print) => {
   if (!node.initialValue) {

--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { join, line }
+  }
+} = require('prettier');
 const { printString } = require('../prettier-comments/common/util');
 
 const StringLiteral = {

--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join, line }
-  }
-} = require('prettier/standalone');
+  builders: { join, line }
+} = require('prettier/doc');
 const { printString } = require('../prettier-comments/common/util');
 
 const StringLiteral = {

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { hardline }
-  }
-} = require('prettier/standalone');
+  builders: { hardline }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -1,6 +1,8 @@
 const {
-  builders: { hardline }
-} = require('prettier/doc');
+  doc: {
+    builders: { hardline }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/TryStatement.js
+++ b/src/nodes/TryStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, join, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, join, line }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/TryStatement.js
+++ b/src/nodes/TryStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, join, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, join, line }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 const printSeparatedList = require('./print-separated-list');

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group }
-  }
-} = require('prettier/standalone');
+  builders: { group }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group }
-} = require('prettier/doc');
+  doc: {
+    builders: { group }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/UncheckedStatement.js
+++ b/src/nodes/UncheckedStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group }
-} = require('prettier/doc');
+  doc: {
+    builders: { group }
+  }
+} = require('prettier');
 
 const UncheckedStatement = {
   print: ({ path, print }) => group(['unchecked ', path.call(print, 'block')])

--- a/src/nodes/UncheckedStatement.js
+++ b/src/nodes/UncheckedStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group }
-  }
-} = require('prettier/standalone');
+  builders: { group }
+} = require('prettier/doc');
 
 const UncheckedStatement = {
   print: ({ path, print }) => group(['unchecked ', path.call(print, 'block')])

--- a/src/nodes/VariableDeclaration.js
+++ b/src/nodes/VariableDeclaration.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/VariableDeclaration.js
+++ b/src/nodes/VariableDeclaration.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/VariableDeclarationStatement.js
+++ b/src/nodes/VariableDeclarationStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group }
-  }
-} = require('prettier/standalone');
+  builders: { group }
+} = require('prettier/doc');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/VariableDeclarationStatement.js
+++ b/src/nodes/VariableDeclarationStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group }
-} = require('prettier/doc');
+  doc: {
+    builders: { group }
+  }
+} = require('prettier');
 
 const printSeparatedList = require('./print-separated-list');
 

--- a/src/nodes/WhileStatement.js
+++ b/src/nodes/WhileStatement.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, line }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, line }
+} = require('prettier/doc');
 
 const printSeparatedItem = require('./print-separated-item');
 

--- a/src/nodes/WhileStatement.js
+++ b/src/nodes/WhileStatement.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, line }
+  }
+} = require('prettier');
 
 const printSeparatedItem = require('./print-separated-item');
 

--- a/src/nodes/print-comments.js
+++ b/src/nodes/print-comments.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { join, line }
-  }
-} = require('prettier');
+  builders: { join, line }
+} = require('prettier/doc');
 
 const printComments = (node, path, options, filter = () => true) =>
   node.comments

--- a/src/nodes/print-comments.js
+++ b/src/nodes/print-comments.js
@@ -1,6 +1,8 @@
 const {
-  builders: { join, line }
-} = require('prettier/doc');
+  doc: {
+    builders: { join, line }
+  }
+} = require('prettier');
 
 const printComments = (node, path, options, filter = () => true) =>
   node.comments

--- a/src/nodes/print-preserving-empty-lines.js
+++ b/src/nodes/print-preserving-empty-lines.js
@@ -1,9 +1,9 @@
 const {
-  doc: {
-    builders: { hardline }
-  },
   util: { isNextLineEmptyAfterIndex }
 } = require('prettier/standalone');
+const {
+  builders: { hardline }
+} = require('prettier/doc');
 
 function printPreservingEmptyLines(path, key, options, print) {
   const parts = [];

--- a/src/nodes/print-preserving-empty-lines.js
+++ b/src/nodes/print-preserving-empty-lines.js
@@ -1,9 +1,9 @@
 const {
+  doc: {
+    builders: { hardline }
+  },
   util: { isNextLineEmptyAfterIndex }
-} = require('prettier/standalone');
-const {
-  builders: { hardline }
-} = require('prettier/doc');
+} = require('prettier');
 
 function printPreservingEmptyLines(path, key, options, print) {
   const parts = [];

--- a/src/nodes/print-separated-item.js
+++ b/src/nodes/print-separated-item.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { indent, softline }
-  }
-} = require('prettier/standalone');
+  builders: { indent, softline }
+} = require('prettier/doc');
 
 // This function will add an indentation to the `item` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/nodes/print-separated-item.js
+++ b/src/nodes/print-separated-item.js
@@ -1,6 +1,8 @@
 const {
-  builders: { indent, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { indent, softline }
+  }
+} = require('prettier');
 
 // This function will add an indentation to the `item` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/nodes/print-separated-list.js
+++ b/src/nodes/print-separated-list.js
@@ -1,6 +1,8 @@
 const {
-  builders: { group, indent, join, line, softline }
-} = require('prettier/doc');
+  doc: {
+    builders: { group, indent, join, line, softline }
+  }
+} = require('prettier');
 
 // This function will add an indentation to the `list` and separate it from the
 // rest of the `doc` in most cases by a `softline`.
@@ -12,7 +14,7 @@ const {
 const printSeparatedList = (
   list,
   {
-    groupId = undefined,
+    groupId,
     firstSeparator = softline,
     separator = [',', line],
     lastSeparator = firstSeparator

--- a/src/nodes/print-separated-list.js
+++ b/src/nodes/print-separated-list.js
@@ -1,8 +1,6 @@
 const {
-  doc: {
-    builders: { group, indent, join, line, softline }
-  }
-} = require('prettier/standalone');
+  builders: { group, indent, join, line, softline }
+} = require('prettier/doc');
 
 // This function will add an indentation to the `list` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/prettier-comments/language-js/comments.js
+++ b/src/prettier-comments/language-js/comments.js
@@ -7,7 +7,7 @@ const {
     addDanglingComment,
     getNextNonSpaceNonCommentCharacterIndex
   }
-} = require('prettier/standalone');
+} = require('prettier');
 const privateUtil = require("../common/util");
 
 function handleOwnLineComment(comment, text, options, ast, isLastComment) {


### PR DESCRIPTION
From Prettier's [documentation](https://prettier.io/docs/en/browser.html).

> The browser field in Prettier’s package.json points to standalone.js. That’s why you can just import or require the prettier module to access Prettier’s API, and your code can stay compatible with both Node and the browser as long as webpack or another bundler that supports the browser field is used. This is especially convenient for plugins.
