### PR TITLE
Throwing if the prettier version is not >=2.3.0

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1,8 +1,24 @@
+const prettier = require('prettier');
+const semver = require('semver');
 const nodes = require('./nodes');
 const { hasNodeIgnoreComment } = require('./prettier-comments/common/util');
 const ignoreComments = require('./comments/ignore');
 
+let checked = false;
+
+function prettierVersionCheck() {
+  if (checked) return;
+  if (!semver.satisfies(prettier.version, '>=2.3.0')) {
+    throw new Error(
+      'The version of prettier in your node-modules does not satisfy the required ">=2.3.0" constraint. Please update the version of Prettier.'
+    );
+  }
+  checked = true;
+}
+
 function genericPrint(path, options, print) {
+  prettierVersionCheck();
+
   const node = path.getValue();
   if (node === null) {
     return '';

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -195,7 +195,7 @@ function runSpec(fixtures, parsers, options) {
 
     describe(title, () => {
       const formatOptions = {
-        plugins: [path.dirname(path.join(__dirname, ".."))],
+        plugins: [path.join(__dirname, "../..")],
         printWidth: 80,
         ...options,
         filepath: filename,

--- a/tests/unit/prettier-version.test.js
+++ b/tests/unit/prettier-version.test.js
@@ -12,7 +12,7 @@ jest.mock('prettier', () => {
 
 const prettier = require('prettier');
 
-test('should throw if the installed version of prettier is lesser than v2.3.0', () => {
+test('should throw if the installed version of prettier is less than v2.3.0', () => {
   const data = 'contract CheckPrettierVersion {}';
 
   const options = {

--- a/tests/unit/prettier-version.test.js
+++ b/tests/unit/prettier-version.test.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+jest.mock('prettier', () => {
+  // Require the original module to not be mocked...
+  const originalModule = jest.requireActual('prettier');
+
+  return {
+    ...originalModule,
+    version: '2.2.1'
+  };
+});
+
+const prettier = require('prettier');
+
+test('should throw if the installed version of prettier is lesser than v2.3.0', () => {
+  const data = 'contract CheckPrettierVersion {}';
+
+  const options = {
+    plugins: [path.join(__dirname, '../..')],
+    parser: 'solidity-parse'
+  };
+
+  expect(() => {
+    prettier.format(data, options);
+  }).toThrow('>=2.3.0');
+});


### PR DESCRIPTION
Preventing from printing with an old version of prettier that still relies on `concat`.