### PR TITLE
Chained member access

### DIFF
--- a/src/nodes/IndexAccess.js
+++ b/src/nodes/IndexAccess.js
@@ -1,16 +1,28 @@
 const {
   doc: {
-    builders: { group, indent, softline }
+    builders: { group, indent, label, softline }
   }
 } = require('prettier');
 
+let indexAccessId = 0;
+
 const IndexAccess = {
-  print: ({ path, print }) => [
-    path.call(print, 'base'),
-    '[',
-    group([indent([softline, path.call(print, 'index')]), softline]),
-    ']'
-  ]
+  print: ({ path, print }) => {
+    const indexAccessLabel = {
+      type: 'IndexAccess',
+      groupId: `IndexAccess-${indexAccessId}`
+    };
+    indexAccessId += 1;
+
+    return label(JSON.stringify(indexAccessLabel), [
+      path.call(print, 'base'),
+      '[',
+      group([indent([softline, path.call(print, 'index')]), softline], {
+        id: indexAccessLabel.groupId
+      }),
+      ']'
+    ]);
+  }
 };
 
 module.exports = IndexAccess;

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -47,30 +47,73 @@ const isEndOfChain = (node, path) => {
   return true;
 };
 
+/**
+ * processChain expects the doc[] of the full chain of MemberAccess.
+ *
+ * It uses the separator label to split the chain into 2 arrays.
+ * The first array is the doc[] corresponding to the first element before the
+ * first separator.
+ * The second array contains the rest of the chain.
+ *
+ * The indentation of the whole chain depends on the result of the first
+ * element.
+ *
+ * If the first element breaks into multiple lines, we won't indent the rest of
+ * the chain as the last line (most likely a closing parentheses) won't be
+ * indented.
+ *
+ * i.e.
+ * ```
+ * functionCall(
+ *     arg1,
+ *     arg2
+ * ).rest.of.chain
+ *
+ * functionCall(
+ *     arg1,
+ *     arg2
+ * )
+ * .long
+ * .rest
+ * .of
+ * .chain
+ * ```
+ *
+ * If the first element doesn't break into multiple lines we treat the rest of
+ * the chain as a normal chain and proceed to indent it.
+ *
+ *
+ * i.e.
+ * ```
+ * a = functionCall(arg1, arg2).rest.of.chain
+ *
+ * b = functionCall(arg1, arg2)
+ *     .long
+ *     .rest
+ *     .of
+ *     .chain
+ * ```
+ *
+ * NOTE: As described in the examples above, the rest of the chain will be grouped
+ * and try to stay in the same line as the end of the first element.
+ *
+ * @param {doc[]} chain is the full chain of MemberAccess
+ * @returns a processed doc[] with the proper grouping and indentation ready to
+ * be printed.
+ */
 const processChain = (chain) => {
   const firstSeparatorIndex = chain.findIndex((element) => {
     if (element.label) {
-      const labelData = JSON.parse(element.label);
-      if (labelData && labelData.type) {
-        return labelData.type === 'separator';
-      }
+      return JSON.parse(element.label).type === 'separator';
     }
     return false;
   });
+  // We fetch the groupId from the firstSeparator
   const { groupId } = JSON.parse(chain[firstSeparatorIndex].label);
+  // The doc[] before the first separator
   const firstExpression = chain.slice(0, firstSeparatorIndex);
-
-  const restOfChain = group(
-    chain
-      .slice(firstSeparatorIndex)
-      .map((element) => {
-        if (element.label) {
-          return element.contents.flat();
-        }
-        return element;
-      })
-      .flat()
-  );
+  // The doc[] containing the rest of the chain
+  const restOfChain = group(chain.slice(firstSeparatorIndex));
 
   return groupId
     ? [
@@ -90,6 +133,8 @@ const MemberAccess = {
     if (expressionDoc.label) {
       const labelData = JSON.parse(expressionDoc.label);
       if (labelData && labelData.groupId) {
+        // if there's a groupId in the data, we pass it to the separator as
+        // this doc[] is going to be stripped of it's metadata
         separatorLabel.groupId = labelData.groupId;
       }
       expressionDoc = expressionDoc.contents.flat();

--- a/tests/format/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/FunctionCalls/__snapshots__/jsfmt.spec.js.snap
@@ -52,7 +52,7 @@ contract FunctionCalls {
 contract FunctionCalls {
     function foo() {
         address veryLongValidatorAddress = veryVeryVeryLongSignature
-        .popLast20Bytes();
+            .popLast20Bytes();
     }
 
     function foo() {
@@ -80,7 +80,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV2(
+        )
+        ._hashTypedDataV2(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -92,7 +93,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV3(
+        )
+        ._hashTypedDataV3(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -104,7 +106,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        ).recover(signature);
+        )
+        .recover(signature);
         signer = _hashTypedDataV1(
             keccak256(
                 abi.encode(
@@ -117,7 +120,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV2(
+        )
+        ._hashTypedDataV2(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -129,7 +133,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV3(
+        )
+        ._hashTypedDataV3(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -141,7 +146,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        ).recover(signature);
+        )
+        .recover(signature);
         return _nonces[req.from] == req.nonce && signer == req.from;
     }
 }
@@ -200,7 +206,7 @@ contract FunctionCalls {
 contract FunctionCalls {
     function foo() {
         address veryLongValidatorAddress = veryVeryVeryLongSignature
-        .popLast20Bytes();
+            .popLast20Bytes();
     }
 
     function foo() {
@@ -228,7 +234,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV2(
+        )
+        ._hashTypedDataV2(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -240,7 +247,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV3(
+        )
+        ._hashTypedDataV3(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -252,7 +260,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        ).recover(signature);
+        )
+        .recover(signature);
         signer = _hashTypedDataV1(
             keccak256(
                 abi.encode(
@@ -265,7 +274,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV2(
+        )
+        ._hashTypedDataV2(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -277,7 +287,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        )._hashTypedDataV3(
+        )
+        ._hashTypedDataV3(
             keccak256(
                 abi.encode(
                     TYPEHASH,
@@ -289,7 +300,8 @@ contract FunctionCalls {
                     keccak256(req.data)
                 )
             )
-        ).recover(signature);
+        )
+        .recover(signature);
         return _nonces[req.from] == req.nonce && signer == req.from;
     }
 }

--- a/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -32,9 +32,7 @@ contract Example {
     function example(address token, uint256 amount) public {
         balanceStates[msg.sender][token].balance = balanceStates[msg.sender][
             token
-        ]
-        .balance
-        .sub(amount);
+        ].balance.sub(amount);
     }
 }
 
@@ -59,8 +57,7 @@ contract Issue289 {
     function f() {
         address[] storage proposalValidators = ethProposals[_blockNumber][
             _proposalId
-        ]
-        .proposalValidators;
+        ].proposalValidators;
     }
 }
 

--- a/tests/format/MemberAccess/MemberAccess.sol
+++ b/tests/format/MemberAccess/MemberAccess.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.5.0;
 
 contract MemberAccess {
     function() {
+        int256 amount = SafeCast.toInt256(10**(18 - underlyingAssetDecimals)).neg();
+        longNameAmount = SafeCast.toInt256(10**(18 - underlyingAssetDecimals)).neg();
         a.b.c.d;
         a.b().c.d;
         a.b.c.d();

--- a/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,8 @@ pragma solidity ^0.5.0;
 
 contract MemberAccess {
     function() {
+        int256 amount = SafeCast.toInt256(10**(18 - underlyingAssetDecimals)).neg();
+        longNameAmount = SafeCast.toInt256(10**(18 - underlyingAssetDecimals)).neg();
         a.b.c.d;
         a.b().c.d;
         a.b.c.d();
@@ -67,6 +69,12 @@ pragma solidity ^0.5.0;
 
 contract MemberAccess {
     function() {
+        int256 amount = SafeCast
+            .toInt256(10**(18 - underlyingAssetDecimals))
+            .neg();
+        longNameAmount = SafeCast
+            .toInt256(10**(18 - underlyingAssetDecimals))
+            .neg();
         a.b.c.d;
         a.b().c.d;
         a.b.c.d();

--- a/tests/format/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/SplittableCommodity/__snapshots__/jsfmt.spec.js.snap
@@ -88,7 +88,7 @@ contract SplittableCommodity is MintableCommodity {
         uint256 _amount
     ) public whenNotPaused {
         address supplierProxy = IContractRegistry(contractRegistry)
-        .getLatestProxyAddr("Supplier");
+            .getLatestProxyAddr("Supplier");
         require(
             msg.sender ==
                 IContractRegistry(contractRegistry).getLatestProxyAddr(


### PR DESCRIPTION
With this PR I'm rethinking the way of how we print chains. This PR has been in my roadmap for a while and was only possible after #523 and #531.

Here we add another function to process the doc.

`processChain` expects the flattened `doc[]` of the complete chain of MemberAccess.

It uses the separator label to split the chain into 2 arrays.
The first array is the `doc[]` corresponding to the first element before the first separator.
The second array contains the rest of the chain.

The indentation of the whole chain depends on the result of the first element.

If the first element breaks into multiple lines, we won't indent the rest of the chain as the last line (most likely a closing parentheses) won't be indented.

i.e.
```Solidity
functionCall(
    arg1,
    arg2
).rest.of.chain

functionCall(
    arg1,
    arg2
)
.long
.rest
.of
.chain
```

If the first element doesn't break into multiple lines we treat the rest of the chain as a normal chain and proceed to indent it.

i.e.
```Solidity
functionCall(arg1, arg2).rest.of.chain

functionCall(arg1, arg2)
    .long
    .rest
    .of
    .chain
```

NOTE: As described in the examples above, the rest of the chain will be grouped and try to stay in the same line as the end of the first element.

Chained `MemberAccess` where always clunky since all of the steps had their own indentation and we where juggling to make things look nice.

I believe that these changes will make the work with chains easier.

PS: Also this PR contains the possibility to have an `IndexAccess` as the beginning of the chain.

```Solidity
veryLongNamedArray[
    aStructVariable.indexValue
].rest.of.chain

veryLongNamedArray[
    aStructVariable.indexValue
]
.long
.rest
.of
.chain
```