### PR TITLE
solving the indentation at the beginning of a var declaration that splits

### DIFF
--- a/src/nodes/VariableDeclarationStatement.js
+++ b/src/nodes/VariableDeclarationStatement.js
@@ -6,7 +6,8 @@ const {
 
 const printSeparatedList = require('./print-separated-list');
 
-const embraceVariables = (doc, embrace) => (embrace ? ['(', doc, ')'] : doc);
+const embraceVariables = (doc, embrace) =>
+  embrace ? ['(', printSeparatedList(doc), ')'] : doc;
 
 const initialValue = (node, path, print) =>
   node.initialValue ? [' = ', path.call(print, 'initialValue')] : '';
@@ -19,7 +20,7 @@ const VariableDeclarationStatement = {
     return group([
       startsWithVar ? 'var ' : '',
       embraceVariables(
-        printSeparatedList(path.map(print, 'variables')),
+        path.map(print, 'variables'),
         node.variables.length > 1 || startsWithVar
       ),
       initialValue(node, path, print),

--- a/tests/format/Issues/Issue564.sol
+++ b/tests/format/Issues/Issue564.sol
@@ -1,0 +1,9 @@
+contract Issue564 {
+    function isAuthorized(
+        bytes32 serviceId,
+        address client
+    ) external view override returns (bool) {
+        WhitelistStatus storage whitelistStatus = serviceIdToClientToWhitelistStatus[serviceId][client];
+        return true;
+    }
+}

--- a/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -137,3 +137,38 @@ contract Issue385 {
 
 ================================================================================
 `;
+
+exports[`Issue564.sol format 1`] = `
+====================================options=====================================
+parsers: ["solidity-parse"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+contract Issue564 {
+    function isAuthorized(
+        bytes32 serviceId,
+        address client
+    ) external view override returns (bool) {
+        WhitelistStatus storage whitelistStatus = serviceIdToClientToWhitelistStatus[serviceId][client];
+        return true;
+    }
+}
+
+=====================================output=====================================
+contract Issue564 {
+    function isAuthorized(bytes32 serviceId, address client)
+        external
+        view
+        override
+        returns (bool)
+    {
+        WhitelistStatus
+            storage whitelistStatus = serviceIdToClientToWhitelistStatus[
+            serviceId
+        ][client];
+        return true;
+    }
+}
+
+================================================================================
+`;

--- a/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Issues/__snapshots__/jsfmt.spec.js.snap
@@ -164,8 +164,8 @@ contract Issue564 {
     {
         WhitelistStatus
             storage whitelistStatus = serviceIdToClientToWhitelistStatus[
-            serviceId
-        ][client];
+                serviceId
+            ][client];
         return true;
     }
 }


### PR DESCRIPTION
closes #564 

This revealed 2 issues

  - The variables where printed as a indented list even if it was only one.
  - If the declaration splits, the indentation of the initial value was not updated.

The Index access looks weird though, maybe we have to create an issue for this.