### PR TITLE
Fix "using for" with qualified library name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,9 +1684,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
-      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.1.tgz",
+      "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "solc": "^0.8.11"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.14.0",
+    "@solidity-parser/parser": "^0.14.1",
     "emoji-regex": "^10.0.0",
     "escape-string-regexp": "^4.0.0",
     "semver": "^7.3.5",

--- a/tests/format/AllSolidityFeatures/AllSolidityFeatures.sol
+++ b/tests/format/AllSolidityFeatures/AllSolidityFeatures.sol
@@ -262,6 +262,7 @@ library UsingExampleLibrary {
 contract UsingExampleContract {
   using UsingExampleLibrary for *;
   using UsingExampleLibrary for uint[];
+  using Example.UsingExampleLibrary for uint;
 }
 
 contract NewStuff {

--- a/tests/format/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/AllSolidityFeatures/__snapshots__/jsfmt.spec.js.snap
@@ -270,6 +270,7 @@ library UsingExampleLibrary {
 contract UsingExampleContract {
   using UsingExampleLibrary for *;
   using UsingExampleLibrary for uint[];
+  using Example.UsingExampleLibrary for uint;
 }
 
 contract NewStuff {
@@ -822,6 +823,7 @@ library UsingExampleLibrary {
 contract UsingExampleContract {
     using UsingExampleLibrary for *;
     using UsingExampleLibrary for uint256[];
+    using Example.UsingExampleLibrary for uint256;
 }
 
 contract NewStuff {


### PR DESCRIPTION
Fixes #622.

Notice that this changes the version of the `package-lock.json`, which causes a lot of modifications there. I recommend you upgrade `npm` to the latest version so that this isn't changed again.