### PR TITLE
Identifiers in function calls with an object are now processed

### DIFF
--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -6,7 +6,7 @@ const {
 
 const printSeparatedList = require('./print-separated-list');
 
-const printObject = (node, path, print, options) => {
+const printObject = (path, print, options) => {
   const identifiers = path.map(print, 'identifiers');
   return [
     '{',
@@ -35,7 +35,7 @@ const FunctionCall = {
 
     if (node.arguments && node.arguments.length > 0) {
       if (node.identifiers && node.identifiers.length > 0) {
-        argumentsDoc = printObject(node, path, print, options);
+        argumentsDoc = printObject(path, print, options);
       } else {
         argumentsDoc = printArguments(path, print);
       }

--- a/src/nodes/FunctionCall.js
+++ b/src/nodes/FunctionCall.js
@@ -6,18 +6,21 @@ const {
 
 const printSeparatedList = require('./print-separated-list');
 
-const printObject = (node, path, print, options) => [
-  '{',
-  printSeparatedList(
-    path
-      .map(print, 'arguments')
-      .map((arg, index) => [node.names[index], ': ', arg]),
-    {
-      firstSeparator: options.bracketSpacing ? line : softline,
-      lastSeparator: [options.bracketSpacing ? line : softline, '})']
-    }
-  )
-];
+const printObject = (node, path, print, options) => {
+  const identifiers = path.map(print, 'identifiers');
+  return [
+    '{',
+    printSeparatedList(
+      path
+        .map(print, 'arguments')
+        .map((arg, index) => [identifiers[index], ': ', arg]),
+      {
+        firstSeparator: options.bracketSpacing ? line : softline,
+        lastSeparator: [options.bracketSpacing ? line : softline, '})']
+      }
+    )
+  ];
+};
 
 const printArguments = (path, print) =>
   printSeparatedList(path.map(print, 'arguments'), {
@@ -31,7 +34,7 @@ const FunctionCall = {
     let argumentsDoc = ')';
 
     if (node.arguments && node.arguments.length > 0) {
-      if (node.names && node.names.length > 0) {
+      if (node.identifiers && node.identifiers.length > 0) {
         argumentsDoc = printObject(node, path, print, options);
       } else {
         argumentsDoc = printArguments(path, print);

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -22,7 +22,7 @@ const RANGE_END_PLACEHOLDER = "<<<PRETTIER_RANGE_END>>>";
 
 // Here we add files that will not be the same when formatting a second time.
 const unstableTests = new Map(
-  [].map((fixture) => {
+  ["Comments/Comments.sol"].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)
       ? fixture
       : [fixture];

--- a/tests/format/Comments/Comments.sol
+++ b/tests/format/Comments/Comments.sol
@@ -102,3 +102,15 @@ contract Comments11 {
     // this should not be removed
   }
 }
+
+contract Comments12 {
+  function f() public {
+    purchaseData[0] = DomainPurchaseData({
+      /* test */prices: _rootPrices,
+      // test2
+      subdomainMintingEnabled: /* test3 */_rootPrices.short > 0,
+      allowSubdomainsToMint: true, // test4
+      wasAllowedToSubdomainMintOnCreation: true
+    });
+  }
+}

--- a/tests/format/Comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Comments/__snapshots__/jsfmt.spec.js.snap
@@ -111,6 +111,18 @@ contract Comments11 {
   }
 }
 
+contract Comments12 {
+  function f() public {
+    purchaseData[0] = DomainPurchaseData({
+      /* test */prices: _rootPrices,
+      // test2
+      subdomainMintingEnabled: /* test3 */_rootPrices.short > 0,
+      allowSubdomainsToMint: true, // test4
+      wasAllowedToSubdomainMintOnCreation: true
+    });
+  }
+}
+
 =====================================output=====================================
 pragma solidity ^0.4.24;
 
@@ -237,6 +249,20 @@ contract Comments11 {
 
     function f() public {
         // this should not be removed
+    }
+}
+
+contract Comments12 {
+    function f() public {
+        purchaseData[0] = DomainPurchaseData({
+            /* test */
+            prices: _rootPrices,
+            // test2
+            subdomainMintingEnabled: /* test3 */
+            _rootPrices.short > 0,
+            allowSubdomainsToMint: true, // test4
+            wasAllowedToSubdomainMintOnCreation: true
+        });
     }
 }
 


### PR DESCRIPTION
closes #680

Had to add `Comments.sol` to the list of tests that should not be formatted twice because of this:

```Solidity
// Original
purchaseData[0] = DomainPurchaseData({
  /* test */prices: _rootPrices,
  // test2
  subdomainMintingEnabled: /* test3 */_rootPrices.short > 0,
  allowSubdomainsToMint: true, // test4
  wasAllowedToSubdomainMintOnCreation: true
});

// 1st format
purchaseData[0] = DomainPurchaseData({
    /* test */
    prices: _rootPrices,
    // test2
    subdomainMintingEnabled: /* test3 */
    _rootPrices.short > 0,
    allowSubdomainsToMint: true, // test4
    wasAllowedToSubdomainMintOnCreation: true
});

// 2nd format
purchaseData[0] = DomainPurchaseData({
    /* test */
    prices: _rootPrices,
    // test2
    subdomainMintingEnabled: _rootPrices.short > 0, /* test3 */
    allowSubdomainsToMint: true, // test4
    wasAllowedToSubdomainMintOnCreation: true
});
```

As you see the second format places the comment `/* test3 */` at the end of the whole line instead of between the identifier and the value.

It's something that will be reviewed but for now this is a great improvement.

@fvictorio We are no longer using the `names` attribute for this printer. Maybe it can be removed from the parser.