### PR TITLE
Grouping all comments in a chain at the beginning of it

### DIFF
--- a/src/comments/handler.js
+++ b/src/comments/handler.js
@@ -6,6 +6,7 @@ const {
 } = require('../prettier-comments/language-js/comments');
 
 const handleContractDefinitionComments = require('./handlers/ContractDefinition');
+const handleMemberAccessComments = require('./handlers/MemberAccess');
 
 function solidityHandleOwnLineComment(
   comment,
@@ -26,6 +27,7 @@ function solidityHandleOwnLineComment(
 
   if (
     handleContractDefinitionComments(...handlerArguments) ||
+    handleMemberAccessComments(...handlerArguments) ||
     handleOwnLineComment(comment, text, options, ast, isLastComment)
   ) {
     return true;
@@ -52,6 +54,7 @@ function solidityHandleEndOfLineComment(
 
   if (
     handleContractDefinitionComments(...handlerArguments) ||
+    handleMemberAccessComments(...handlerArguments) ||
     handleEndOfLineComment(comment, text, options, ast, isLastComment)
   ) {
     return true;
@@ -78,6 +81,7 @@ function solidityHandleRemainingComment(
 
   if (
     handleContractDefinitionComments(...handlerArguments) ||
+    handleMemberAccessComments(...handlerArguments) ||
     handleRemainingComment(comment, text, options, ast, isLastComment)
   ) {
     return true;

--- a/src/comments/handlers/MemberAccess.js
+++ b/src/comments/handlers/MemberAccess.js
@@ -1,0 +1,19 @@
+const {
+  util: { addDanglingComment }
+} = require('prettier');
+
+function handleMemberAccessComments(
+  text,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  comment
+) {
+  if (enclosingNode && enclosingNode.type === 'MemberAccess') {
+    addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+module.exports = handleMemberAccessComments;

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -22,7 +22,7 @@ const RANGE_END_PLACEHOLDER = "<<<PRETTIER_RANGE_END>>>";
 
 // Here we add files that will not be the same when formatting a second time.
 const unstableTests = new Map(
-  ["Comments/Comments.sol"].map((fixture) => {
+  ["Comments/Comments.sol", "MemberAccess/MemberAccess.sol"].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)
       ? fixture
       : [fixture];
@@ -32,7 +32,7 @@ const unstableTests = new Map(
 
 // Here we add files that will not have the same AST after being formatted.
 const unstableAstTests = new Map(
-  [].map((fixture) => {
+  ["MemberAccess/MemberAccess.sol"].map((fixture) => {
     const [file, isAstUnstable = () => true] = Array.isArray(fixture)
       ? fixture
       : [fixture];

--- a/tests/format/MemberAccess/MemberAccess.sol
+++ b/tests/format/MemberAccess/MemberAccess.sol
@@ -57,6 +57,59 @@ contract MemberAccess {
             path,
             address(this, aoeu, aoeueu, aoeu)
         );
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            array[/* inside array comment */ 1].
+            // Comment 5
+            call{value: 10, gas: 800}();
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            array[/* inside array comment */ 1].
+            // Comment 5
+            endOfChain;
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            endOfChain;
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            endOfChain;
     }
 }
 

--- a/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -65,6 +65,59 @@ contract MemberAccess {
             path,
             address(this, aoeu, aoeueu, aoeu)
         );
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            array[/* inside array comment */ 1].
+            // Comment 5
+            call{value: 10, gas: 800}();
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            array[/* inside array comment */ 1].
+            // Comment 5
+            endOfChain;
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            functionCall(/* inside function comment */).
+            // Comment 4
+            endOfChain;
+
+
+        // Comment before chain
+        game.
+            // CONFIG
+            config.
+            // Comment 1
+            // Comment 2
+            resolveWindow.
+            // Comment 3
+            endOfChain;
     }
 }
 
@@ -195,6 +248,59 @@ contract MemberAccess {
                 path,
                 address(this, aoeu, aoeueu, aoeu)
             );
+
+        // Comment before chain
+        // CONFIG
+        // Comment 1
+        // Comment 2
+        // Comment 3
+        // Comment 4
+        // Comment 5
+        game
+            .config
+            .resolveWindow
+            .functionCall() /* inside function comment */
+            .array[
+                /* inside array comment */
+                1
+            ]
+            .call{value: 10, gas: 800}();
+
+        // Comment before chain
+        // CONFIG
+        // Comment 1
+        // Comment 2
+        // Comment 3
+        // Comment 4
+        // Comment 5
+        game
+            .config
+            .resolveWindow
+            .functionCall() /* inside function comment */
+            .array[
+                /* inside array comment */
+                1
+            ]
+            .endOfChain;
+
+        // Comment before chain
+        // CONFIG
+        // Comment 1
+        // Comment 2
+        // Comment 3
+        // Comment 4
+        game
+            .config
+            .resolveWindow
+            .functionCall() /* inside function comment */
+            .endOfChain;
+
+        // Comment before chain
+        // CONFIG
+        // Comment 1
+        // Comment 2
+        // Comment 3
+        game.config.resolveWindow.endOfChain;
     }
 }
 


### PR DESCRIPTION
addressing some issues with comments in chains. #644

For now we are grouping comments at the beginning of the chain.

This is a good first step however we must address some questions if we want to continue with this approach.

first of all in this scenario:

```Solidity
// Original
begin.
    // Comment 1
    functionCall(/* Comment about parameter */ parameter).
    // Comment 2
    end;

// Formatted
// Comment 1
// Comment 2
begin.
    functionCall(/* Comment about parameter */ parameter).
    end;
```

This is the expected behaviour but the order of the comments is not the same anymore. Therefore the AST comparison will fail.

Shall we remove the comments from the AST comparison understanding that Prettier already has a lot of security making sure that each comment will be printed?

In this case we are making new advances since Prettier JS does mess up with the order of the comments when the chain get a bit complex and also the indentation.

Thoughts @fvictorio @mattiaerre 

there are some more ideas I have but for now this is a good first step.