### PR TITLE
print-separated-item using grouped option

### DIFF
--- a/src/nodes/AssemblyBlock.js
+++ b/src/nodes/AssemblyBlock.js
@@ -16,7 +16,7 @@ const AssemblyBlock = {
         printPreservingEmptyLines(path, 'operations', options, print),
         printComments(node, path, options)
       ],
-      { firstSeparator: hardline }
+      { firstSeparator: hardline, grouped: false }
     ),
     '}'
   ]

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { group, line }
+    builders: { line }
   }
 } = require('prettier');
 
@@ -16,17 +16,15 @@ const AssemblyFunctionDefinition = {
     ')',
     node.returnArguments.length === 0
       ? ' '
-      : group(
-          printSeparatedItem(
-            [
-              '->',
-              printSeparatedList(path.map(print, 'returnArguments'), {
-                firstSeparator: line,
-                lastSeparator: ''
-              })
-            ],
-            { firstSeparator: line }
-          )
+      : printSeparatedItem(
+          [
+            '->',
+            printSeparatedList(path.map(print, 'returnArguments'), {
+              firstSeparator: line,
+              lastSeparator: ''
+            })
+          ],
+          { firstSeparator: line }
         ),
     path.call(print, 'body')
   ]

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -26,7 +26,7 @@ const body = (node, path, options, print) =>
           printPreservingEmptyLines(path, 'subNodes', options, print),
           printComments(node, path, options)
         ],
-        { firstSeparator: hardline }
+        { firstSeparator: hardline, grouped: false }
       )
     : '';
 

--- a/src/nodes/DoWhileStatement.js
+++ b/src/nodes/DoWhileStatement.js
@@ -15,7 +15,9 @@ const DoWhileStatement = {
   print: ({ node, path, print }) => [
     'do',
     printBody(node, path, print),
-    group(['while (', printSeparatedItem(path.call(print, 'condition')), ');'])
+    'while (',
+    printSeparatedItem(path.call(print, 'condition')),
+    ');'
   ]
 };
 

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -45,9 +45,7 @@ const IfStatement = {
 
     const parts = [];
 
-    parts.push(
-      group(['if (', printSeparatedItem(path.call(print, 'condition')), ')'])
-    );
+    parts.push('if (', printSeparatedItem(path.call(print, 'condition')), ')');
     parts.push(printTrueBody(node, path, print));
     if (commentsBetweenIfAndElse.length && node.falseBody) {
       parts.push(hardline);

--- a/src/nodes/TryStatement.js
+++ b/src/nodes/TryStatement.js
@@ -1,6 +1,6 @@
 const {
   doc: {
-    builders: { group, join, line }
+    builders: { join, line }
   }
 } = require('prettier');
 
@@ -20,11 +20,9 @@ const TryStatement = {
   print: ({ node, path, print }) => {
     let parts = [
       'try',
-      group(
-        printSeparatedItem(path.call(print, 'expression'), {
-          firstSeparator: line
-        })
-      )
+      printSeparatedItem(path.call(print, 'expression'), {
+        firstSeparator: line
+      })
     ];
 
     const formattedReturnParameters = returnParameters(node, path, print);

--- a/src/nodes/WhileStatement.js
+++ b/src/nodes/WhileStatement.js
@@ -13,7 +13,9 @@ const printBody = (node, path, print) =>
 
 const WhileStatement = {
   print: ({ node, path, print }) => [
-    group(['while (', printSeparatedItem(path.call(print, 'condition')), ')']),
+    'while (',
+    printSeparatedItem(path.call(print, 'condition')),
+    ')',
     printBody(node, path, print)
   ]
 };

--- a/src/nodes/print-separated-item.js
+++ b/src/nodes/print-separated-item.js
@@ -1,17 +1,21 @@
 const {
   doc: {
-    builders: { indent, softline }
+    builders: { group, indent, softline }
   }
 } = require('prettier');
 
 // This function will add an indentation to the `item` and separate it from the
 // rest of the `doc` in most cases by a `softline`.
-//
-// NOTE: it doesn't `group` the resulting `doc` because single items can also be
-// part of a larger structure.
 const printSeparatedItem = (
   item,
-  { firstSeparator = softline, lastSeparator = firstSeparator } = {}
-) => [indent([firstSeparator, item]), lastSeparator];
+  {
+    firstSeparator = softline,
+    lastSeparator = firstSeparator,
+    grouped = true
+  } = {}
+) => {
+  const doc = [indent([firstSeparator, item]), lastSeparator];
+  return grouped ? group(doc) : doc;
+};
 
 module.exports = printSeparatedItem;


### PR DESCRIPTION
`print-separated-item` behaves the same as `print-separated-list`