### PR TITLE
Upgrade parser and fix several issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.4.tgz",
-      "integrity": "sha512-AQ9s1g1NrrN8DTgyQHLvxeUBq7RtJ4zKZdlLe+GzRcsD7dGtC5K7+1YcCqits7Z+tGnX5MyXx3QKO9+vc+McQw==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
+      "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.3.tgz",
-      "integrity": "sha512-29g2SZ29HtsqA58pLCtopI1P/cPy5/UAzlcAXO6T/CNJimG6yA8kx4NaseMyJULiC+TEs02Y9/yeHzClqoA0hw==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.4.tgz",
+      "integrity": "sha512-AQ9s1g1NrrN8DTgyQHLvxeUBq7RtJ4zKZdlLe+GzRcsD7dGtC5K7+1YcCqits7Z+tGnX5MyXx3QKO9+vc+McQw==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
       }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "solc": "^0.8.17"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.14.4",
+    "@solidity-parser/parser": "^0.14.5",
     "emoji-regex": "^10.1.0",
     "escape-string-regexp": "^4.0.0",
     "semver": "^7.3.7",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "solc": "^0.8.17"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.14.3",
+    "@solidity-parser/parser": "^0.14.4",
     "emoji-regex": "^10.1.0",
     "escape-string-regexp": "^4.0.0",
     "semver": "^7.3.7",

--- a/src/binary-operator-printers/index.js
+++ b/src/binary-operator-printers/index.js
@@ -1,4 +1,4 @@
-/* This file was automatically generated on 1657595765.198 */
+/* This file was automatically generated on 1666691919.933 */
 
 /* eslint-disable global-require */
 

--- a/src/nodes/AssemblyStackAssignment.js
+++ b/src/nodes/AssemblyStackAssignment.js
@@ -1,0 +1,12 @@
+const {
+  doc: {
+    builders: { join }
+  }
+} = require('prettier');
+
+const AssemblyAssignment = {
+  print: ({ node, path, print }) =>
+    join(' ', [path.call(print, 'expression'), '=:', node.name])
+};
+
+module.exports = AssemblyAssignment;

--- a/src/nodes/AssemblyStackAssignment.js
+++ b/src/nodes/AssemblyStackAssignment.js
@@ -1,12 +1,9 @@
-const {
-  doc: {
-    builders: { join }
-  }
-} = require('prettier');
-
 const AssemblyAssignment = {
-  print: ({ node, path, print }) =>
-    join(' ', [path.call(print, 'expression'), '=:', node.name])
+  print: ({ node, path, print }) => [
+    path.call(print, 'expression'),
+    ' =: ',
+    node.name
+  ]
 };
 
 module.exports = AssemblyAssignment;

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -1,4 +1,4 @@
-/* This file was automatically generated on 1657595765.093 */
+/* This file was automatically generated on 1666691919.885 */
 
 /* eslint-disable global-require */
 
@@ -13,6 +13,7 @@ module.exports = {
   AssemblyIf: require('./AssemblyIf'),
   AssemblyLocalDefinition: require('./AssemblyLocalDefinition'),
   AssemblyMemberAccess: require('./AssemblyMemberAccess'),
+  AssemblyStackAssignment: require('./AssemblyStackAssignment'),
   AssemblySwitch: require('./AssemblySwitch'),
   BinaryOperation: require('./BinaryOperation'),
   Block: require('./Block'),

--- a/tests/format/Assembly/Assembly.sol
+++ b/tests/format/Assembly/Assembly.sol
@@ -201,3 +201,13 @@ for { let i := 0 } lt(i, x) { i := add(i, 1) } {
 }
 }
 }
+
+contract BooleanLiteralsInAssembly {
+  function f() {
+    uint a;
+    assembly {
+      a := true
+      a := false
+    }
+  }
+}

--- a/tests/format/Assembly/Assembly.sol
+++ b/tests/format/Assembly/Assembly.sol
@@ -211,3 +211,16 @@ contract BooleanLiteralsInAssembly {
     }
   }
 }
+
+contract MultipleAssemblyAssignement {
+    function foo() public pure {
+        assembly {
+            function bar() -> a, b {
+                a := 1
+                b := 2
+            }
+
+            let i, j := bar()
+        }
+    }
+}

--- a/tests/format/Assembly/Assembly.sol
+++ b/tests/format/Assembly/Assembly.sol
@@ -224,3 +224,11 @@ contract MultipleAssemblyAssignement {
         }
     }
 }
+
+contract AssemblyStackAssignment {
+  function f() public {
+    assembly {
+      4 =: y
+    }
+  }
+}

--- a/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
@@ -210,6 +210,16 @@ for { let i := 0 } lt(i, x) { i := add(i, 1) } {
 }
 }
 
+contract BooleanLiteralsInAssembly {
+  function f() {
+    uint a;
+    assembly {
+      a := true
+      a := false
+    }
+  }
+}
+
 =====================================output=====================================
 contract Assembly {
     function ifAssembly() {
@@ -450,6 +460,16 @@ contract Assembly {
 
                 b := i
             }
+        }
+    }
+}
+
+contract BooleanLiteralsInAssembly {
+    function f() {
+        uint a;
+        assembly {
+            a := true
+            a := false
         }
     }
 }

--- a/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
@@ -220,6 +220,19 @@ contract BooleanLiteralsInAssembly {
   }
 }
 
+contract MultipleAssemblyAssignement {
+    function foo() public pure {
+        assembly {
+            function bar() -> a, b {
+                a := 1
+                b := 2
+            }
+
+            let i, j := bar()
+        }
+    }
+}
+
 =====================================output=====================================
 contract Assembly {
     function ifAssembly() {
@@ -470,6 +483,19 @@ contract BooleanLiteralsInAssembly {
         assembly {
             a := true
             a := false
+        }
+    }
+}
+
+contract MultipleAssemblyAssignement {
+    function foo() public pure {
+        assembly {
+            function bar() -> a, b {
+                a := 1
+                b := 2
+            }
+
+            let i, j := bar()
         }
     }
 }

--- a/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Assembly/__snapshots__/jsfmt.spec.js.snap
@@ -233,6 +233,14 @@ contract MultipleAssemblyAssignement {
     }
 }
 
+contract AssemblyStackAssignment {
+  function f() public {
+    assembly {
+      4 =: y
+    }
+  }
+}
+
 =====================================output=====================================
 contract Assembly {
     function ifAssembly() {
@@ -496,6 +504,14 @@ contract MultipleAssemblyAssignement {
             }
 
             let i, j := bar()
+        }
+    }
+}
+
+contract AssemblyStackAssignment {
+    function f() public {
+        assembly {
+            4 =: y
         }
     }
 }

--- a/tests/format/MemberAccess/MemberAccess.sol
+++ b/tests/format/MemberAccess/MemberAccess.sol
@@ -57,6 +57,11 @@ contract MemberAccess {
             path,
             address(this, aoeu, aoeueu, aoeu)
         );
+        vm.mockCall(
+            f.address,
+            abi.encodeWithSelector(f.selector),
+            abi.encode(returned1)
+        );
     }
 }
 

--- a/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/MemberAccess/__snapshots__/jsfmt.spec.js.snap
@@ -65,6 +65,11 @@ contract MemberAccess {
             path,
             address(this, aoeu, aoeueu, aoeu)
         );
+        vm.mockCall(
+            f.address,
+            abi.encodeWithSelector(f.selector),
+            abi.encode(returned1)
+        );
     }
 }
 
@@ -108,6 +113,7 @@ contract MemberAccessIsEndOfChainCases {
         return b.c;
     }
 }
+
 =====================================output=====================================
 pragma solidity ^0.5.0;
 
@@ -195,6 +201,11 @@ contract MemberAccess {
                 path,
                 address(this, aoeu, aoeueu, aoeu)
             );
+        vm.mockCall(
+            f.address,
+            abi.encodeWithSelector(f.selector),
+            abi.encode(returned1)
+        );
     }
 }
 


### PR DESCRIPTION
Closes #677.

The problem reported in that issue is not the type function (which was already supported by the parser). The problem was the `f.address` part, which was causing an error because address is a special keyword that needs special handling.

Closes #602.

Also: add support for the `AssemblyStackAssignement` node.