### PR TITLE
Omit last line if there's a parent parser

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 coverage/**/*.js
 tests/format/**/*.sol
+tests/format/Markdown/Markdown.md
 tests/format/RespectDefaultOptions/respect-default-options.js
 tests/config/**/*.js
 src/prettier-comments/**/*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 coverage/**/*.js
 tests/format/**/*.sol
+tests/format/Markdown/Markdown.md
 tests/format/RespectDefaultOptions/respect-default-options.js
 src/prettier-comments/**/*.js

--- a/src/nodes/SourceUnit.js
+++ b/src/nodes/SourceUnit.js
@@ -9,7 +9,7 @@ const printPreservingEmptyLines = require('./print-preserving-empty-lines');
 const SourceUnit = {
   print: ({ options, path, print }) => [
     printPreservingEmptyLines(path, 'children', options, print),
-    line
+    options.parentParser ? '' : line
   ]
 };
 

--- a/tests/config/require-standalone.js
+++ b/tests/config/require-standalone.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const prettier = require("prettier/standalone");
+const markdownPlugin = require("prettier/parser-markdown");
 const babelPlugin = require("prettier/parser-babel");
 const solidityPlugin = require("../../src/index");
 
@@ -8,7 +9,12 @@ module.exports = {
   formatWithCursor(input, options) {
     const $$$options = {
       ...options,
-      plugins: [babelPlugin, solidityPlugin, ...(options.plugins || [])],
+      plugins: [
+        babelPlugin,
+        markdownPlugin,
+        solidityPlugin,
+        ...(options.plugins || []),
+      ],
     };
     return prettier.formatWithCursor(input, $$$options);
   },
@@ -17,7 +23,12 @@ module.exports = {
     parse(input, options, massage) {
       const $$$options = {
         ...options,
-        plugins: [babelPlugin, solidityPlugin, ...(options.plugins || [])],
+        plugins: [
+          babelPlugin,
+          markdownPlugin,
+          solidityPlugin,
+          ...(options.plugins || []),
+        ],
       };
       return prettier.__debug.parse(input, $$$options, massage);
     },

--- a/tests/format/Markdown/Markdown.md
+++ b/tests/format/Markdown/Markdown.md
@@ -1,0 +1,13 @@
+# Embedded Solidity Code
+
+- original
+
+<!-- prettier-ignore -->
+```solidity
+import    "./Foo.sol";
+```
+
+- formatted
+```solidity
+import    "./Foo.sol";
+```

--- a/tests/format/Markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/Markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Markdown.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+# Embedded Solidity Code
+
+- original
+
+<!-- prettier-ignore -->
+\`\`\`solidity
+import    "./Foo.sol";
+\`\`\`
+
+- formatted
+\`\`\`solidity
+import    "./Foo.sol";
+\`\`\`
+
+=====================================output=====================================
+# Embedded Solidity Code
+
+- original
+
+<!-- prettier-ignore -->
+\`\`\`solidity
+import    "./Foo.sol";
+\`\`\`
+
+- formatted
+
+\`\`\`solidity
+import "./Foo.sol";
+\`\`\`
+
+================================================================================
+`;

--- a/tests/format/Markdown/jsfmt.spec.js
+++ b/tests/format/Markdown/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ['markdown']);


### PR DESCRIPTION
Relates to #764

Could be unnecessary once Prettier fixes the bug on their side. But at least we'll have ready tests for this case.