### PR TITLE
moving the split of the logic coupled to the Prettier version to prin…

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,6 +1,6 @@
 {
   "check-coverage": true,
-  "branches": 98,
+  "branches": 99,
   "lines": 99,
   "functions": 100,
   "statements": 99,

--- a/src/nodes/ExpressionStatement.js
+++ b/src/nodes/ExpressionStatement.js
@@ -3,7 +3,6 @@ const {
     builders: { hardline }
   }
 } = require('prettier');
-const { prettierVersionSatisfies } = require('../common/util');
 
 const printComments = require('./print-comments');
 
@@ -16,10 +15,7 @@ const ExpressionStatement = {
     if (parent.type === 'IfStatement') {
       if (node.comments && node.comments.length) {
         const comments = printComments(node, path, options);
-        const hasComments = prettierVersionSatisfies('^2.3.0')
-          ? comments && comments.parts && comments.parts.length // Prettier V2
-          : comments && comments.length; // Prettier V3
-        if (hasComments) {
+        if (comments && comments.length) {
           parts.push(comments);
           parts.push(hardline);
         }

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -4,7 +4,6 @@ const {
   },
   util: { getNextNonSpaceNonCommentCharacterIndex }
 } = require('prettier');
-const { prettierVersionSatisfies } = require('../common/util');
 
 const printSeparatedList = require('./print-separated-list');
 const printSeparatedItem = require('./print-separated-item');
@@ -48,10 +47,9 @@ const parameters = (parametersType, node, path, print, options) => {
           )
         ) === ')'
     );
-    const hasComments = prettierVersionSatisfies('^2.3.0')
-      ? parameterComments.parts.length > 0 // Prettier V2
-      : parameterComments.length > 0; // Prettier V3
-    return hasComments ? printSeparatedItem(parameterComments) : '';
+    return parameterComments.length > 0
+      ? printSeparatedItem(parameterComments)
+      : '';
   }
   return '';
 };

--- a/src/nodes/print-comments.js
+++ b/src/nodes/print-comments.js
@@ -3,25 +3,35 @@ const {
     builders: { join, line }
   }
 } = require('prettier');
+const { prettierVersionSatisfies } = require('../common/util');
 
-const printComments = (node, path, options, filter = () => true) =>
-  node.comments
-    ? join(
-        line,
-        path
-          .map((commentPath) => {
-            const comment = commentPath.getValue();
-            if (comment.trailing || comment.leading || comment.printed) {
-              return null;
-            }
-            if (!filter(comment)) {
-              return null;
-            }
-            comment.printed = true;
-            return options.printer.printComment(commentPath);
-          }, 'comments')
-          .filter(Boolean)
-      )
-    : '';
+const printComments = (node, path, options, filter = () => true) => {
+  if (!node.comments) return '';
+  const doc = join(
+    line,
+    path
+      .map((commentPath) => {
+        const comment = commentPath.getValue();
+        if (comment.trailing || comment.leading || comment.printed) {
+          return null;
+        }
+        if (!filter(comment)) {
+          return null;
+        }
+        comment.printed = true;
+        return options.printer.printComment(commentPath);
+      }, 'comments')
+      .filter(Boolean)
+  );
+
+  // The following if statement will never be 100% covered in a single run
+  // since it depends on the version of Prettier being used.
+  // Mocking the behaviour will introduce a lot of maintenance in the tests.
+  /* c8 ignore start */
+  return prettierVersionSatisfies('^2.3.0')
+    ? doc.parts // Prettier V2
+    : doc; // Prettier V3
+  /* c8 ignore stop */
+};
 
 module.exports = printComments;


### PR DESCRIPTION
The mayor logic change was because the builder `join` would return a `concat` object in V2 and an array in V3. Normally this would not affect our plugin except when we print comments since checking for the length in V2 we ask `comments.parts.length` and in V3 we ask `comments.length`.

By deciding to return always an array in `printComments`, we simplify the logic regarding Prettier's version everywhere.

Since this branch will never be fully covered by our tests we can also ignore this line from the `c8` coverage.