### PR TITLE
removing unused package jest-mock-now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "exports-loader": "^4.0.0",
         "jest": "^29.6.1",
         "jest-light-runner": "^0.5.0",
-        "jest-mock-now": "^1.3.0",
         "jest-snapshot-serializer-ansi": "^2.1.0",
         "jest-snapshot-serializer-raw": "^1.2.0",
         "jest-watch-typeahead": "^2.2.2",
@@ -2664,9 +2663,9 @@
       }
     },
     "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3905,9 +3904,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4292,12 +4291,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-mock-now": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-now/-/jest-mock-now-1.3.0.tgz",
-      "integrity": "sha512-EGikN9thoUwc3nVDN3DIcmNWA6qLELjM54df66CrqxZECBUVkddyaluoPunTL4FxOxMI8XF/JsqWO1NTSe48Wg==",
-      "dev": true
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
@@ -5912,9 +5905,9 @@
       }
     },
     "node_modules/solc/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "exports-loader": "^4.0.0",
     "jest": "^29.6.1",
     "jest-light-runner": "^0.5.0",
-    "jest-mock-now": "^1.3.0",
     "jest-snapshot-serializer-ansi": "^2.1.0",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "jest-watch-typeahead": "^2.2.2",


### PR DESCRIPTION
This package was used for a specific test that we don't use anymore.