### PR TITLE
Remove gitcoin paragraph

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: ['https://gitcoin.co/grants/1534/prettier-solidity']

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 A [Prettier plugin](https://prettier.io/docs/en/plugins.html) for automatically formatting your [Solidity](https://github.com/ethereum/solidity) code.
 
-If you like this project, please consider contributing to our [Gitcoin grant](https://gitcoin.co/grants/1534/prettier-solidity)!
-
 ## Installation and usage
 
 ### Using in NodeJS


### PR DESCRIPTION
We could link to the new gitcoin page, but the behavior seems to be completely different and there doesn't seem to be a "Donation" option outside rounds. And since the current link is broken, I'd say we just remove it for now.