### PR TITLE
Full tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+import prettier from 'prettier';
+import satisfies from 'semver/functions/satisfies.js';
+
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const testMatch = [
   '<rootDir>/tests/format/**/jsfmt.spec.js',
@@ -19,13 +22,13 @@ export default {
   testEnvironment: 'node',
   // ignore console warnings in TEST_STANDALONE
   silent: TEST_STANDALONE,
-  testPathIgnorePatterns: TEST_STANDALONE
+  testPathIgnorePatterns: satisfies(prettier.version, '^2.3.0')
     ? [
         // Standalone mode doesn't have default options.
         // This has been reported https://github.com/prettier/prettier/issues/11107
         'tests/format/RespectDefaultOptions'
-      ]
-    : [],
+      ] // Ignore on v2
+    : [], // fixed on V3
   testMatch,
   transform: {},
   watchPlugins: [

--- a/tests/config/require-standalone.cjs
+++ b/tests/config/require-standalone.cjs
@@ -12,15 +12,19 @@ const pluginPrefix = isPrettier2
   ? "parser-" // Prettier V2
   : "plugins/"; // Prettier V3
 
-let files = [
-  path.join(prettierPath, "standalone.js"),
+const plugins = [
   path.join(prettierPath, `${pluginPrefix}babel.js`),
   path.join(prettierPath, `${pluginPrefix}markdown.js`),
   path.join(__dirname, "../../dist/standalone.cjs"),
 ];
 
-if (!isPrettier2)
-  files = [path.join(prettierPath, `${pluginPrefix}estree.js`), ...files];
+const files = isPrettier2
+  ? [path.join(prettierPath, "standalone.js"), ...plugins]
+  : [
+      path.join(prettierPath, "standalone.js"),
+      path.join(prettierPath, `${pluginPrefix}estree.js`),
+      ...plugins,
+    ];
 
 const sandbox = createSandBox({ files });
 

--- a/tests/config/require-standalone.cjs
+++ b/tests/config/require-standalone.cjs
@@ -7,18 +7,22 @@ const satisfies = require("semver/functions/satisfies");
 const createSandBox = require("./utils/create-sandbox.cjs");
 
 const prettierPath = path.dirname(require.resolve("prettier"));
-const pluginPrefix = satisfies(prettier.version, "^2.3.0")
+const isPrettier2 = satisfies(prettier.version, "^2.3.0");
+const pluginPrefix = isPrettier2
   ? "parser-" // Prettier V2
   : "plugins/"; // Prettier V3
 
-const sandbox = createSandBox({
-  files: [
-    path.join(prettierPath, "standalone.js"),
-    path.join(prettierPath, `${pluginPrefix}babel.js`),
-    path.join(prettierPath, `${pluginPrefix}markdown.js`),
-    path.join(__dirname, "../../dist/standalone.cjs"),
-  ],
-});
+let files = [
+  path.join(prettierPath, "standalone.js"),
+  path.join(prettierPath, `${pluginPrefix}babel.js`),
+  path.join(prettierPath, `${pluginPrefix}markdown.js`),
+  path.join(__dirname, "../../dist/standalone.cjs"),
+];
+
+if (!isPrettier2)
+  files = [path.join(prettierPath, `${pluginPrefix}estree.js`), ...files];
+
+const sandbox = createSandBox({ files });
 
 // TODO: maybe expose (and write tests) for `format`, `utils`, and
 // `__debug` methods

--- a/tests/config/require-standalone.cjs
+++ b/tests/config/require-standalone.cjs
@@ -13,7 +13,6 @@ const pluginPrefix = isPrettier2
   : "plugins/"; // Prettier V3
 
 const plugins = [
-  path.join(prettierPath, `${pluginPrefix}babel.js`),
   path.join(prettierPath, `${pluginPrefix}markdown.js`),
   path.join(__dirname, "../../dist/standalone.cjs"),
 ];
@@ -22,6 +21,7 @@ const files = isPrettier2
   ? [path.join(prettierPath, "standalone.js"), ...plugins]
   : [
       path.join(prettierPath, "standalone.js"),
+      path.join(prettierPath, `${pluginPrefix}babel.js`),
       path.join(prettierPath, `${pluginPrefix}estree.js`),
       ...plugins,
     ];


### PR DESCRIPTION
in V2 there was an unexpected behaviour that would only trigger in the `standalone` files where Prettier's default options would be replaced by our default options.

The uncompiled versions would work as expected.

This is a more obscure test that we were avoiding to run in V2 but got fixed on V3.

In this PR we are making sure to run it with V3 compiled and uncompiled.
