### PR TITLE
replacing `getValue` on V3

### DIFF
--- a/src/binary-operator-printers/arithmetic.js
+++ b/src/binary-operator-printers/arithmetic.js
@@ -1,5 +1,6 @@
 import { doc } from 'prettier';
 import { comparison } from './comparison.js';
+import { getNode } from '../common/backward-compatibility.js';
 
 const { group, line, indent } = doc.builders;
 
@@ -15,7 +16,7 @@ const groupIfNecessaryBuilder = (path) => (document) => {
 };
 
 const indentIfNecessaryBuilder = (path) => (document) => {
-  let node = path.getNode();
+  let node = getNode(path);
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
     if (parentNode.type === 'ReturnStatement') return document;

--- a/src/binary-operator-printers/comparison.js
+++ b/src/binary-operator-printers/comparison.js
@@ -1,9 +1,10 @@
 import { doc } from 'prettier';
+import { getNode } from '../common/backward-compatibility.js';
 
 const { group, indent, line } = doc.builders;
 
 const indentIfNecessaryBuilder = (path) => (document) => {
-  let node = path.getNode();
+  let node = getNode(path);
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
     if (parentNode.type === 'ReturnStatement') return document;

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -1,4 +1,5 @@
 import { doc } from 'prettier';
+import { getNode } from '../common/backward-compatibility.js';
 
 const { group, line, indent } = doc.builders;
 
@@ -6,7 +7,7 @@ const groupIfNecessaryBuilder = (path) => (document) =>
   path.getParentNode().type === 'BinaryOperation' ? document : group(document);
 
 const indentIfNecessaryBuilder = (path, options) => (document) => {
-  let node = path.getNode();
+  let node = getNode(path);
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
     if (parentNode.type === 'ReturnStatement') return document;

--- a/src/comments/ignore.js
+++ b/src/comments/ignore.js
@@ -1,5 +1,7 @@
+import { getNode } from '../common/backward-compatibility.js';
+
 function ignoreComments(path) {
-  const node = path.getValue();
+  const node = getNode(path);
   // We ignore anything that is not an object
   if (node === null || typeof node !== 'object') return;
 
@@ -13,7 +15,7 @@ function ignoreComments(path) {
       // The key `comments` will contain every comment for this node
       case 'comments':
         path.each((commentPath) => {
-          const comment = commentPath.getValue();
+          const comment = getNode(commentPath);
           comment.printed = true;
         }, 'comments');
         break;

--- a/src/comments/printer.js
+++ b/src/comments/printer.js
@@ -1,4 +1,5 @@
 import { doc, util } from 'prettier';
+import { getNode } from '../common/backward-compatibility.js';
 
 const { hardline, join } = doc.builders;
 
@@ -29,7 +30,7 @@ function printIndentableBlockComment(comment) {
 }
 
 export function printComment(commentPath, options) {
-  const comment = commentPath.getValue();
+  const comment = getNode(commentPath);
 
   switch (comment.type) {
     case 'BlockComment': {

--- a/src/common/backward-compatibility.js
+++ b/src/common/backward-compatibility.js
@@ -27,8 +27,7 @@ export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
     : util.getNextNonSpaceNonCommentCharacter(text, locEnd(node)); // V3 exposes this function directly
 }
 
-export const getNode = (path) =>
-  isPrettier2 ? path.getValue() : path.getNode(); // V3 deprecated `getValue`
+export const getNode = (path) => (isPrettier2 ? path.getValue() : path.node); // V3 deprecated `getValue`
 
 export function isLast(path, key, index) {
   return isPrettier2

--- a/src/common/backward-compatibility.js
+++ b/src/common/backward-compatibility.js
@@ -27,6 +27,9 @@ export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
     : util.getNextNonSpaceNonCommentCharacter(text, locEnd(node)); // V3 exposes this function directly
 }
 
+export const getNode = (path) =>
+  isPrettier2 ? path.getValue() : path.getNode(); // V3 deprecated `getValue`
+
 export function isLast(path, key, index) {
   return isPrettier2
     ? index === path.getParentNode()[key].length - 1

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -1,5 +1,6 @@
 import { doc } from 'prettier';
 import {
+  getNode,
   isLast,
   isNextLineEmpty,
   isPrettier2
@@ -13,7 +14,7 @@ export const printComments = (node, path, options, filter = () => true) => {
     line,
     path
       .map((commentPath) => {
-        const comment = commentPath.getValue();
+        const comment = getNode(commentPath);
         if (comment.trailing || comment.leading || comment.printed) {
           return null;
         }
@@ -39,7 +40,7 @@ export const printComments = (node, path, options, filter = () => true) => {
 export function printPreservingEmptyLines(path, key, options, print) {
   const parts = [];
   path.each((childPath, index) => {
-    const node = childPath.getValue();
+    const node = getNode(childPath);
     const nodeType = node.type;
 
     if (

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,4 +1,5 @@
 import * as nodes from './nodes/index.js';
+import { getNode } from './common/backward-compatibility.js';
 import {
   hasNodeIgnoreComment,
   prettierVersionSatisfies
@@ -20,7 +21,7 @@ function prettierVersionCheck() {
 function genericPrint(path, options, print) {
   prettierVersionCheck();
 
-  const node = path.getValue();
+  const node = getNode(path);
   if (node === null) {
     return '';
   }

--- a/tests/unit/binary-operation.test.js
+++ b/tests/unit/binary-operation.test.js
@@ -1,16 +1,13 @@
 import genericPrint from '../../src/printer.js';
 
 test('given an unknown operator then the BinaryOperation print function should throw', () => {
-  const mockPath = {
-    getNode: () => ({ type: 'BinaryOperation', operator: '?' })
-  };
-  const node = mockPath.getNode();
+  const mockPath = { node: { type: 'BinaryOperation', operator: '?' } };
 
   expect(() => {
     genericPrint(mockPath);
   }).toThrow(
     `Assertion error: no printer found for operator ${JSON.stringify(
-      node.operator
+      mockPath.node.operator
     )}`
   );
 });

--- a/tests/unit/binary-operation.test.js
+++ b/tests/unit/binary-operation.test.js
@@ -2,9 +2,9 @@ import genericPrint from '../../src/printer.js';
 
 test('given an unknown operator then the BinaryOperation print function should throw', () => {
   const mockPath = {
-    getValue: () => ({ type: 'BinaryOperation', operator: '?' })
+    getNode: () => ({ type: 'BinaryOperation', operator: '?' })
   };
-  const node = mockPath.getValue();
+  const node = mockPath.getNode();
 
   expect(() => {
     genericPrint(mockPath);

--- a/tests/unit/comments/printer.test.js
+++ b/tests/unit/comments/printer.test.js
@@ -3,7 +3,7 @@ import loc from '../../../src/loc.js';
 
 test('given an unknown comment type then printComment function should throw', () => {
   const mockCommentPath = {
-    getValue: () => ({ type: 'UnknownComment', range: [0, 1] })
+    getNode: () => ({ type: 'UnknownComment', range: [0, 1] })
   };
   const mockOptions = { ...loc, originalText: 'foo' };
 

--- a/tests/unit/comments/printer.test.js
+++ b/tests/unit/comments/printer.test.js
@@ -2,9 +2,7 @@ import { printComment } from '../../../src/comments/printer.js';
 import loc from '../../../src/loc.js';
 
 test('given an unknown comment type then printComment function should throw', () => {
-  const mockCommentPath = {
-    getNode: () => ({ type: 'UnknownComment', range: [0, 1] })
-  };
+  const mockCommentPath = { node: { type: 'UnknownComment', range: [0, 1] } };
   const mockOptions = { ...loc, originalText: 'foo' };
 
   expect(() => {

--- a/tests/unit/printer.test.js
+++ b/tests/unit/printer.test.js
@@ -1,18 +1,17 @@
 import genericPrint from '../../src/printer.js';
 
 test('given an unknown module type then genericPrint function should throw', () => {
-  const mockPath = { getNode: () => ({ type: 'UnknownModule' }) };
-  const node = mockPath.getNode();
+  const mockPath = { node: { type: 'UnknownModule' } };
 
   expect(() => {
     genericPrint(mockPath);
-  }).toThrow(`Unknown type: ${JSON.stringify(node.type)}`);
+  }).toThrow(`Unknown type: ${JSON.stringify(mockPath.node.type)}`);
 });
 
 test('if the AST contains a null node, print an empty string', () => {
   // Prettier V3 avoids returning null when traversing the AST, but V2 does not.
   // By mocking this, we ensure both cases are covered.
-  const mockPath = { getNode: () => null };
+  const mockPath = { node: null };
 
   expect(genericPrint(mockPath)).toEqual('');
 });

--- a/tests/unit/printer.test.js
+++ b/tests/unit/printer.test.js
@@ -1,8 +1,8 @@
 import genericPrint from '../../src/printer.js';
 
 test('given an unknown module type then genericPrint function should throw', () => {
-  const mockPath = { getValue: () => ({ type: 'UnknownModule' }) };
-  const node = mockPath.getValue();
+  const mockPath = { getNode: () => ({ type: 'UnknownModule' }) };
+  const node = mockPath.getNode();
 
   expect(() => {
     genericPrint(mockPath);
@@ -12,7 +12,7 @@ test('given an unknown module type then genericPrint function should throw', () 
 test('if the AST contains a null node, print an empty string', () => {
   // Prettier V3 avoids returning null when traversing the AST, but V2 does not.
   // By mocking this, we ensure both cases are covered.
-  const mockPath = { getValue: () => null };
+  const mockPath = { getNode: () => null };
 
   expect(genericPrint(mockPath)).toEqual('');
 });


### PR DESCRIPTION
future proofing for V4

Caveat:

The optimal solution is to use `path.node()` but there's a bug that I reported here prettier/prettier#15291.
For now using `path.getNode()`.

EDIT

I was informed that the proper way to call it was as a getter `path.node` and not a function.