### PR TITLE
This behaviour was left after we removed the explicitTypes option

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -61,13 +61,6 @@ function parse(text, _parsers, options = _parsers) {
         ? `hex'${ctx.value.slice(4, -1)}'`
         : `hex"${ctx.value.slice(4, -1)}"`;
     },
-    ElementaryTypeName(ctx) {
-      // if the compiler is below 0.8.0 we will recognize the type 'byte' as an
-      // alias of 'bytes1'. Otherwise we will ignore this and enforce always
-      // 'bytes1'.
-      const pre080 = compiler && satisfies(compiler, '<0.8.0');
-      if (!pre080 && ctx.name === 'byte') ctx.name = 'bytes1';
-    },
     BinaryOperation(ctx) {
       switch (ctx.operator) {
         case '+':

--- a/tests/format/BreakingChangesV0.8.0/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/BreakingChangesV0.8.0/__snapshots__/jsfmt.spec.js.snap
@@ -158,16 +158,16 @@ contract BreakingChangesV080 {
      *   use of bytes1.
      */
     bytes1 public c;
-    bytes1 public g;
+    byte public g;
 
     struct S {
         bytes1 c;
-        bytes1 g;
+        byte g;
     }
 
-    event Event(bytes1 _c, bytes1 _g);
+    event Event(bytes1 _c, byte _g);
 
-    function func(bytes1 _c, bytes1 _g) public returns (bytes1, bytes1) {
+    function func(bytes1 _c, byte _g) public returns (bytes1, byte) {
         emit Event(_c, _g);
         return (_c, _g);
     }
@@ -245,16 +245,16 @@ contract BreakingChangesV080 {
      *   use of bytes1.
      */
     bytes1 public c;
-    bytes1 public g;
+    byte public g;
 
     struct S {
         bytes1 c;
-        bytes1 g;
+        byte g;
     }
 
-    event Event(bytes1 _c, bytes1 _g);
+    event Event(bytes1 _c, byte _g);
 
-    function func(bytes1 _c, bytes1 _g) public returns (bytes1, bytes1) {
+    function func(bytes1 _c, byte _g) public returns (bytes1, byte) {
         emit Event(_c, _g);
         return (_c, _g);
     }


### PR DESCRIPTION
The bug only appears when the `compiler` option is smaller than `0.8.0`.
Then all `byte` declarations are changed to `bytes1`.