### PR TITLE
Proposal to avoid separating function definitions without an implementation

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -5,7 +5,11 @@
   "functions": 100,
   "statements": 100,
   "exclude": ["/node_modules/", "/src/prettier-comments/"],
-  "include": ["src/**/*.js", "!src/prettier-comments/**/*.js"],
+  "include": [
+    "src/**/*.js",
+    "!src/prettier-comments/**/*.js",
+    "!src/common/backward-compatibility.js"
+  ],
   "reporter": ["lcov", "text"],
   "temp-dir": "./coverage/"
 }

--- a/src/comments/handlers/handleContractDefinitionComments.js
+++ b/src/comments/handlers/handleContractDefinitionComments.js
@@ -1,5 +1,5 @@
 import { util } from 'prettier';
-import { getNextNonSpaceNonCommentCharacter } from '../../common/util.js';
+import { getNextNonSpaceNonCommentCharacter } from '../../common/backward-compatibility.js';
 
 const { addLeadingComment, addTrailingComment, addDanglingComment } = util;
 

--- a/src/comments/handlers/handleModifierInvocationComments.js
+++ b/src/comments/handlers/handleModifierInvocationComments.js
@@ -1,5 +1,5 @@
 import { util } from 'prettier';
-import { getNextNonSpaceNonCommentCharacter } from '../../common/util.js';
+import { getNextNonSpaceNonCommentCharacter } from '../../common/backward-compatibility.js';
 
 const { addLeadingComment, addTrailingComment, addDanglingComment } = util;
 

--- a/src/common/backward-compatibility.js
+++ b/src/common/backward-compatibility.js
@@ -1,5 +1,7 @@
 import { util } from 'prettier';
-import { isPrettier2 } from './util.js';
+import { prettierVersionSatisfies } from './util.js';
+
+export const isPrettier2 = () => prettierVersionSatisfies('^2.3.0');
 
 // The functions in this file will never be 100% covered in a single run
 // since it depends on the version of Prettier being used.

--- a/src/common/backward-compatibility.js
+++ b/src/common/backward-compatibility.js
@@ -1,26 +1,26 @@
 import { util } from 'prettier';
 import { prettierVersionSatisfies } from './util.js';
 
-export const isPrettier2 = () => prettierVersionSatisfies('^2.3.0');
+export const isPrettier2 = prettierVersionSatisfies('^2.3.0');
 
 // The functions in this file will never be 100% covered in a single run
 // since it depends on the version of Prettier being used.
 // Mocking the behaviour will introduce a lot of maintenance in the tests.
 
 export function isNextLineEmpty(text, startIndex) {
-  return isPrettier2()
+  return isPrettier2
     ? util.isNextLineEmptyAfterIndex(text, startIndex)
     : util.isNextLineEmpty(text, startIndex); // V3 deprecated `isNextLineEmptyAfterIndex`
 }
 
 export function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
-  return isPrettier2()
+  return isPrettier2
     ? util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
     : util.getNextNonSpaceNonCommentCharacterIndex(text, locEnd(node)); // V3 signature changed
 }
 
 export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
-  return isPrettier2()
+  return isPrettier2
     ? text.charAt(
         util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
       )
@@ -28,19 +28,19 @@ export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
 }
 
 export function isFirst(path, _, index) {
-  return isPrettier2() ? index === 0 : path.isFirst;
+  return isPrettier2 ? index === 0 : path.isFirst;
 }
 
 export function isLast(path, key, index) {
-  return isPrettier2()
+  return isPrettier2
     ? index === path.getParentNode()[key].length - 1
     : path.isLast;
 }
 
 export function previous(path, key, index) {
-  return isPrettier2() ? path.getParentNode()[key][index - 1] : path.previous;
+  return isPrettier2 ? path.getParentNode()[key][index - 1] : path.previous;
 }
 
 export function next(path, key, index) {
-  return isPrettier2() ? path.getParentNode()[key][index + 1] : path.next;
+  return isPrettier2 ? path.getParentNode()[key][index + 1] : path.next;
 }

--- a/src/common/backward-compatibility.js
+++ b/src/common/backward-compatibility.js
@@ -1,0 +1,44 @@
+import { util } from 'prettier';
+import { isPrettier2 } from './util.js';
+
+// The functions in this file will never be 100% covered in a single run
+// since it depends on the version of Prettier being used.
+// Mocking the behaviour will introduce a lot of maintenance in the tests.
+
+export function isNextLineEmpty(text, startIndex) {
+  return isPrettier2()
+    ? util.isNextLineEmptyAfterIndex(text, startIndex)
+    : util.isNextLineEmpty(text, startIndex); // V3 deprecated `isNextLineEmptyAfterIndex`
+}
+
+export function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+  return isPrettier2()
+    ? util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
+    : util.getNextNonSpaceNonCommentCharacterIndex(text, locEnd(node)); // V3 signature changed
+}
+
+export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
+  return isPrettier2()
+    ? text.charAt(
+        util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
+      )
+    : util.getNextNonSpaceNonCommentCharacter(text, locEnd(node)); // V3 exposes this function directly
+}
+
+export function isFirst(path, _, index) {
+  return isPrettier2() ? index === 0 : path.isFirst;
+}
+
+export function isLast(path, key, index) {
+  return isPrettier2()
+    ? index === path.getParentNode()[key].length - 1
+    : path.isLast;
+}
+
+export function previous(path, key, index) {
+  return isPrettier2() ? path.getParentNode()[key][index - 1] : path.previous;
+}
+
+export function next(path, key, index) {
+  return isPrettier2() ? path.getParentNode()[key][index + 1] : path.next;
+}

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -1,5 +1,12 @@
 import { doc } from 'prettier';
-import { isNextLineEmpty, isPrettier2 } from './util.js';
+import {
+  isFirst,
+  isLast,
+  isNextLineEmpty,
+  isPrettier2,
+  next,
+  previous
+} from './util.js';
 
 const { group, indent, join, line, softline, hardline } = doc.builders;
 
@@ -51,7 +58,7 @@ const separatingLine = (firstNode, secondNode) =>
 
 export function printPreservingEmptyLines(path, key, options, print) {
   const parts = [];
-  path.each((childPath) => {
+  path.each((childPath, index) => {
     const node = childPath.getValue();
     const nodeType = node.type;
 
@@ -65,11 +72,14 @@ export function printPreservingEmptyLines(path, key, options, print) {
       parts.push(hardline);
     }
 
-    if (!childPath.isFirst && parts[parts.length - 2] !== hardline) {
+    if (
+      !isFirst(childPath, key, index) &&
+      parts[parts.length - 2] !== hardline
+    ) {
       if (nodeType === 'ContractDefinition') {
         parts.push(hardline);
       } else if (nodeType === 'FunctionDefinition') {
-        parts.push(separatingLine(childPath.previous, node));
+        parts.push(separatingLine(previous(childPath, key, index), node));
       }
     }
 
@@ -77,8 +87,11 @@ export function printPreservingEmptyLines(path, key, options, print) {
 
     if (isNextLineEmpty(options.originalText, options.locEnd(node) + 1)) {
       parts.push(hardline);
-    } else if (nodeType === 'FunctionDefinition' && !childPath.isLast) {
-      parts.push(separatingLine(node, childPath.next));
+    } else if (
+      nodeType === 'FunctionDefinition' &&
+      !isLast(childPath, key, index)
+    ) {
+      parts.push(separatingLine(node, next(childPath, key, index)));
     }
   }, key);
 

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -72,24 +72,37 @@ export function printPreservingEmptyLines(path, key, options, print) {
       parts.push(hardline);
     }
 
+    // Only attempt to prepend an empty line if `node` is not the first item
+    // and an empty line hasn't already been appended after the previous `node`
     if (
       !isFirst(childPath, key, index) &&
       parts[parts.length - 2] !== hardline
     ) {
-      if (nodeType === 'ContractDefinition') {
-        parts.push(hardline);
-      } else if (nodeType === 'FunctionDefinition') {
+      if (nodeType === 'FunctionDefinition') {
+        // Prepend FunctionDefinition with an empty line if there should be a
+        // separation with the previous `node`
         parts.push(separatingLine(previous(childPath, key, index), node));
+      } else if (nodeType === 'ContractDefinition') {
+        // Prepend ContractDefinition with an empty line
+        parts.push(hardline);
       }
     }
 
     parts.push(print(childPath));
 
+    // Only attempt to append an empty line if `node` is not the last item
     if (!isLast(childPath, key, index)) {
       if (isNextLineEmpty(options.originalText, options.locEnd(node) + 1)) {
+        // Append an empty line if the original text already had an one after
+        // the current `node`
         parts.push(hardline);
       } else if (nodeType === 'FunctionDefinition') {
+        // Append FunctionDefinition with an empty line if there should be a
+        // separation with the next `node`
         parts.push(separatingLine(node, next(childPath, key, index)));
+      } else if (nodeType === 'ContractDefinition') {
+        // Append ContractDefinition with an empty line
+        parts.push(hardline);
       }
     }
   }, key);

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -1,12 +1,12 @@
 import { doc } from 'prettier';
+import { isPrettier2 } from './util.js';
 import {
   isFirst,
   isLast,
   isNextLineEmpty,
-  isPrettier2,
   next,
   previous
-} from './util.js';
+} from './backward-compatibility.js';
 
 const { group, indent, join, line, softline, hardline } = doc.builders;
 

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -85,19 +85,14 @@ export function printPreservingEmptyLines(path, key, options, print) {
 
     parts.push(print(childPath));
 
-    if (isNextLineEmpty(options.originalText, options.locEnd(node) + 1)) {
-      parts.push(hardline);
-    } else if (
-      nodeType === 'FunctionDefinition' &&
-      !isLast(childPath, key, index)
-    ) {
-      parts.push(separatingLine(node, next(childPath, key, index)));
+    if (!isLast(childPath, key, index)) {
+      if (isNextLineEmpty(options.originalText, options.locEnd(node) + 1)) {
+        parts.push(hardline);
+      } else if (nodeType === 'FunctionDefinition') {
+        parts.push(separatingLine(node, next(childPath, key, index)));
+      }
     }
   }, key);
-
-  if (parts.length > 1 && parts[parts.length - 1] === hardline) {
-    parts.pop();
-  }
 
   return parts;
 }

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -33,7 +33,7 @@ export const printComments = (node, path, options, filter = () => true) => {
   // since it depends on the version of Prettier being used.
   // Mocking the behaviour will introduce a lot of maintenance in the tests.
   /* c8 ignore start */
-  return isPrettier2()
+  return isPrettier2
     ? document.parts // Prettier V2
     : document; // Prettier V3
   /* c8 ignore stop */

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -39,7 +39,7 @@ export const printComments = (node, path, options, filter = () => true) => {
   /* c8 ignore stop */
 };
 
-const shouldHaveEmptyLine = (node, commentPosition) =>
+const shouldHaveEmptyLine = (node, checkForLeading) =>
   Boolean(
     // if node is not FunctionDefinition, it should have an empty line
     node.type !== 'FunctionDefinition' ||
@@ -47,12 +47,11 @@ const shouldHaveEmptyLine = (node, commentPosition) =>
       node.body ||
       // if FunctionDefinition has the comment we are looking for (trailing or
       // leading), it should have an empty line
-      node.comments?.some((comment) => comment[commentPosition])
+      node.comments?.some((comment) => checkForLeading && comment.leading)
   );
 
 const separatingLine = (firstNode, secondNode) =>
-  shouldHaveEmptyLine(firstNode, 'trailing') ||
-  shouldHaveEmptyLine(secondNode, 'leading')
+  shouldHaveEmptyLine(firstNode, false) || shouldHaveEmptyLine(secondNode, true)
     ? hardline
     : '';
 

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -1,9 +1,9 @@
 import { doc } from 'prettier';
-import { isPrettier2 } from './util.js';
 import {
   isFirst,
   isLast,
   isNextLineEmpty,
+  isPrettier2,
   next,
   previous
 } from './backward-compatibility.js';

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -2,7 +2,6 @@ import { util, version } from 'prettier';
 import satisfies from 'semver/functions/satisfies.js';
 
 export const prettierVersionSatisfies = (range) => satisfies(version, range);
-export const isPrettier2 = () => prettierVersionSatisfies('^2.3.0');
 
 export function printString(rawContent, options) {
   const double = { quote: '"', regex: /"/g };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -4,49 +4,6 @@ import satisfies from 'semver/functions/satisfies.js';
 export const prettierVersionSatisfies = (range) => satisfies(version, range);
 export const isPrettier2 = () => prettierVersionSatisfies('^2.3.0');
 
-// The following functions will never be 100% covered in a single run
-// since it depends on the version of Prettier being used.
-// Mocking the behaviour will introduce a lot of maintenance in the tests.
-/* c8 ignore start */
-export function isNextLineEmpty(text, startIndex) {
-  return isPrettier2()
-    ? util.isNextLineEmptyAfterIndex(text, startIndex)
-    : util.isNextLineEmpty(text, startIndex); // V3 deprecated `isNextLineEmptyAfterIndex`
-}
-
-export function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
-  return isPrettier2()
-    ? util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
-    : util.getNextNonSpaceNonCommentCharacterIndex(text, locEnd(node)); // V3 signature changed
-}
-
-export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
-  return isPrettier2()
-    ? text.charAt(
-        util.getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
-      )
-    : util.getNextNonSpaceNonCommentCharacter(text, locEnd(node)); // V3 exposes this function directly
-}
-
-export function isFirst(path, _, index) {
-  return isPrettier2() ? index === 0 : path.isFirst;
-}
-
-export function isLast(path, key, index) {
-  return isPrettier2()
-    ? index === path.getParentNode()[key].length - 1
-    : path.isLast;
-}
-
-export function previous(path, key, index) {
-  return isPrettier2() ? path.getParentNode()[key][index - 1] : path.previous;
-}
-
-export function next(path, key, index) {
-  return isPrettier2() ? path.getParentNode()[key][index + 1] : path.next;
-}
-/* c8 ignore stop */
-
 export function printString(rawContent, options) {
   const double = { quote: '"', regex: /"/g };
   const single = { quote: "'", regex: /'/g };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -27,6 +27,24 @@ export function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
       )
     : util.getNextNonSpaceNonCommentCharacter(text, locEnd(node)); // V3 exposes this function directly
 }
+
+export function isFirst(path, _, index) {
+  return isPrettier2() ? index === 0 : path.isFirst;
+}
+
+export function isLast(path, key, index) {
+  return isPrettier2()
+    ? index === path.getParentNode()[key].length - 1
+    : path.isLast;
+}
+
+export function previous(path, key, index) {
+  return isPrettier2() ? path.getParentNode()[key][index - 1] : path.previous;
+}
+
+export function next(path, key, index) {
+  return isPrettier2() ? path.getParentNode()[key][index + 1] : path.next;
+}
 /* c8 ignore stop */
 
 export function printString(rawContent, options) {

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -1,5 +1,5 @@
 import { doc } from 'prettier';
-import { getNextNonSpaceNonCommentCharacter } from '../common/util.js';
+import { getNextNonSpaceNonCommentCharacter } from '../common/backward-compatibility.js';
 import {
   printComments,
   printSeparatedItem,

--- a/src/prettier-comments/language-js/comments.js
+++ b/src/prettier-comments/language-js/comments.js
@@ -1,5 +1,5 @@
 import { util } from "prettier";
-import { getNextNonSpaceNonCommentCharacter } from "../../common/util.js";
+import { getNextNonSpaceNonCommentCharacter } from "../../common/backward-compatibility.js";
 
 const {
   addLeadingComment,

--- a/tests/format/FunctionDefinitions/FunctionDefinitions.sol
+++ b/tests/format/FunctionDefinitions/FunctionDefinitions.sol
@@ -1,169 +1,130 @@
 interface FunctionInterfaces {
   function noParamsNoModifiersNoReturns();
-
   function oneParam(uint x);
-
   function oneModifier() modifier1;
-
   function oneReturn() returns(uint y1);
-
   function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10);
-
   function manyModifiers() modifier1() modifier2() modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function manyReturns() returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1() modifier2 modifier3;
-
   function someParamsSomeReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3);
-
   function someModifiersSomeReturns() modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3);
-
   function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3);
-
   function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function someParamsManyReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3;
-
-  function manyParamssomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3);
-
+  function manyParamsSomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3);
   function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint);
-
   function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string);
-
   function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address);
-
   function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint);
-
   function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint);
-
   function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint);
-
   function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint);
-
   function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint);
+}
+
+interface FunctionInterfaces {
+  function functionDefinition0();
+  function functionDefinition1();
+  function functionDefinition2();
+  // Leading Comment
+  function functionDefinition3();
+  function functionDefinition4();
+  function functionDefinition5() public {}
+  function functionDefinition6();
+  function functionDefinition7(); // Tailing Comment
+  function functionDefinition8();
+  function functionDefinition9();
 }
 
 contract FunctionDefinitions {
   function () external {}
   fallback () external {}
-
   function () external payable {}
   fallback () external payable {}
   receive () external payable {}
-
   function noParamsNoModifiersNoReturns() {
     a = 1;
   }
-
   function oneParam(uint x) {
     a = 1;
   }
-
   function oneModifier() modifier1 {
     a = 1;
   }
-
   function oneReturn() returns(uint y1) {
     a = 1;
   }
-
   function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) {
     a = 1;
   }
-
   function manyModifiers() modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
     a = 1;
   }
-
   function manyReturns() returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 {
     a = 1;
   }
-
   function someParamsSomeReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someModifiersSomeReturns() modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
     a = 1;
   }
-
   function someParamsManyReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 {
     a = 1;
   }
-
-  function manyParamssomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3) {
+  function manyParamsSomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 public {
     a = 1;
   }
-
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string) {
     a = 1;
   }
-
   function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address) {
     a = 1;
   }
-
   function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint) {
     a = 1;
   }
-
   fallback() external payable virtual {}
   fallback(bytes calldata _input) external {}
   receive() external payable virtual {}

--- a/tests/format/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -8,170 +8,131 @@ printWidth: 80
 =====================================input======================================
 interface FunctionInterfaces {
   function noParamsNoModifiersNoReturns();
-
   function oneParam(uint x);
-
   function oneModifier() modifier1;
-
   function oneReturn() returns(uint y1);
-
   function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10);
-
   function manyModifiers() modifier1() modifier2() modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function manyReturns() returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1() modifier2 modifier3;
-
   function someParamsSomeReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3);
-
   function someModifiersSomeReturns() modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3);
-
   function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3);
-
   function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function someParamsManyReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3;
-
-  function manyParamssomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3);
-
+  function manyParamsSomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3);
   function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10;
-
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10);
-
   function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint);
-
   function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string);
-
   function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address);
-
   function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint);
-
   function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint);
-
   function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint);
-
   function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint);
-
   function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint);
+}
+
+interface FunctionInterfaces {
+  function functionDefinition0();
+  function functionDefinition1();
+  function functionDefinition2();
+  // Leading Comment
+  function functionDefinition3();
+  function functionDefinition4();
+  function functionDefinition5() public {}
+  function functionDefinition6();
+  function functionDefinition7(); // Tailing Comment
+  function functionDefinition8();
+  function functionDefinition9();
 }
 
 contract FunctionDefinitions {
   function () external {}
   fallback () external {}
-
   function () external payable {}
   fallback () external payable {}
   receive () external payable {}
-
   function noParamsNoModifiersNoReturns() {
     a = 1;
   }
-
   function oneParam(uint x) {
     a = 1;
   }
-
   function oneModifier() modifier1 {
     a = 1;
   }
-
   function oneReturn() returns(uint y1) {
     a = 1;
   }
-
   function manyParams(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) {
     a = 1;
   }
-
   function manyModifiers() modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
     a = 1;
   }
-
   function manyReturns() returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function someParamsSomeModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 {
     a = 1;
   }
-
   function someParamsSomeReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someModifiersSomeReturns() modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someParamSomeModifiersSomeReturns(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function someParamsManyModifiers(uint x1, uint x2, uint x3) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 {
     a = 1;
   }
-
   function someParamsManyReturns(uint x1, uint x2, uint x3) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function manyParamsSomeModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 {
     a = 1;
   }
-
-  function manyParamssomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3) {
+  function manyParamsSomeReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3) {
     a = 1;
   }
-
   function manyParamsManyModifiers(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 public {
     a = 1;
   }
-
   function manyParamsManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function manyParamsManyModifiersManyReturns(uint x1, uint x2, uint x3, uint x4, uint x5, uint x6, uint x7, uint x8, uint x9, uint x10) modifier1 modifier2 modifier3 modifier4 modifier5 modifier6 modifier7 modifier8 modifier9 modifier10 returns(uint y1, uint y2, uint y3, uint y4, uint y5, uint y6, uint y7, uint y8, uint y9, uint y10) {
     a = 1;
   }
-
   function modifierOrderCorrect01() public view virtual override modifier1 modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderCorrect02() private pure virtual modifier1 modifier2 returns(string) {
     a = 1;
   }
-
   function modifierOrderCorrect03() external payable override modifier1 modifier2 returns(address) {
     a = 1;
   }
-
   function modifierOrderCorrect04() internal virtual override modifier1 modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect01() public modifier1 modifier2 override virtual view returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect02() virtual modifier1 external modifier2 override returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect03() modifier1 pure internal virtual modifier2 returns(uint) {
     a = 1;
   }
-
   function modifierOrderIncorrect04() override modifier1 payable external modifier2 returns(uint) {
     a = 1;
   }
-
   fallback() external payable virtual {}
   fallback(bytes calldata _input) external {}
   receive() external payable virtual {}
@@ -180,13 +141,9 @@ contract FunctionDefinitions {
 =====================================output=====================================
 interface FunctionInterfaces {
     function noParamsNoModifiersNoReturns();
-
     function oneParam(uint x);
-
     function oneModifier() modifier1;
-
     function oneReturn() returns (uint y1);
-
     function manyParams(
         uint x1,
         uint x2,
@@ -199,7 +156,6 @@ interface FunctionInterfaces {
         uint x9,
         uint x10
     );
-
     function manyModifiers()
         modifier1
         modifier2
@@ -211,7 +167,6 @@ interface FunctionInterfaces {
         modifier8
         modifier9
         modifier10;
-
     function manyReturns()
         returns (
             uint y1,
@@ -225,31 +180,26 @@ interface FunctionInterfaces {
             uint y9,
             uint y10
         );
-
     function someParamsSomeModifiers(
         uint x1,
         uint x2,
         uint x3
     ) modifier1 modifier2 modifier3;
-
     function someParamsSomeReturns(
         uint x1,
         uint x2,
         uint x3
     ) returns (uint y1, uint y2, uint y3);
-
     function someModifiersSomeReturns()
         modifier1
         modifier2
         modifier3
         returns (uint y1, uint y2, uint y3);
-
     function someParamSomeModifiersSomeReturns(
         uint x1,
         uint x2,
         uint x3
     ) modifier1 modifier2 modifier3 returns (uint y1, uint y2, uint y3);
-
     function someParamsManyModifiers(
         uint x1,
         uint x2,
@@ -265,7 +215,6 @@ interface FunctionInterfaces {
         modifier8
         modifier9
         modifier10;
-
     function someParamsManyReturns(
         uint x1,
         uint x2,
@@ -283,7 +232,6 @@ interface FunctionInterfaces {
             uint y9,
             uint y10
         );
-
     function manyParamsSomeModifiers(
         uint x1,
         uint x2,
@@ -296,8 +244,7 @@ interface FunctionInterfaces {
         uint x9,
         uint x10
     ) modifier1 modifier2 modifier3;
-
-    function manyParamssomeReturns(
+    function manyParamsSomeReturns(
         uint x1,
         uint x2,
         uint x3,
@@ -309,7 +256,6 @@ interface FunctionInterfaces {
         uint x9,
         uint x10
     ) returns (uint y1, uint y2, uint y3);
-
     function manyParamsManyModifiers(
         uint x1,
         uint x2,
@@ -332,7 +278,6 @@ interface FunctionInterfaces {
         modifier8
         modifier9
         modifier10;
-
     function manyParamsManyReturns(
         uint x1,
         uint x2,
@@ -357,7 +302,6 @@ interface FunctionInterfaces {
             uint y9,
             uint y10
         );
-
     function manyParamsManyModifiersManyReturns(
         uint x1,
         uint x2,
@@ -392,7 +336,6 @@ interface FunctionInterfaces {
             uint y9,
             uint y10
         );
-
     function modifierOrderCorrect01()
         public
         view
@@ -401,7 +344,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
-
     function modifierOrderCorrect02()
         private
         pure
@@ -409,7 +351,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (string);
-
     function modifierOrderCorrect03()
         external
         payable
@@ -417,7 +358,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (address);
-
     function modifierOrderCorrect04()
         internal
         virtual
@@ -425,7 +365,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
-
     function modifierOrderIncorrect01()
         public
         view
@@ -434,7 +373,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
-
     function modifierOrderIncorrect02()
         external
         virtual
@@ -442,7 +380,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
-
     function modifierOrderIncorrect03()
         internal
         pure
@@ -450,7 +387,6 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
-
     function modifierOrderIncorrect04()
         external
         payable
@@ -458,6 +394,24 @@ interface FunctionInterfaces {
         modifier1
         modifier2
         returns (uint);
+}
+
+interface FunctionInterfaces {
+    function functionDefinition0();
+    function functionDefinition1();
+    function functionDefinition2();
+
+    // Leading Comment
+    function functionDefinition3();
+    function functionDefinition4();
+
+    function functionDefinition5() public {}
+
+    function functionDefinition6();
+    function functionDefinition7(); // Tailing Comment
+
+    function functionDefinition8();
+    function functionDefinition9();
 }
 
 contract FunctionDefinitions {
@@ -622,7 +576,7 @@ contract FunctionDefinitions {
         a = 1;
     }
 
-    function manyParamssomeReturns(
+    function manyParamsSomeReturns(
         uint x1,
         uint x2,
         uint x3,

--- a/tests/format/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/FunctionDefinitions/__snapshots__/jsfmt.spec.js.snap
@@ -409,7 +409,6 @@ interface FunctionInterfaces {
 
     function functionDefinition6();
     function functionDefinition7(); // Tailing Comment
-
     function functionDefinition8();
     function functionDefinition9();
 }


### PR DESCRIPTION
closes #930 

This is just an idea and would love some feedback.

The idea of function definition without implementation being separated just creates a lot of verticality in the document and doesn't serve much the reader.

I added a rule where if a comment involved, there should be a separation to group the comment to the definition.
Also there will be a separation if the previous or next node is not a function definition without implementation.

```Solidity
// Original
interface FunctionInterfaces {
  function functionDefinition0();
  function functionDefinition1();
  function functionDefinition2();
  // Leading Comment adds a line behind
  function functionDefinition3();
  function functionDefinition4();
  function functionDefinition5(/* has an implementation so it will add lines before and after */) public {}
  function functionDefinition6();
  function functionDefinition7(); // Tailing Comment adds a line after
  function functionDefinition8();
  function functionDefinition9();
}


// Proposal
interface FunctionInterfaces {
    function functionDefinition0();
    function functionDefinition1();
    function functionDefinition2();

    // Leading Comment adds a line behind
    function functionDefinition3();
    function functionDefinition4();

    function functionDefinition5(/* has an implementation so it will add lines before and after */) public {}

    function functionDefinition6();
    function functionDefinition7(); // Tailing Comment adds a line after

    function functionDefinition8();
    function functionDefinition9();
}
```

This change won't impact already formatted files as we still respect the rule of user generated space.

Another thing to take into consideration is that now long definitions that break, won't be separated
```Solidity
// Before
function functionDefinition0();

function functionDefinition1()
    returns (
        uint var1,
        uint var2,
        uint var3
    );

function functionDefinition2(
    uint var1,
    uint var2,
    uint var3
) modifier1 modifier2 modifier3;

function functionDefinition3();

// Proposal
function functionDefinition0();
function functionDefinition1()
    returns (
        uint var1,
        uint var2,
        uint var3
    );
function functionDefinition2(
    uint var1,
    uint var2,
    uint var3
) modifier1 modifier2 modifier3;
function functionDefinition3();
```