### PR TITLE
Build now uses `prettier/standalone`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Build test app
+        run: npm run build:test
       - name: Run tests
         run: npm run test:standalone
 
@@ -54,8 +56,10 @@ jobs:
         run: npm run build
       - name: Downgrade Prettier to V2
         run: npm install prettier@2.8.8
+      - name: Build test app
+        run: npm run build:test
       - name: Run standalone tests
-        run: npm run test:standalone tests/format tests/unit/prettier-version
+        run: npm run test:standalone tests/format tests/integration tests/unit/prettier-version
 
   test_linux:
     name: Test on Linux with Node ${{ matrix.node }}

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ We follow Prettier's strategy for populating their plugins in the object `pretti
 <script>
   async function format(code) {
     return await prettier.format(code, {
-      parser: "solidity-parse",
-      plugins: [solidityPlugin],
+      parser: 'solidity-parse',
+      plugins: [solidityPlugin]
     });
   }
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,40 @@ We follow Prettier's strategy for populating their plugins in the object `pretti
 
 ```html
 <script>
+  async function format(code) {
+    return await prettier.format(code, {
+      parser: "solidity-parse",
+      plugins: [solidityPlugin],
+    });
+  }
+
   const originalCode = 'contract Foo {}';
-  const formattedCode = prettier.format(originalCode, {
-    parser: 'solidity-parse',
-    plugins: prettierPlugins
-  });
+  const formattedCode = format(originalCode);
 </script>
 ```
 
 For more details and please have a look at [Prettier's documentation](https://prettier.io/docs/en/browser.html).
+
+### Creating a package for the Browser
+
+_Added in v1.1.4_
+
+If you are creating your own package to be run in a browser, you might want to import the standalone files directly.
+
+```Javascript
+import prettier from 'prettier/standalone';
+import solidityPlugin from 'prettier-plugin-solidity/standalone';
+
+async function format(code) {
+  return await prettier.format(code, {
+    parser: "solidity-parse",
+    plugins: [solidityPlugin],
+  });
+}
+
+const originalCode = 'contract Foo {}';
+const formattedCode = format(originalCode);
+```
 
 ## Configuration File
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,13 @@
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
+const testMatch = [
+  '<rootDir>/tests/format/**/jsfmt.spec.js',
+
+  '<rootDir>/tests/unit/**/*.test.js'
+];
+
+if (TEST_STANDALONE) {
+  testMatch.push('<rootDir>/tests/integration/**/*.test.js');
+}
 
 export default {
   runner: 'jest-light-runner',
@@ -17,10 +26,7 @@ export default {
         'tests/format/RespectDefaultOptions'
       ]
     : [],
-  testMatch: [
-    '<rootDir>/tests/format/**/jsfmt.spec.js',
-    '<rootDir>/tests/unit/**/*.test.js'
-  ],
+  testMatch,
   transform: {},
   watchPlugins: [
     'jest-watch-typeahead/filename',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "1.1.3",
+  "version": "1.1.4-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-solidity",
-      "version": "1.1.3",
+      "version": "1.1.4-dev",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,18 @@
   "browser": "./dist/standalone.cjs",
   "unpkg": "./dist/standalone.cjs",
   "exports": {
-    "import": "./src/index.js",
-    "require": "./dist/standalone.cjs"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/standalone.cjs"
+    },
+    "./standalone": {
+      "default": "./dist/standalone.cjs"
+    }
   },
   "scripts": {
     "build": "webpack --env production",
     "build:dev": "webpack --env development",
+    "build:test": "webpack --config test.config.js",
     "eslint": "eslint 'src/**' 'tests/**'",
     "lint": "npm run eslint && npm run prettier -- --list-different",
     "lint:fix": "npm run eslint -- --fix && npm run prettier -- --write",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "1.1.3",
+  "version": "1.1.4-dev",
   "description": "A Prettier Plugin for automatically formatting your Solidity code.",
   "type": "module",
   "main": "./src/index.js",

--- a/test.config.js
+++ b/test.config.js
@@ -4,8 +4,6 @@ import createEsmUtils from 'esm-utils';
 
 const { __dirname } = createEsmUtils(import.meta);
 
-// This is the production and development configuration.
-// It is focused on developer experience, fast rebuilds, and a minimal bundle.
 export default {
   entry: './tests/integration/test-app.js',
   mode: 'production',
@@ -28,10 +26,7 @@ export default {
     `,
     library: {
       export: 'default',
-      name: {
-        commonjs: 'format',
-        root: 'format'
-      },
+      name: 'format',
       type: 'umd2'
     }
   },

--- a/test.config.js
+++ b/test.config.js
@@ -1,0 +1,43 @@
+import path from 'node:path';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import createEsmUtils from 'esm-utils';
+
+const { __dirname } = createEsmUtils(import.meta);
+
+// This is the production and development configuration.
+// It is focused on developer experience, fast rebuilds, and a minimal bundle.
+export default {
+  entry: './tests/integration/test-app.js',
+  mode: 'production',
+  bail: true,
+
+  optimization: { minimize: false },
+  target: ['browserslist'],
+
+  output: {
+    filename: 'test.cjs',
+    path: path.resolve(__dirname, 'dist'),
+    globalObject: `
+      typeof globalThis !== "undefined"
+        ? globalThis
+        : typeof global !== "undefined"
+        ? global
+        : typeof self !== "undefined"
+        ? self
+        : this || {}
+    `,
+    library: {
+      export: 'default',
+      name: {
+        commonjs: 'format',
+        root: 'format'
+      },
+      type: 'umd2'
+    }
+  },
+
+  performance: {
+    maxEntrypointSize: 1024 * 1024,
+    maxAssetSize: 1024 * 1024
+  }
+};

--- a/tests/integration/node.test.js
+++ b/tests/integration/node.test.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import format from '../../dist/test.cjs';
 
 test('Should run a a test app in a node environment', async () => {

--- a/tests/integration/node.test.js
+++ b/tests/integration/node.test.js
@@ -1,0 +1,7 @@
+import format from '../../dist/test.cjs';
+
+test('Should run a a test app in a node environment', async () => {
+  const data = 'contract    CheckPackage {}';
+
+  expect(await format(data)).toEqual('contract CheckPackage {}\n');
+});

--- a/tests/integration/sandbox-test-app.cjs
+++ b/tests/integration/sandbox-test-app.cjs
@@ -1,0 +1,16 @@
+const path = require('path');
+const vm = require('vm');
+const createSandBox = require('../config/utils/create-sandbox.cjs');
+
+const sandbox = createSandBox({
+  files: [path.join(__dirname, '../../dist/test.cjs')]
+});
+
+module.exports = {
+  format(input) {
+    return vm.runInNewContext('format($$$input);', {
+      $$$input: input,
+      ...sandbox
+    });
+  }
+};

--- a/tests/integration/sandbox.test.js
+++ b/tests/integration/sandbox.test.js
@@ -1,0 +1,8 @@
+test('Should run a a test app in a sandbox', async () => {
+  const data = 'contract    CheckPackage {}';
+  const entry = new URL('./sandbox-test-app.cjs', import.meta.url);
+
+  const { format } = await import(entry).then((module) => module.default);
+
+  expect(await format(data)).toEqual('contract CheckPackage {}\n');
+});

--- a/tests/integration/test-app.js
+++ b/tests/integration/test-app.js
@@ -1,0 +1,10 @@
+import prettier from 'prettier/standalone';
+import solidityPlugin from '../../dist/standalone.cjs';
+
+export default async function format(code) {
+  const formattedCode = await prettier.format(code, {
+    parser: 'solidity-parse',
+    plugins: [solidityPlugin]
+  });
+  return formattedCode;
+}

--- a/tests/integration/test-app.js
+++ b/tests/integration/test-app.js
@@ -1,4 +1,5 @@
 import prettier from 'prettier/standalone.js';
+// eslint-disable-next-line import/no-unresolved
 import solidityPlugin from '../../dist/standalone.cjs';
 
 export default async function format(code) {

--- a/tests/integration/test-app.js
+++ b/tests/integration/test-app.js
@@ -1,4 +1,4 @@
-import prettier from 'prettier/standalone';
+import prettier from 'prettier/standalone.js';
 import solidityPlugin from '../../dist/standalone.cjs';
 
 export default async function format(code) {

--- a/tests/unit/prettier-version/proxyquire-plugin.cjs
+++ b/tests/unit/prettier-version/proxyquire-plugin.cjs
@@ -1,11 +1,11 @@
 const proxyquire = require('proxyquire');
-const prettier = require('prettier/standalone.js');
+const prettier = require('prettier/standalone');
 
 const proxyquirePlugin = () => {
   const prettierMock = { ...prettier, version: '2.2.1', '@global': true };
 
   const plugin = proxyquire('../../../dist/standalone.cjs', {
-    prettier: prettierMock
+    'prettier/standalone': prettierMock
   });
 
   return { plugin, prettierMock };

--- a/tests/unit/prettier-version/proxyquire-plugin.cjs
+++ b/tests/unit/prettier-version/proxyquire-plugin.cjs
@@ -1,5 +1,5 @@
 const proxyquire = require('proxyquire');
-const prettier = require('prettier/standalone');
+const prettier = require('prettier/standalone.js');
 
 const proxyquirePlugin = () => {
   const prettierMock = { ...prettier, version: '2.2.1', '@global': true };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,14 @@ export default (webpackEnv) => {
 
     // Avoid bundling Prettier
     externals: {
-      prettier: 'prettier'
+      prettier: {
+        // use 'prettier/standalone' in case the project importing this file is
+        // bundling for the browser.
+        amd: 'prettier/standalone',
+        commonjs: 'prettier/standalone',
+        commonjs2: 'prettier/standalone',
+        root: 'prettier' // global variable if it was loaded by the browser
+      }
     },
 
     mode: isEnvProduction ? 'production' : 'development',


### PR DESCRIPTION
With this change users won't have to uses aliases when building applications for the browser.

This feature was by 2 users (#942 and another one in the Telegram thread), having issues when building an application for the browser.

Before this fix, webpack was generating code that used `require('prettier')`. This would lead to requiring the use of aliases in the webpack configuration so `'prettier'` would be resolved to `'prettier/standalone'`.

With this change, users will still be able to build for node using `commons`, `esm`, and building for the browser without the need for aliases.