### PR TITLE
Experimental ternaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,19 @@ You might have a multi-version project, where different files are compiled with 
 | ------- | --------------------- | ---------------------- |
 | None    | `--compiler <string>` | `compiler: "<string>"` |
 
+### Experimental Ternaries
+
+Mimicking prettier's [new ternary formatting](https://prettier.io/blog/2023/11/13/curious-ternaries) for the community to try.
+
+Valid options:
+
+- `true` - Use curious ternaries, with the question mark after the condition.
+- `false` - Retain the default behavior of ternaries; keep question marks on the same line as the consequent.
+
+| Default | CLI Override               | API Override                    |
+| ------- | -------------------------- | ------------------------------- |
+| false   | `--experimental-ternaries` | `experimentalTernaries: <bool>` |
+
 ## Integrations
 
 ### Vim

--- a/src/binary-operator-printers/logical.js
+++ b/src/binary-operator-printers/logical.js
@@ -5,13 +5,19 @@ const { group, line, indent } = doc.builders;
 const groupIfNecessaryBuilder = (path) => (document) =>
   path.getParentNode().type === 'BinaryOperation' ? document : group(document);
 
-const indentIfNecessaryBuilder = (path) => (document) => {
+const indentIfNecessaryBuilder = (path, options) => (document) => {
   let node = path.getNode();
   for (let i = 0; ; i += 1) {
     const parentNode = path.getParentNode(i);
     if (parentNode.type === 'ReturnStatement') return document;
     if (parentNode.type === 'IfStatement') return document;
     if (parentNode.type === 'WhileStatement') return document;
+    if (
+      options.experimentalTernaries &&
+      parentNode.type === 'Conditional' &&
+      parentNode.condition === node
+    )
+      return document;
     if (parentNode.type !== 'BinaryOperation') return indent(document);
     if (node === parentNode.right) return document;
     node = parentNode;
@@ -20,9 +26,9 @@ const indentIfNecessaryBuilder = (path) => (document) => {
 
 export const logical = {
   match: (op) => ['&&', '||'].includes(op),
-  print: (node, path, print) => {
+  print: (node, path, print, options) => {
     const groupIfNecessary = groupIfNecessaryBuilder(path);
-    const indentIfNecessary = indentIfNecessaryBuilder(path);
+    const indentIfNecessary = indentIfNecessaryBuilder(path, options);
 
     const right = [node.operator, line, path.call(print, 'right')];
     // If it's a single binary operation, avoid having a small right

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -48,19 +48,22 @@ const experimentalTernaries = (node, path, print) => {
     : document;
 };
 
+const traditionalTernaries = (path, print) =>
+  group([
+    path.call(print, 'condition'),
+    indent([
+      path.getParentNode().type === 'Conditional' ? hardline : line,
+      '? ',
+      path.call(print, 'trueExpression'),
+      line,
+      ': ',
+      path.call(print, 'falseExpression')
+    ])
+  ]);
+
 export const Conditional = {
   print: ({ node, path, print, options }) =>
     options.experimentalTernaries
       ? experimentalTernaries(node, path, print)
-      : group([
-          path.call(print, 'condition'),
-          indent([
-            line,
-            '? ',
-            path.call(print, 'trueExpression'),
-            line,
-            ': ',
-            path.call(print, 'falseExpression')
-          ])
-        ])
+      : traditionalTernaries(path, print)
 };

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -7,9 +7,6 @@ const experimentalTernaries = (node, path, print) => {
   const parent = path.getParentNode();
   const isNested = parent.type === 'Conditional';
   const isNestedAsTrueExpression = isNested && parent.trueExpression === node;
-  const hasNestedConditional =
-    node.trueExpression.type === 'Conditional' ||
-    node.falseExpression.type === 'Conditional';
 
   // If the `conditionDoc` breaks into multiple lines, we add parentheses,
   // unless it already is a `TupleExpression`.
@@ -29,10 +26,10 @@ const experimentalTernaries = (node, path, print) => {
     path.call(print, 'trueExpression')
   ]);
 
-  // We force a new line if current `Conditional` is nested or nests a
-  // `Conditional`. Otherwise we add a normal line.
+  // We force a new line if current `Conditional` is a nested `Conditional`.
+  // Otherwise we add a normal line.
   const falseExpressionDoc = [
-    isNested || hasNestedConditional ? hardline : line,
+    isNested ? hardline : line,
     ': ',
     path.call(print, 'falseExpression')
   ];

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -26,9 +26,7 @@ const experimentalTernaries = (node, path, print) => {
     [
       parent.type === 'Conditional' && parent.trueExpression === node
         ? hardlineWithoutBreakParent
-        : parent.type === 'FunctionCall'
-          ? breakParent
-          : '',
+        : '',
       node.condition.type === 'TupleExpression'
         ? conditionDoc
         : group(
@@ -72,7 +70,9 @@ const experimentalTernaries = (node, path, print) => {
   ];
 
   const document = group([
-    parent.type === 'TupleExpression' ? breakParent : '',
+    parent.type === 'TupleExpression' || parent.type === 'FunctionCall'
+      ? breakParent
+      : '',
     conditionGroup,
     trueExpressionDoc,
     falseExpressionDoc

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -24,35 +24,27 @@ const experimentalTernaries = (node, path, print) => {
       ),
       ' ?'
     ],
-    {
-      id: `Conditional.condition-${groupIndex}`
-    }
+    { id: `Conditional.condition-${groupIndex}` }
   );
 
   groupIndex += 1;
 
   const expressionSeparator = ifBreak(
-    ['Conditional', 'VariableDeclarationStatement', 'ReturnStatement'].includes(
-      parent.type
-    )
+    ['Conditional', 'VariableDeclarationStatement'].includes(parent.type)
       ? hardlineWithoutBreakParent
-      : hardline,
+      : line,
     line,
-    {
-      groupId: conditionalGroup.id
-    }
+    { groupId: conditionalGroup.id }
   );
 
   const document = group([
     conditionalGroup,
     group(indent([expressionSeparator, path.call(print, 'trueExpression')])),
-    group([
-      parent.type === 'Conditional' || falseExpressionIsConditional
-        ? hardlineWithoutBreakParent
-        : expressionSeparator,
-      ': ',
-      path.call(print, 'falseExpression')
-    ])
+    parent.type === 'Conditional' || falseExpressionIsConditional
+      ? hardlineWithoutBreakParent
+      : expressionSeparator,
+    ': ',
+    path.call(print, 'falseExpression')
   ]);
 
   return parent.type === 'VariableDeclarationStatement'

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,10 +1,8 @@
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../common/printer-helpers.js';
 
-const { group, hardline, hardlineWithoutBreakParent, ifBreak, indent, line } =
-  doc.builders;
+const { group, hardline, ifBreak, indent, line } = doc.builders;
 
-let groupIndex = 0;
 const experimentalTernaries = (node, path, print) => {
   const parent = path.getParentNode();
   const isNested = parent.type === 'Conditional';
@@ -16,49 +14,31 @@ const experimentalTernaries = (node, path, print) => {
   // If the `conditionDoc` breaks into multiple lines, we add parentheses,
   // unless it already is a `TupleExpression`.
   const conditionDoc = path.call(print, 'condition');
-  const conditionGroup = group(
-    [
-      node.condition.type === 'TupleExpression'
-        ? conditionDoc
-        : ifBreak(['(', printSeparatedItem(conditionDoc), ')'], conditionDoc),
-      ' ?'
-    ],
-    { id: `Conditional.condition-${groupIndex}` }
-  );
-
-  groupIndex += 1;
-
-  // If the `conditionGroup` breaks we force a new line to separate the
-  // `trueExpression` and `falseExpression` following the "curious" ternaries
-  // format.
-  // We need a `hardlineWithoutBreakParent` because `hardline` doesn't play
-  // well with `ifBreak`. (See https://github.com/prettier/prettier/issues/15710)
-  const expressionSeparator = ifBreak(hardlineWithoutBreakParent, line, {
-    groupId: conditionGroup.id
-  });
+  const conditionGroup = group([
+    node.condition.type === 'TupleExpression'
+      ? conditionDoc
+      : ifBreak(['(', printSeparatedItem(conditionDoc), ')'], conditionDoc),
+    ' ?'
+  ]);
 
   // To switch between "case-style" and "curious" ternaries we force a
   // `hardline` without propagating the break thus keeping "case-style"
   // ternaries in the parent `Conditional`s.
-  const trueExpressionDoc = printSeparatedItem(
-    [
-      isNestedAsTrueExpression ? hardline : expressionSeparator,
-      path.call(print, 'trueExpression')
-    ],
-    { firstSeparator: '' }
-  );
-
-  // We force a new line if current `Conditional` is nested or nests a
-  // `Conditional`. Otherwise we add a normal separator.
-  const falseExpressionDoc = group([
-    isNested || hasNestedConditional ? hardline : expressionSeparator,
-    ': ',
-    path.call(print, 'falseExpression')
+  const trueExpressionDoc = indent([
+    isNestedAsTrueExpression ? hardline : line,
+    path.call(print, 'trueExpression')
   ]);
 
+  // We force a new line if current `Conditional` is nested or nests a
+  // `Conditional`. Otherwise we add a normal line.
+  const falseExpressionDoc = [
+    isNested || hasNestedConditional ? hardline : line,
+    ': ',
+    path.call(print, 'falseExpression')
+  ];
+
   const document = group([
-    conditionGroup,
-    trueExpressionDoc,
+    group([conditionGroup, trueExpressionDoc]),
     falseExpressionDoc
   ]);
 

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -4,11 +4,11 @@ const { group, indent, line, ifBreak, hardline, hardlineWithoutBreakParent } =
   doc.builders;
 
 const experimentalTernaries = (node, path, print) => {
-  const { parent } = path;
+  const parent = path.getParentNode();
   let style = 'case-style';
 
   if (parent.type === 'Conditional') {
-    if (parent.condition === node) style = 'case-style';
+    if (parent.condition === node) style = 'curious';
     if (parent.trueExpression === node) style = 'case-style';
     if (parent.falseExpression === node) style = 'case-style';
   }
@@ -17,9 +17,8 @@ const experimentalTernaries = (node, path, print) => {
     node.condition.type,
     node.trueExpression.type
   ].includes('Conditional');
-
-  const hasConditional =
-    hasConditionalAtBeginning || node.falseExpression.type === 'Conditional';
+  const hasConditionalAtEnd = node.falseExpression.type === 'Conditional';
+  const hasConditional = hasConditionalAtBeginning || hasConditionalAtEnd;
 
   const document = group([
     group([
@@ -27,38 +26,38 @@ const experimentalTernaries = (node, path, print) => {
       ' ?',
       group(
         indent([
-          style === 'curious' ? hardline : line,
+          style === 'curious' ? hardlineWithoutBreakParent : line,
           path.call(print, 'trueExpression')
         ])
       )
     ]),
     group([
-      parent.type === 'Conditional' || hasConditionalAtBeginning ?
-        hardlineWithoutBreakParent
-      : line,
+      parent.type === 'Conditional' || hasConditionalAtEnd
+        ? hardlineWithoutBreakParent
+        : line,
       ': ',
       path.call(print, 'falseExpression')
     ])
   ]);
 
-  return path.parent.type === 'VariableDeclarationStatement' ?
-      ifBreak(indent([hasConditional ? hardline : line, document]), document)
+  return path.parent.type === 'VariableDeclarationStatement'
+    ? ifBreak(indent([hasConditional ? hardline : line, document]), document)
     : document;
 };
 
 export const Conditional = {
   print: ({ node, path, print, options }) =>
-    options.experimentalTernaries ?
-      experimentalTernaries(node, path, print)
-    : group([
-        path.call(print, 'condition'),
-        indent([
-          line,
-          '? ',
-          path.call(print, 'trueExpression'),
-          line,
-          ': ',
-          path.call(print, 'falseExpression')
+    options.experimentalTernaries
+      ? experimentalTernaries(node, path, print)
+      : group([
+          path.call(print, 'condition'),
+          indent([
+            line,
+            '? ',
+            path.call(print, 'trueExpression'),
+            line,
+            ': ',
+            path.call(print, 'falseExpression')
+          ])
         ])
-      ])
 };

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -7,52 +7,60 @@ let groupIndex = 0;
 const experimentalTernaries = (node, path, print) => {
   const parent = path.getParentNode();
 
-  const hasConditionalAtEnd = node.falseExpression.type === 'Conditional';
+  const falseExpressionIsConditional =
+    node.falseExpression.type === 'Conditional';
   const hasConditional =
-    [node.condition.type, node.trueExpression.type].includes('Conditional') ||
-    hasConditionalAtEnd;
+    node.trueExpression.type === 'Conditional' || falseExpressionIsConditional;
 
-  const conditionalGroup = group([path.call(print, 'condition'), ' ?'], {
-    id: `Conditional.condition-${groupIndex}`
-  });
+  const conditionalGroup = group(
+    [
+      parent.type === 'Conditional' && parent.trueExpression === node
+        ? hardlineWithoutBreakParent
+        : '',
+      path.call(print, 'condition'),
+      ' ?'
+    ],
+    {
+      id: `Conditional.condition-${groupIndex}`
+    }
+  );
 
   groupIndex += 1;
+
   const expressionSeparator = ifBreak(hardlineWithoutBreakParent, line, {
     groupId: conditionalGroup.id
   });
 
   const document = group([
+    conditionalGroup,
+    group(indent([expressionSeparator, path.call(print, 'trueExpression')])),
     group([
-      conditionalGroup,
-      group(indent([expressionSeparator, path.call(print, 'trueExpression')]))
-    ]),
-    group([
-      parent.type === 'Conditional' || hasConditionalAtEnd ?
-        hardlineWithoutBreakParent
-      : expressionSeparator,
+      parent.type === 'Conditional' || falseExpressionIsConditional
+        ? hardlineWithoutBreakParent
+        : expressionSeparator,
       ': ',
       path.call(print, 'falseExpression')
     ])
   ]);
 
-  return path.parent.type === 'VariableDeclarationStatement' ?
-      ifBreak(indent([hasConditional ? hardline : line, document]), document)
+  return parent.type === 'VariableDeclarationStatement'
+    ? ifBreak(indent([hasConditional ? hardline : line, document]), document)
     : document;
 };
 
 export const Conditional = {
   print: ({ node, path, print, options }) =>
-    options.experimentalTernaries ?
-      experimentalTernaries(node, path, print)
-    : group([
-        path.call(print, 'condition'),
-        indent([
-          line,
-          '? ',
-          path.call(print, 'trueExpression'),
-          line,
-          ': ',
-          path.call(print, 'falseExpression')
+    options.experimentalTernaries
+      ? experimentalTernaries(node, path, print)
+      : group([
+          path.call(print, 'condition'),
+          indent([
+            line,
+            '? ',
+            path.call(print, 'trueExpression'),
+            line,
+            ': ',
+            path.call(print, 'falseExpression')
+          ])
         ])
-      ])
 };

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,18 +1,64 @@
 import { doc } from 'prettier';
 
-const { group, indent, line } = doc.builders;
+const { group, indent, line, ifBreak, hardline, hardlineWithoutBreakParent } =
+  doc.builders;
 
-export const Conditional = {
-  print: ({ path, print }) =>
+const experimentalTernaries = (node, path, print) => {
+  const { parent } = path;
+  let style = 'case-style';
+
+  if (parent.type === 'Conditional') {
+    if (parent.condition === node) style = 'case-style';
+    if (parent.trueExpression === node) style = 'case-style';
+    if (parent.falseExpression === node) style = 'case-style';
+  }
+
+  const hasConditionalAtBeginning = [
+    node.condition.type,
+    node.trueExpression.type
+  ].includes('Conditional');
+
+  const hasConditional =
+    hasConditionalAtBeginning || node.falseExpression.type === 'Conditional';
+
+  const document = group([
     group([
       path.call(print, 'condition'),
-      indent([
-        line,
-        '? ',
-        path.call(print, 'trueExpression'),
-        line,
-        ': ',
-        path.call(print, 'falseExpression')
-      ])
+      ' ?',
+      group(
+        indent([
+          style === 'curious' ? hardline : line,
+          path.call(print, 'trueExpression')
+        ])
+      )
+    ]),
+    group([
+      parent.type === 'Conditional' || hasConditionalAtBeginning ?
+        hardlineWithoutBreakParent
+      : line,
+      ': ',
+      path.call(print, 'falseExpression')
     ])
+  ]);
+
+  return path.parent.type === 'VariableDeclarationStatement' ?
+      ifBreak(indent([hasConditional ? hardline : line, document]), document)
+    : document;
+};
+
+export const Conditional = {
+  print: ({ node, path, print, options }) =>
+    options.experimentalTernaries ?
+      experimentalTernaries(node, path, print)
+    : group([
+        path.call(print, 'condition'),
+        indent([
+          line,
+          '? ',
+          path.call(print, 'trueExpression'),
+          line,
+          ': ',
+          path.call(print, 'falseExpression')
+        ])
+      ])
 };

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,7 +1,7 @@
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../common/printer-helpers.js';
 
-const { group, hardline, ifBreak, indent, line } = doc.builders;
+const { group, hardline, ifBreak, indent, line, softline } = doc.builders;
 
 const experimentalTernaries = (node, path, print) => {
   const parent = path.getParentNode();
@@ -40,7 +40,7 @@ const experimentalTernaries = (node, path, print) => {
   ]);
 
   return parent.type === 'VariableDeclarationStatement'
-    ? ifBreak(indent([line, document]), document)
+    ? indent([softline, document])
     : document;
 };
 

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -10,7 +10,8 @@ const experimentalTernaries = (node, path, print) => {
 
   // If the current `Conditional` is nested in another `Conditional`'s
   // `trueExpression`, we add a line without propagating the break group.
-  // If the `conditionDoc` breaks into multiple lines, we add parentheses.
+  // If the `conditionDoc` breaks into multiple lines, we add parentheses,
+  // unless it already is a `TupleExpression`.
   // This can only be done because we are sure that the `condition` must be a
   // single `bool` value.
   const conditionDoc = path.call(print, 'condition');
@@ -19,7 +20,9 @@ const experimentalTernaries = (node, path, print) => {
       parent.type === 'Conditional' && parent.trueExpression === node
         ? hardlineWithoutBreakParent
         : '',
-      ifBreak(['(', printSeparatedItem(conditionDoc), ')'], conditionDoc),
+      node.condition.type === 'TupleExpression'
+        ? conditionDoc
+        : ifBreak(['(', printSeparatedItem(conditionDoc), ')'], conditionDoc),
       ' ?'
     ],
     { id: `Conditional.condition-${groupIndex}` }

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -52,7 +52,7 @@ const experimentalTernaries = (node, path, print, options) => {
     ':',
     falseExpressionIsNested
       ? [' ', falseExpression]
-      : ifBreak([fillTab, falseExpression], [' ', falseExpression], {
+      : ifBreak([fillTab, indent(falseExpression)], [' ', falseExpression], {
           // We only add `fillTab` if we are sure the trueExpression is indented
           groupId: conditionAndTrueExpressionGroup.id
         })

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -1,4 +1,5 @@
 import { doc } from 'prettier';
+import { printSeparatedItem } from '../common/printer-helpers.js';
 
 const { group, indent, line, ifBreak, hardline, hardlineWithoutBreakParent } =
   doc.builders;
@@ -17,7 +18,10 @@ const experimentalTernaries = (node, path, print) => {
       parent.type === 'Conditional' && parent.trueExpression === node
         ? hardlineWithoutBreakParent
         : '',
-      path.call(print, 'condition'),
+      ifBreak(
+        ['(', printSeparatedItem(path.call(print, 'condition')), ')'],
+        path.call(print, 'condition')
+      ),
       ' ?'
     ],
     {
@@ -27,9 +31,17 @@ const experimentalTernaries = (node, path, print) => {
 
   groupIndex += 1;
 
-  const expressionSeparator = ifBreak(hardlineWithoutBreakParent, line, {
-    groupId: conditionalGroup.id
-  });
+  const expressionSeparator = ifBreak(
+    ['Conditional', 'VariableDeclarationStatement', 'ReturnStatement'].includes(
+      parent.type
+    )
+      ? hardlineWithoutBreakParent
+      : hardline,
+    line,
+    {
+      groupId: conditionalGroup.id
+    }
+  );
 
   const document = group([
     conditionalGroup,

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -84,6 +84,7 @@ const traditionalTernaries = (path, print) =>
   group([
     path.call(print, 'condition'),
     indent([
+      // We force line breaks if it's a nested `Conditional`
       path.getParentNode().type === 'Conditional' ? hardline : line,
       '? ',
       path.call(print, 'trueExpression'),

--- a/src/nodes/Conditional.js
+++ b/src/nodes/Conditional.js
@@ -18,16 +18,15 @@ const experimentalTernaries = (node, path, print) => {
     ' ?'
   ]);
 
-  // To switch between "case-style" and "curious" ternaries we force a
-  // `hardline` without propagating the break thus keeping "case-style"
-  // ternaries in the parent `Conditional`s.
+  // To switch between "case-style" and "curious" ternaries we force a new line
+  // before a nested `trueExpression` if the current `Conditional` is also a
+  // `trueExpression`.
   const trueExpressionDoc = indent([
     isNestedAsTrueExpression ? hardline : line,
     path.call(print, 'trueExpression')
   ]);
 
-  // We force a new line if current `Conditional` is a nested `Conditional`.
-  // Otherwise we add a normal line.
+  // A nested `falseExpression` is always printed in a new line.
   const falseExpressionDoc = [
     isNested ? hardline : line,
     ': ',
@@ -48,7 +47,8 @@ const traditionalTernaries = (path, print) =>
   group([
     path.call(print, 'condition'),
     indent([
-      // We force line breaks if it's a nested `Conditional`
+      // Nested trueExpression and falseExpression are always printed in a new
+      // line
       path.getParentNode().type === 'Conditional' ? hardline : line,
       '? ',
       path.call(print, 'trueExpression'),

--- a/src/nodes/ReturnStatement.js
+++ b/src/nodes/ReturnStatement.js
@@ -2,9 +2,10 @@ import { doc } from 'prettier';
 
 const { group, indent, line } = doc.builders;
 
-const expression = (node, path, print) => {
+const expression = (node, path, print, options) => {
   if (node.expression) {
-    return node.expression.type === 'TupleExpression'
+    return node.expression.type === 'TupleExpression' ||
+      (options.experimentalTernaries && node.expression.type === 'Conditional')
       ? [' ', path.call(print, 'expression')]
       : group(indent([line, path.call(print, 'expression')]));
   }
@@ -12,9 +13,9 @@ const expression = (node, path, print) => {
 };
 
 export const ReturnStatement = {
-  print: ({ node, path, print }) => [
+  print: ({ node, path, print, options }) => [
     'return',
-    expression(node, path, print),
+    expression(node, path, print, options),
     ';'
   ]
 };

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -3,18 +3,34 @@ import { printSeparatedList } from '../common/printer-helpers.js';
 
 const { group } = doc.builders;
 
-const contents = (node, path, print) =>
-  node.components &&
-  node.components.length === 1 &&
-  node.components[0].type === 'BinaryOperation'
+const contents = (node, path, print, options) => {
+  if (
+    options.experimentalTernaries &&
+    path.getParentNode().type === 'Conditional'
+  ) {
+    return printSeparatedList(path.map(print, 'components'));
+  }
+
+  return node.components &&
+    node.components.length === 1 &&
+    node.components[0].type === 'BinaryOperation'
     ? path.map(print, 'components')
-    : [printSeparatedList(path.map(print, 'components'))];
+    : printSeparatedList(path.map(print, 'components'));
+};
+
+const brackets = {
+  true: '[]',
+  false: '()'
+};
 
 export const TupleExpression = {
-  print: ({ node, path, print }) =>
-    group([
-      node.isArray ? '[' : '(',
-      ...contents(node, path, print),
-      node.isArray ? ']' : ')'
-    ])
+  print: ({ node, path, print, options }) => {
+    const bracket = brackets[node.isArray.toString()];
+
+    return group([
+      bracket[0],
+      contents(node, path, print, options),
+      bracket[1]
+    ]);
+  }
 };

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -11,9 +11,10 @@ const contents = (node, path, print) =>
     : printSeparatedList(path.map(print, 'components'));
 
 export const TupleExpression = {
-  print: ({ node, path, print }) => {
-    const [openingBracket, closingBracket] = node.isArray ? '[]' : '()';
-
-    return group([openingBracket, contents(node, path, print), closingBracket]);
-  }
+  print: ({ node, path, print }) =>
+    group([
+      node.isArray ? '[' : '(',
+      contents(node, path, print),
+      node.isArray ? ']' : ')'
+    ])
 };

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -18,19 +18,14 @@ const contents = (node, path, print, options) => {
     : printSeparatedList(path.map(print, 'components'));
 };
 
-const brackets = {
-  true: '[]',
-  false: '()'
-};
-
 export const TupleExpression = {
   print: ({ node, path, print, options }) => {
-    const bracket = brackets[node.isArray.toString()];
+    const [openingBracket, closingBracket] = node.isArray ? '[]' : '()';
 
     return group([
-      bracket[0],
+      openingBracket,
       contents(node, path, print, options),
-      bracket[1]
+      closingBracket
     ]);
   }
 };

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -3,29 +3,17 @@ import { printSeparatedList } from '../common/printer-helpers.js';
 
 const { group } = doc.builders;
 
-const contents = (node, path, print, options) => {
-  if (
-    options.experimentalTernaries &&
-    path.getParentNode().type === 'Conditional'
-  ) {
-    return printSeparatedList(path.map(print, 'components'));
-  }
-
-  return node.components &&
-    node.components.length === 1 &&
-    node.components[0].type === 'BinaryOperation'
+const contents = (node, path, print) =>
+  node.components &&
+  node.components.length === 1 &&
+  node.components[0].type === 'BinaryOperation'
     ? path.map(print, 'components')
     : printSeparatedList(path.map(print, 'components'));
-};
 
 export const TupleExpression = {
-  print: ({ node, path, print, options }) => {
+  print: ({ node, path, print }) => {
     const [openingBracket, closingBracket] = node.isArray ? '[]' : '()';
 
-    return group([
-      openingBracket,
-      contents(node, path, print, options),
-      closingBracket
-    ]);
+    return group([openingBracket, contents(node, path, print), closingBracket]);
   }
 };

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,6 @@
 const CATEGORY_GLOBAL = 'Global';
 const CATEGORY_COMMON = 'Common';
+const CATEGORY_JAVASCRIPT = 'JavaScript';
 const CATEGORY_SOLIDITY = 'Solidity';
 
 const options = {
@@ -39,6 +40,15 @@ const options = {
     type: 'boolean',
     default: false,
     description: 'Use single quotes instead of double quotes.'
+  },
+  experimentalTernaries: {
+    category: CATEGORY_JAVASCRIPT,
+    type: 'boolean',
+    default: false,
+    description:
+      'Use curious ternaries, with the question mark after the condition.',
+    oppositeDescription:
+      'Default behavior of ternaries; keep question marks on the same line as the consequent.'
   },
   compiler: {
     category: CATEGORY_SOLIDITY,

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,10 +88,11 @@ function parse(text, _parsers, options = _parsers) {
     },
     Conditional(ctx) {
       rearrangeConditional(ctx);
-      if (
+      while (
         ctx.condition.type === 'TupleExpression' &&
         !ctx.condition.isArray &&
-        ctx.condition.components.length === 1
+        ctx.condition.components.length === 1 &&
+        ctx.condition.components[0].type !== 'Conditional'
       ) {
         [ctx.condition] = ctx.condition.components;
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,6 +88,8 @@ function parse(text, _parsers, options = _parsers) {
     },
     Conditional(ctx) {
       rearrangeConditional(ctx);
+      // We can remove parentheses only because we are sure that the
+      // `condition` must be a single `bool` value.
       while (
         ctx.condition.type === 'TupleExpression' &&
         !ctx.condition.isArray &&

--- a/src/parser.js
+++ b/src/parser.js
@@ -88,6 +88,13 @@ function parse(text, _parsers, options = _parsers) {
     },
     Conditional(ctx) {
       rearrangeConditional(ctx);
+      if (
+        ctx.condition.type === 'TupleExpression' &&
+        !ctx.condition.isArray &&
+        ctx.condition.components.length === 1
+      ) {
+        [ctx.condition] = ctx.condition.components;
+      }
     },
     BinaryOperation(ctx) {
       switch (ctx.operator) {

--- a/test.config.js
+++ b/test.config.js
@@ -16,13 +16,10 @@ export default {
     filename: 'test.cjs',
     path: path.resolve(__dirname, 'dist'),
     globalObject: `
-      typeof globalThis !== "undefined"
-        ? globalThis
-        : typeof global !== "undefined"
-        ? global
-        : typeof self !== "undefined"
-        ? self
-        : this || {}
+      typeof globalThis !== "undefined" ? globalThis
+      : typeof global !== "undefined" ? global
+      : typeof self !== "undefined" ? self
+      : this || {}
     `,
     library: {
       export: 'default',

--- a/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
+++ b/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
@@ -46,6 +46,14 @@ contract Conditional {
             makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
         : silent();
 
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+         isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
         isLoudReallyReallyReallyReallyLoud() ? silent() : (

--- a/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
+++ b/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
@@ -1,0 +1,186 @@
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+        isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+        isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+        isLoudReallyReallyReallyReallyLoud() ? silent() : (
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        );
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+        isCat() ? meow()
+        : isDog() ? bark()
+        : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+        isCat() ?
+            aNestedCondition ? theResult()
+            : theAlternate()
+        : isDog() ? bark()
+        : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+        x == 1 ? "one"
+        : x == 2 ? "two"
+        : x == 3 ? "three"
+        : (
+            x == 5 &&
+            y == 7 &&
+            someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+        ) ?
+            "four"
+        : x == 6 ? "six"
+        : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : anotherCondition ? "bar"
+        : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+        row[field] != "undefined" ? row[field]
+        : definition.defaults != "undefined" ? definition.defaults
+        : "null",
+        row[field] == "undefined" ?
+            definition.defaults == "undefined" ?
+            "null"
+            : definition.defaults
+        : row[field]
+        );
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return row[aVeryLongFieldName] != "undefined" ?
+            row[aVeryLongFieldName]
+            : "null";
+    }
+
+
+    function examples2() {string storage message =
+  i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+  : i % 3 == 0 ? "fizz"
+  : i % 5 == 0 ? "buzz"
+  : String(i);
+
+string storage paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage typeofExample =
+  definition.encode ?
+    definition.encode(
+      row[field] != "undefined" ? row[field]
+      : definition.defaults != "undefined" ? definition.defaults
+      : "null"
+    )
+  : row[field] != "undefined" ? row[field]
+  : definition.defaults != "undefined" ? definition.defaults
+  : "null";
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+string storage typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      row[field] == "undefined" ?
+        definition.defaults == "undefined" ?
+          "null"
+        : definition.defaults
+      : row[field]
+    )
+  : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+      "null"
+    : definition.defaults
+  : row[field];
+    }
+}
+
+

--- a/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
+++ b/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
@@ -2,6 +2,36 @@ pragma solidity ^0.4.24;
 
 
 contract Conditional {
+    function blogPostExample() {
+      // "curious" ternaries
+      string storage animalName =
+        pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ?
+          'cat'
+        : 'probably a bunny';
+
+      // "case-style" ternaries
+      string storage animalName =
+        pet.isScary() ? 'wolf'
+        : pet.canBark() ? 'dog'
+        : pet.canMeow() ? 'cat'
+        : 'probably a bunny';
+      
+      // fluidity between "case-style" and "curious" ternaries
+      string storage animalName =
+        pet.canSqueak() ? 'mouse'
+        : pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ? 'cat'
+        : pet.canSqueak() ? 'mouse'
+        : 'probably a bunny';
+    }
+
     function examples1() {
         // remain on one line if possible:
         string storage short = isLoud() ? makeNoise() : silent();

--- a/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
+++ b/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
@@ -75,6 +75,25 @@ contract Conditional {
             .thatWouldCauseALineBreak()
             .willCauseAnIndentButNotParens();
 
+        // Assignment also groups and indents as Variable Declaration:
+        assignment =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // illustrating case of mostly short conditionals
         string storage mostlyShort =
         x == 1 ? "one"

--- a/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
+++ b/tests/format/ExperimentalTernaries/ExperimentalTernaries.sol
@@ -142,6 +142,12 @@ contract Conditional {
         : row[field]
         );
 
+        // Conditional as a condition
+        (((foo ? 1 : bar))) ? 3 : 4;
+        (isCat() ? meow()
+        : isDog() ? bark()
+        : silent()) ? 1: 2;
+
         // In a return, break and over-indent:
         if (short) {
             return foo ? 1 : 2;

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -355,8 +355,7 @@ contract Conditional {
 
         // As a function parameter, don't add an extra indent:
         definition.encode(
-            row[field] != "undefined" ?
-                row[field]
+            row[field] != "undefined" ? row[field]
             : definition.defaults != "undefined" ? definition.defaults
             : "null",
             row[field] == "undefined" ?
@@ -413,8 +412,7 @@ contract Conditional {
         string storage typeofExample =
             definition.encode ?
                 definition.encode(
-                    row[field] != "undefined" ?
-                        row[field]
+                    row[field] != "undefined" ? row[field]
                     : definition.defaults != "undefined" ? definition.defaults
                     : "null"
                 )

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -262,7 +262,8 @@ contract Conditional {
             : (
                 isNotAnAdorableKittyCat() &&
                     (someReallyLongCondition || moreInThisLongCondition)
-            ) ? bark()
+            ) ?
+                bark()
             : shortCondition() ? shortConsequent()
             : someReallyLargeExpression
                 .thatWouldCauseALineBreak()
@@ -277,7 +278,8 @@ contract Conditional {
                 x == 5 &&
                     y == 7 &&
                     someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
-            ) ? "four"
+            ) ?
+                "four"
             : x == 6 ? "six"
             : "idk";
 
@@ -289,7 +291,9 @@ contract Conditional {
                     glimseGlyphsHazardNoopsTieTie >=
                     averredBathersBoxroomBuggyNurl()
                         .anodyneCondosMalateOverateRetinol()
-            ) ? "foo" : "bar";
+            ) ?
+                "foo"
+            : "bar";
 
         // long conditional, short consequent/alternate, chained
         // (break on short consequents iff in chained ternary and its conditional broke)
@@ -300,7 +304,8 @@ contract Conditional {
                     glimseGlyphsHazardNoopsTieTie >=
                     averredBathersBoxroomBuggyNurl()
                         .anodyneCondosMalateOverateRetinol()
-            ) ? "foo"
+            ) ?
+                "foo"
             : anotherCondition ? "bar"
             : "baz";
 

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -234,7 +234,8 @@ contract Conditional {
 
         // nested ternary in consequent always breaks:
         string storage chainedWithTernaryConsequent =
-            isCat() ? aNestedCondition ? theResult()
+            isCat() ?
+                aNestedCondition ? theResult()
                 : theAlternate()
             : isDog() ? bark()
             : silent();
@@ -358,12 +359,9 @@ contract Conditional {
 
         // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
         string storage typeofExampleFlipped =
-            definition.encode ?
-                definition.encode(
-                    row[field] == "undefined" ?
+            definition.encode ? definition.encode(row[field] == "undefined" ?
                         definition.defaults == "undefined" ? "null"
-                        : definition.defaults : row[field]
-                )
+                        : definition.defaults : row[field])
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
                 : definition.defaults

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -252,13 +252,17 @@ contract Conditional {
 
         // multiline conditions and consequents/alternates:
         string storage multilineConditionsConsequentsAndAlternates =
-            (isAnAdorableKittyCat() &&
-                (someReallyLongCondition || moreInThisLongCondition)) ?
+            (
+                isAnAdorableKittyCat() &&
+                    (someReallyLongCondition || moreInThisLongCondition)
+            ) ?
                 someReallyLargeExpression
                     .thatWouldCauseALineBreak()
                     .willCauseAnIndentButNotParens()
-            : (isNotAnAdorableKittyCat() &&
-                (someReallyLongCondition || moreInThisLongCondition)) ? bark()
+            : (
+                isNotAnAdorableKittyCat() &&
+                    (someReallyLongCondition || moreInThisLongCondition)
+            ) ? bark()
             : shortCondition() ? shortConsequent()
             : someReallyLargeExpression
                 .thatWouldCauseALineBreak()
@@ -269,30 +273,34 @@ contract Conditional {
             x == 1 ? "one"
             : x == 2 ? "two"
             : x == 3 ? "three"
-            : (x == 5 &&
-                y == 7 &&
-                someOtherThing
-                    .thatIsSoLong
-                    .thatItBreaksTheTestCondition()) ? "four"
+            : (
+                x == 5 &&
+                    y == 7 &&
+                    someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+            ) ? "four"
             : x == 6 ? "six"
             : "idk";
 
         // long conditional, short consequent/alternate, not chained - do indent after ?
         string storage longConditional =
-            (bifornCringerMoshedPerplexSawder ==
-                2 / askTrovenaBeenaDependsRowans &&
-                glimseGlyphsHazardNoopsTieTie >=
-                averredBathersBoxroomBuggyNurl()
-                    .anodyneCondosMalateOverateRetinol()) ? "foo" : "bar";
+            (
+                bifornCringerMoshedPerplexSawder ==
+                    2 / askTrovenaBeenaDependsRowans &&
+                    glimseGlyphsHazardNoopsTieTie >=
+                    averredBathersBoxroomBuggyNurl()
+                        .anodyneCondosMalateOverateRetinol()
+            ) ? "foo" : "bar";
 
         // long conditional, short consequent/alternate, chained
         // (break on short consequents iff in chained ternary and its conditional broke)
         string storage longConditionalChained =
-            (bifornCringerMoshedPerplexSawder ==
-                2 / askTrovenaBeenaDependsRowans &&
-                glimseGlyphsHazardNoopsTieTie >=
-                averredBathersBoxroomBuggyNurl()
-                    .anodyneCondosMalateOverateRetinol()) ? "foo"
+            (
+                bifornCringerMoshedPerplexSawder ==
+                    2 / askTrovenaBeenaDependsRowans &&
+                    glimseGlyphsHazardNoopsTieTie >=
+                    averredBathersBoxroomBuggyNurl()
+                        .anodyneCondosMalateOverateRetinol()
+            ) ? "foo"
             : anotherCondition ? "bar"
             : "baz";
 
@@ -301,8 +309,7 @@ contract Conditional {
             : definition.defaults != "undefined" ? definition.defaults
             : "null", row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
-                : definition.defaults
-            : row[field]);
+                : definition.defaults : row[field]);
 
         // In a return, break and over-indent:
         if (short) {
@@ -330,8 +337,8 @@ contract Conditional {
         string storage paymentMessageWithABreak =
             state == "success" ? "Payment completed successfully"
             : state == "processing" ? "Payment processing"
-            : state ==
-                "invalid_cvc" ? "There was an issue with your CVC number, and you need to take a prompt action on it."
+            : state == "invalid_cvc" ?
+                "There was an issue with your CVC number, and you need to take a prompt action on it."
             : state == "invalid_expiry" ? "Expiry must be sometime in the past."
             : "There was an issue with the payment.  Please contact support.";
 
@@ -350,8 +357,7 @@ contract Conditional {
                 definition.encode(
                     row[field] == "undefined" ?
                         definition.defaults == "undefined" ? "null"
-                        : definition.defaults
-                    : row[field]
+                        : definition.defaults : row[field]
                 )
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -348,11 +348,16 @@ contract Conditional {
             : "baz";
 
         // As a function parameter, don't add an extra indent:
-        definition.encode(row[field] != "undefined" ? row[field]
+        definition.encode(
+            row[field] != "undefined" ?
+                row[field]
             : definition.defaults != "undefined" ? definition.defaults
-            : "null", row[field] == "undefined" ?
+            : "null",
+            row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
-                : definition.defaults : row[field]);
+                : definition.defaults
+            : row[field]
+        );
 
         // In a return, break and over-indent:
         if (short) {
@@ -386,18 +391,25 @@ contract Conditional {
 
         string storage typeofExample =
             definition.encode ?
-                definition.encode(row[field] != "undefined" ? row[field]
+                definition.encode(
+                    row[field] != "undefined" ?
+                        row[field]
                     : definition.defaults != "undefined" ? definition.defaults
-                    : "null")
+                    : "null"
+                )
             : row[field] != "undefined" ? row[field]
             : definition.defaults != "undefined" ? definition.defaults
             : "null";
 
         // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
         string storage typeofExampleFlipped =
-            definition.encode ? definition.encode(row[field] == "undefined" ?
+            definition.encode ?
+                definition.encode(
+                    row[field] == "undefined" ?
                         definition.defaults == "undefined" ? "null"
-                        : definition.defaults : row[field])
+                        : definition.defaults
+                    : row[field]
+                )
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
                 : definition.defaults

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -367,15 +367,13 @@ contract Conditional {
 
         // Conditional as a condition
         (
-            foo ?
-                1
+            foo ? 1
             : bar
         ) ?
             3
         : 4;
         (
-            isCat() ?
-                meow()
+            isCat() ? meow()
             : isDog() ? bark()
             : silent()
         ) ?

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -367,11 +367,7 @@ contract Conditional {
         );
 
         // Conditional as a condition
-        (
-            foo ? 1 : bar
-        ) ?
-            3
-        : 4;
+        (foo ? 1 : bar) ? 3 : 4;
         (
             isCat() ? meow()
             : isDog() ? bark()

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,997 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true,"tabWidth":1} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["solidity-parse"]
+printWidth: 80
+tabWidth: 1
+                                                                                | printWidth
+=====================================input======================================
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function blogPostExample() {
+      // "curious" ternaries
+      string storage animalName =
+        pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ?
+          'cat'
+        : 'probably a bunny';
+
+      // "case-style" ternaries
+      string storage animalName =
+        pet.isScary() ? 'wolf'
+        : pet.canBark() ? 'dog'
+        : pet.canMeow() ? 'cat'
+        : 'probably a bunny';
+      
+      // fluidity between "case-style" and "curious" ternaries
+      string storage animalName =
+        pet.canSqueak() ? 'mouse'
+        : pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ? 'cat'
+        : pet.canSqueak() ? 'mouse'
+        : 'probably a bunny';
+    }
+
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+        isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+        isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+        isLoudReallyReallyReallyReallyLoud() ? silent() : (
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        );
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+        isCat() ? meow()
+        : isDog() ? bark()
+        : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+        isCat() ?
+            aNestedCondition ? theResult()
+            : theAlternate()
+        : isDog() ? bark()
+        : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // Assignment also groups and indents as Variable Declaration:
+        assignment =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+        x == 1 ? "one"
+        : x == 2 ? "two"
+        : x == 3 ? "three"
+        : (
+            x == 5 &&
+            y == 7 &&
+            someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+        ) ?
+            "four"
+        : x == 6 ? "six"
+        : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : anotherCondition ? "bar"
+        : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+        row[field] != "undefined" ? row[field]
+        : definition.defaults != "undefined" ? definition.defaults
+        : "null",
+        row[field] == "undefined" ?
+            definition.defaults == "undefined" ?
+            "null"
+            : definition.defaults
+        : row[field]
+        );
+
+        // Conditional as a condition
+        (((foo ? 1 : bar))) ? 3 : 4;
+        (isCat() ? meow()
+        : isDog() ? bark()
+        : silent()) ? 1: 2;
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return row[aVeryLongFieldName] != "undefined" ?
+            row[aVeryLongFieldName]
+            : "null";
+    }
+
+
+    function examples2() {string storage message =
+  i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+  : i % 3 == 0 ? "fizz"
+  : i % 5 == 0 ? "buzz"
+  : String(i);
+
+string storage paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage typeofExample =
+  definition.encode ?
+    definition.encode(
+      row[field] != "undefined" ? row[field]
+      : definition.defaults != "undefined" ? definition.defaults
+      : "null"
+    )
+  : row[field] != "undefined" ? row[field]
+  : definition.defaults != "undefined" ? definition.defaults
+  : "null";
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+string storage typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      row[field] == "undefined" ?
+        definition.defaults == "undefined" ?
+          "null"
+        : definition.defaults
+      : row[field]
+    )
+  : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+      "null"
+    : definition.defaults
+  : row[field];
+    }
+}
+
+
+
+=====================================output=====================================
+pragma solidity ^0.4.24;
+
+contract Conditional {
+ function blogPostExample() {
+  // "curious" ternaries
+  string storage animalName =
+   pet.canBark() ?
+    pet.isScary() ?
+     "wolf"
+    : "dog"
+   : pet.canMeow() ? "cat"
+   : "probably a bunny";
+
+  // "case-style" ternaries
+  string storage animalName =
+   pet.isScary() ? "wolf"
+   : pet.canBark() ? "dog"
+   : pet.canMeow() ? "cat"
+   : "probably a bunny";
+
+  // fluidity between "case-style" and "curious" ternaries
+  string storage animalName =
+   pet.canSqueak() ? "mouse"
+   : pet.canBark() ?
+    pet.isScary() ?
+     "wolf"
+    : "dog"
+   : pet.canMeow() ? "cat"
+   : pet.canSqueak() ? "mouse"
+   : "probably a bunny";
+ }
+
+ function examples1() {
+  // remain on one line if possible:
+  string storage short = isLoud() ? makeNoise() : silent();
+
+  // next, put everything after the =
+  string storage lessShort =
+   isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+  // next, indent the consequent:
+  string storage andIndented =
+   isLoudReallyReallyReallyReallyLoud() ?
+    makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+   : silent();
+
+  // unless the consequent is short (less than ten characters long):
+  string storage shortSoCase =
+   isLoudReallyReallyReallyReallyLoud() ? silent()
+   : (makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud());
+
+  // if chained, always break and put after the =
+  string storage chainedShort =
+   isCat() ? meow()
+   : isDog() ? bark()
+   : silent();
+
+  // when a consequent breaks in a chain:
+  string storage chainedWithLongConsequent =
+   isCat() ?
+    someReallyLargeExpression
+     .thatWouldCauseALineBreak()
+     .willCauseAnIndentButNotParens()
+   : isDog() ? bark()
+   : silent();
+
+  // nested ternary in consequent always breaks:
+  string storage chainedWithTernaryConsequent =
+   isCat() ?
+    aNestedCondition ?
+     theResult()
+    : theAlternate()
+   : isDog() ? bark()
+   : silent();
+
+  // consequent and terminal alternate break:
+  string storage consequentAndTerminalAlternateBreak =
+   isCat() ?
+    someReallyLargeExpression
+     .thatWouldCauseALineBreak()
+     .willCauseAnIndentButNotParens()
+   : isDog() ? bark()
+   : someReallyLargeExpression
+    .thatWouldCauseALineBreak()
+    .willCauseAnIndentButNotParens();
+
+  // multiline conditions and consequents/alternates:
+  string storage multilineConditionsConsequentsAndAlternates =
+   (
+    isAnAdorableKittyCat() &&
+    (someReallyLongCondition || moreInThisLongCondition)
+   ) ?
+    someReallyLargeExpression
+     .thatWouldCauseALineBreak()
+     .willCauseAnIndentButNotParens()
+   : (
+    isNotAnAdorableKittyCat() &&
+    (someReallyLongCondition || moreInThisLongCondition)
+   ) ?
+    bark()
+   : shortCondition() ? shortConsequent()
+   : someReallyLargeExpression
+    .thatWouldCauseALineBreak()
+    .willCauseAnIndentButNotParens();
+
+  // Assignment also groups and indents as Variable Declaration:
+  assignment = (
+   isAnAdorableKittyCat() &&
+   (someReallyLongCondition || moreInThisLongCondition)
+  ) ?
+   someReallyLargeExpression
+    .thatWouldCauseALineBreak()
+    .willCauseAnIndentButNotParens()
+  : (
+   isNotAnAdorableKittyCat() &&
+   (someReallyLongCondition || moreInThisLongCondition)
+  ) ?
+   bark()
+  : shortCondition() ? shortConsequent()
+  : someReallyLargeExpression
+   .thatWouldCauseALineBreak()
+   .willCauseAnIndentButNotParens();
+
+  // illustrating case of mostly short conditionals
+  string storage mostlyShort =
+   x == 1 ? "one"
+   : x == 2 ? "two"
+   : x == 3 ? "three"
+   : (
+    x == 5 &&
+    y == 7 &&
+    someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+   ) ?
+    "four"
+   : x == 6 ? "six"
+   : "idk";
+
+  // long conditional, short consequent/alternate, not chained - do indent after ?
+  string storage longConditional =
+   (
+    bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+    glimseGlyphsHazardNoopsTieTie >=
+    averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+   ) ?
+    "foo"
+   : "bar";
+
+  // long conditional, short consequent/alternate, chained
+  // (break on short consequents iff in chained ternary and its conditional broke)
+  string storage longConditionalChained =
+   (
+    bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+    glimseGlyphsHazardNoopsTieTie >=
+    averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+   ) ?
+    "foo"
+   : anotherCondition ? "bar"
+   : "baz";
+
+  // As a function parameter, don't add an extra indent:
+  definition.encode(
+   row[field] != "undefined" ? row[field]
+   : definition.defaults != "undefined" ? definition.defaults
+   : "null",
+   row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+     "null"
+    : definition.defaults
+   : row[field]
+  );
+
+  // Conditional as a condition
+  (foo ? 1 : bar) ? 3 : 4;
+  (
+   isCat() ? meow()
+   : isDog() ? bark()
+   : silent()
+  ) ?
+   1
+  : 2;
+
+  // In a return, break and over-indent:
+  if (short) {
+   return foo ? 1 : 2;
+  }
+  return row[aVeryLongFieldName] != "undefined" ? row[aVeryLongFieldName]
+  : "null";
+ }
+
+ function examples2() {
+  string storage message =
+   i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+   : i % 3 == 0 ? "fizz"
+   : i % 5 == 0 ? "buzz"
+   : String(i);
+
+  string storage paymentMessageShort =
+   state == "success" ? "Payment completed successfully"
+   : state == "processing" ? "Payment processing"
+   : state == "invalid_cvc" ? "There was an issue with your CVC number"
+   : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+   : "There was an issue with the payment.  Please contact support.";
+
+  string storage paymentMessageWithABreak =
+   state == "success" ? "Payment completed successfully"
+   : state == "processing" ? "Payment processing"
+   : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+   : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+   : "There was an issue with the payment.  Please contact support.";
+
+  string storage typeofExample =
+   definition.encode ?
+    definition.encode(
+     row[field] != "undefined" ? row[field]
+     : definition.defaults != "undefined" ? definition.defaults
+     : "null"
+    )
+   : row[field] != "undefined" ? row[field]
+   : definition.defaults != "undefined" ? definition.defaults
+   : "null";
+
+  // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+  string storage typeofExampleFlipped =
+   definition.encode ?
+    definition.encode(
+     row[field] == "undefined" ?
+      definition.defaults == "undefined" ?
+       "null"
+      : definition.defaults
+     : row[field]
+    )
+   : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+     "null"
+    : definition.defaults
+   : row[field];
+ }
+}
+
+================================================================================
+`;
+
+exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true,"useTabs":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["solidity-parse"]
+printWidth: 80
+useTabs: true
+                                                                                | printWidth
+=====================================input======================================
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function blogPostExample() {
+      // "curious" ternaries
+      string storage animalName =
+        pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ?
+          'cat'
+        : 'probably a bunny';
+
+      // "case-style" ternaries
+      string storage animalName =
+        pet.isScary() ? 'wolf'
+        : pet.canBark() ? 'dog'
+        : pet.canMeow() ? 'cat'
+        : 'probably a bunny';
+      
+      // fluidity between "case-style" and "curious" ternaries
+      string storage animalName =
+        pet.canSqueak() ? 'mouse'
+        : pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ? 'cat'
+        : pet.canSqueak() ? 'mouse'
+        : 'probably a bunny';
+    }
+
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+        isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+        isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+        isLoudReallyReallyReallyReallyLoud() ? silent() : (
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        );
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+        isCat() ? meow()
+        : isDog() ? bark()
+        : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+        isCat() ?
+            aNestedCondition ? theResult()
+            : theAlternate()
+        : isDog() ? bark()
+        : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // Assignment also groups and indents as Variable Declaration:
+        assignment =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+        x == 1 ? "one"
+        : x == 2 ? "two"
+        : x == 3 ? "three"
+        : (
+            x == 5 &&
+            y == 7 &&
+            someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+        ) ?
+            "four"
+        : x == 6 ? "six"
+        : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : anotherCondition ? "bar"
+        : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+        row[field] != "undefined" ? row[field]
+        : definition.defaults != "undefined" ? definition.defaults
+        : "null",
+        row[field] == "undefined" ?
+            definition.defaults == "undefined" ?
+            "null"
+            : definition.defaults
+        : row[field]
+        );
+
+        // Conditional as a condition
+        (((foo ? 1 : bar))) ? 3 : 4;
+        (isCat() ? meow()
+        : isDog() ? bark()
+        : silent()) ? 1: 2;
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return row[aVeryLongFieldName] != "undefined" ?
+            row[aVeryLongFieldName]
+            : "null";
+    }
+
+
+    function examples2() {string storage message =
+  i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+  : i % 3 == 0 ? "fizz"
+  : i % 5 == 0 ? "buzz"
+  : String(i);
+
+string storage paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage typeofExample =
+  definition.encode ?
+    definition.encode(
+      row[field] != "undefined" ? row[field]
+      : definition.defaults != "undefined" ? definition.defaults
+      : "null"
+    )
+  : row[field] != "undefined" ? row[field]
+  : definition.defaults != "undefined" ? definition.defaults
+  : "null";
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+string storage typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      row[field] == "undefined" ?
+        definition.defaults == "undefined" ?
+          "null"
+        : definition.defaults
+      : row[field]
+    )
+  : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+      "null"
+    : definition.defaults
+  : row[field];
+    }
+}
+
+
+
+=====================================output=====================================
+pragma solidity ^0.4.24;
+
+contract Conditional {
+	function blogPostExample() {
+		// "curious" ternaries
+		string storage animalName =
+			pet.canBark() ?
+				pet.isScary() ?
+					"wolf"
+				:	"dog"
+			: pet.canMeow() ? "cat"
+			: "probably a bunny";
+
+		// "case-style" ternaries
+		string storage animalName =
+			pet.isScary() ? "wolf"
+			: pet.canBark() ? "dog"
+			: pet.canMeow() ? "cat"
+			: "probably a bunny";
+
+		// fluidity between "case-style" and "curious" ternaries
+		string storage animalName =
+			pet.canSqueak() ? "mouse"
+			: pet.canBark() ?
+				pet.isScary() ?
+					"wolf"
+				:	"dog"
+			: pet.canMeow() ? "cat"
+			: pet.canSqueak() ? "mouse"
+			: "probably a bunny";
+	}
+
+	function examples1() {
+		// remain on one line if possible:
+		string storage short = isLoud() ? makeNoise() : silent();
+
+		// next, put everything after the =
+		string storage lessShort =
+			isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+		// next, indent the consequent:
+		string storage andIndented =
+			isLoudReallyReallyReallyReallyLoud() ?
+				makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+			:	silent();
+
+		// unless the consequent is short (less than ten characters long):
+		string storage shortSoCase =
+			isLoudReallyReallyReallyReallyLoud() ? silent()
+			: (makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud());
+
+		// if chained, always break and put after the =
+		string storage chainedShort =
+			isCat() ? meow()
+			: isDog() ? bark()
+			: silent();
+
+		// when a consequent breaks in a chain:
+		string storage chainedWithLongConsequent =
+			isCat() ?
+				someReallyLargeExpression
+					.thatWouldCauseALineBreak()
+					.willCauseAnIndentButNotParens()
+			: isDog() ? bark()
+			: silent();
+
+		// nested ternary in consequent always breaks:
+		string storage chainedWithTernaryConsequent =
+			isCat() ?
+				aNestedCondition ?
+					theResult()
+				:	theAlternate()
+			: isDog() ? bark()
+			: silent();
+
+		// consequent and terminal alternate break:
+		string storage consequentAndTerminalAlternateBreak =
+			isCat() ?
+				someReallyLargeExpression
+					.thatWouldCauseALineBreak()
+					.willCauseAnIndentButNotParens()
+			: isDog() ? bark()
+			: someReallyLargeExpression
+				.thatWouldCauseALineBreak()
+				.willCauseAnIndentButNotParens();
+
+		// multiline conditions and consequents/alternates:
+		string storage multilineConditionsConsequentsAndAlternates =
+			(
+				isAnAdorableKittyCat() &&
+				(someReallyLongCondition || moreInThisLongCondition)
+			) ?
+				someReallyLargeExpression
+					.thatWouldCauseALineBreak()
+					.willCauseAnIndentButNotParens()
+			: (
+				isNotAnAdorableKittyCat() &&
+				(someReallyLongCondition || moreInThisLongCondition)
+			) ?
+				bark()
+			: shortCondition() ? shortConsequent()
+			: someReallyLargeExpression
+				.thatWouldCauseALineBreak()
+				.willCauseAnIndentButNotParens();
+
+		// Assignment also groups and indents as Variable Declaration:
+		assignment = (
+			isAnAdorableKittyCat() &&
+			(someReallyLongCondition || moreInThisLongCondition)
+		) ?
+			someReallyLargeExpression
+				.thatWouldCauseALineBreak()
+				.willCauseAnIndentButNotParens()
+		: (
+			isNotAnAdorableKittyCat() &&
+			(someReallyLongCondition || moreInThisLongCondition)
+		) ?
+			bark()
+		: shortCondition() ? shortConsequent()
+		: someReallyLargeExpression
+			.thatWouldCauseALineBreak()
+			.willCauseAnIndentButNotParens();
+
+		// illustrating case of mostly short conditionals
+		string storage mostlyShort =
+			x == 1 ? "one"
+			: x == 2 ? "two"
+			: x == 3 ? "three"
+			: (
+				x == 5 &&
+				y == 7 &&
+				someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+			) ?
+				"four"
+			: x == 6 ? "six"
+			: "idk";
+
+		// long conditional, short consequent/alternate, not chained - do indent after ?
+		string storage longConditional =
+			(
+				bifornCringerMoshedPerplexSawder ==
+					2 / askTrovenaBeenaDependsRowans &&
+				glimseGlyphsHazardNoopsTieTie >=
+				averredBathersBoxroomBuggyNurl()
+					.anodyneCondosMalateOverateRetinol()
+			) ?
+				"foo"
+			:	"bar";
+
+		// long conditional, short consequent/alternate, chained
+		// (break on short consequents iff in chained ternary and its conditional broke)
+		string storage longConditionalChained =
+			(
+				bifornCringerMoshedPerplexSawder ==
+					2 / askTrovenaBeenaDependsRowans &&
+				glimseGlyphsHazardNoopsTieTie >=
+				averredBathersBoxroomBuggyNurl()
+					.anodyneCondosMalateOverateRetinol()
+			) ?
+				"foo"
+			: anotherCondition ? "bar"
+			: "baz";
+
+		// As a function parameter, don't add an extra indent:
+		definition.encode(
+			row[field] != "undefined" ? row[field]
+			: definition.defaults != "undefined" ? definition.defaults
+			: "null",
+			row[field] == "undefined" ?
+				definition.defaults == "undefined" ?
+					"null"
+				:	definition.defaults
+			:	row[field]
+		);
+
+		// Conditional as a condition
+		(foo ? 1 : bar) ? 3 : 4;
+		(
+			isCat() ? meow()
+			: isDog() ? bark()
+			: silent()
+		) ?
+			1
+		:	2;
+
+		// In a return, break and over-indent:
+		if (short) {
+			return foo ? 1 : 2;
+		}
+		return row[aVeryLongFieldName] != "undefined" ? row[aVeryLongFieldName]
+		: "null";
+	}
+
+	function examples2() {
+		string storage message =
+			i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+			: i % 3 == 0 ? "fizz"
+			: i % 5 == 0 ? "buzz"
+			: String(i);
+
+		string storage paymentMessageShort =
+			state == "success" ? "Payment completed successfully"
+			: state == "processing" ? "Payment processing"
+			: state == "invalid_cvc" ? "There was an issue with your CVC number"
+			: state == "invalid_expiry" ? "Expiry must be sometime in the past."
+			: "There was an issue with the payment.  Please contact support.";
+
+		string storage paymentMessageWithABreak =
+			state == "success" ? "Payment completed successfully"
+			: state == "processing" ? "Payment processing"
+			: state == "invalid_cvc" ?
+				"There was an issue with your CVC number, and you need to take a prompt action on it."
+			: state == "invalid_expiry" ? "Expiry must be sometime in the past."
+			: "There was an issue with the payment.  Please contact support.";
+
+		string storage typeofExample =
+			definition.encode ?
+				definition.encode(
+					row[field] != "undefined" ? row[field]
+					: definition.defaults != "undefined" ? definition.defaults
+					: "null"
+				)
+			: row[field] != "undefined" ? row[field]
+			: definition.defaults != "undefined" ? definition.defaults
+			: "null";
+
+		// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+		string storage typeofExampleFlipped =
+			definition.encode ?
+				definition.encode(
+					row[field] == "undefined" ?
+						definition.defaults == "undefined" ?
+							"null"
+						:	definition.defaults
+					:	row[field]
+				)
+			: row[field] == "undefined" ?
+				definition.defaults == "undefined" ?
+					"null"
+				:	definition.defaults
+			:	row[field];
+	}
+}
+
+================================================================================
+`;
+
 exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -259,7 +1251,7 @@ contract Conditional {
             pet.canBark() ?
                 pet.isScary() ?
                     "wolf"
-                : "dog"
+                :   "dog"
             : pet.canMeow() ? "cat"
             : "probably a bunny";
 
@@ -276,7 +1268,7 @@ contract Conditional {
             : pet.canBark() ?
                 pet.isScary() ?
                     "wolf"
-                : "dog"
+                :   "dog"
             : pet.canMeow() ? "cat"
             : pet.canSqueak() ? "mouse"
             : "probably a bunny";
@@ -294,7 +1286,7 @@ contract Conditional {
         string storage andIndented =
             isLoudReallyReallyReallyReallyLoud() ?
                 makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
-            : silent();
+            :   silent();
 
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
@@ -321,7 +1313,7 @@ contract Conditional {
             isCat() ?
                 aNestedCondition ?
                     theResult()
-                : theAlternate()
+                :   theAlternate()
             : isDog() ? bark()
             : silent();
 
@@ -397,7 +1389,7 @@ contract Conditional {
                     .anodyneCondosMalateOverateRetinol()
             ) ?
                 "foo"
-            : "bar";
+            :   "bar";
 
         // long conditional, short consequent/alternate, chained
         // (break on short consequents iff in chained ternary and its conditional broke)
@@ -421,8 +1413,8 @@ contract Conditional {
             row[field] == "undefined" ?
                 definition.defaults == "undefined" ?
                     "null"
-                : definition.defaults
-            : row[field]
+                :   definition.defaults
+            :   row[field]
         );
 
         // Conditional as a condition
@@ -433,7 +1425,7 @@ contract Conditional {
             : silent()
         ) ?
             1
-        : 2;
+        :   2;
 
         // In a return, break and over-indent:
         if (short) {
@@ -483,14 +1475,14 @@ contract Conditional {
                     row[field] == "undefined" ?
                         definition.defaults == "undefined" ?
                             "null"
-                        : definition.defaults
-                    : row[field]
+                        :   definition.defaults
+                    :   row[field]
                 )
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ?
                     "null"
-                : definition.defaults
-            : row[field];
+                :   definition.defaults
+            :   row[field];
     }
 }
 

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,36 @@ pragma solidity ^0.4.24;
 
 
 contract Conditional {
+    function blogPostExample() {
+      // "curious" ternaries
+      string storage animalName =
+        pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ?
+          'cat'
+        : 'probably a bunny';
+
+      // "case-style" ternaries
+      string storage animalName =
+        pet.isScary() ? 'wolf'
+        : pet.canBark() ? 'dog'
+        : pet.canMeow() ? 'cat'
+        : 'probably a bunny';
+      
+      // fluidity between "case-style" and "curious" ternaries
+      string storage animalName =
+        pet.canSqueak() ? 'mouse'
+        : pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ? 'cat'
+        : pet.canSqueak() ? 'mouse'
+        : 'probably a bunny';
+    }
+
     function examples1() {
         // remain on one line if possible:
         string storage short = isLoud() ? makeNoise() : silent();
@@ -223,6 +253,35 @@ string storage typeofExampleFlipped =
 pragma solidity ^0.4.24;
 
 contract Conditional {
+    function blogPostExample() {
+        // "curious" ternaries
+        string storage animalName =
+            pet.canBark() ?
+                pet.isScary() ?
+                    "wolf"
+                : "dog"
+            : pet.canMeow() ? "cat"
+            : "probably a bunny";
+
+        // "case-style" ternaries
+        string storage animalName =
+            pet.isScary() ? "wolf"
+            : pet.canBark() ? "dog"
+            : pet.canMeow() ? "cat"
+            : "probably a bunny";
+
+        // fluidity between "case-style" and "curious" ternaries
+        string storage animalName =
+            pet.canSqueak() ? "mouse"
+            : pet.canBark() ?
+                pet.isScary() ?
+                    "wolf"
+                : "dog"
+            : pet.canMeow() ? "cat"
+            : pet.canSqueak() ? "mouse"
+            : "probably a bunny";
+    }
+
     function examples1() {
         // remain on one line if possible:
         string storage short = isLoud() ? makeNoise() : silent();
@@ -448,6 +507,36 @@ pragma solidity ^0.4.24;
 
 
 contract Conditional {
+    function blogPostExample() {
+      // "curious" ternaries
+      string storage animalName =
+        pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ?
+          'cat'
+        : 'probably a bunny';
+
+      // "case-style" ternaries
+      string storage animalName =
+        pet.isScary() ? 'wolf'
+        : pet.canBark() ? 'dog'
+        : pet.canMeow() ? 'cat'
+        : 'probably a bunny';
+      
+      // fluidity between "case-style" and "curious" ternaries
+      string storage animalName =
+        pet.canSqueak() ? 'mouse'
+        : pet.canBark() ?
+          pet.isScary() ?
+            'wolf'
+          : 'dog'
+        : pet.canMeow() ? 'cat'
+        : pet.canSqueak() ? 'mouse'
+        : 'probably a bunny';
+    }
+
     function examples1() {
         // remain on one line if possible:
         string storage short = isLoud() ? makeNoise() : silent();
@@ -660,6 +749,39 @@ string storage typeofExampleFlipped =
 pragma solidity ^0.4.24;
 
 contract Conditional {
+    function blogPostExample() {
+        // "curious" ternaries
+        string storage animalName = pet.canBark()
+            ? pet.isScary()
+                ? "wolf"
+                : "dog"
+            : pet.canMeow()
+                ? "cat"
+                : "probably a bunny";
+
+        // "case-style" ternaries
+        string storage animalName = pet.isScary()
+            ? "wolf"
+            : pet.canBark()
+                ? "dog"
+                : pet.canMeow()
+                    ? "cat"
+                    : "probably a bunny";
+
+        // fluidity between "case-style" and "curious" ternaries
+        string storage animalName = pet.canSqueak()
+            ? "mouse"
+            : pet.canBark()
+                ? pet.isScary()
+                    ? "wolf"
+                    : "dog"
+                : pet.canMeow()
+                    ? "cat"
+                    : pet.canSqueak()
+                        ? "mouse"
+                        : "probably a bunny";
+    }
+
     function examples1() {
         // remain on one line if possible:
         string storage short = isLoud() ? makeNoise() : silent();

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -348,25 +348,18 @@ contract Conditional {
             : "baz";
 
         // As a function parameter, don't add an extra indent:
-        definition.encode(
-            row[field] != "undefined" ?
-                row[field]
+        definition.encode(row[field] != "undefined" ? row[field]
             : definition.defaults != "undefined" ? definition.defaults
-            : "null",
-            row[field] == "undefined" ?
-
+            : "null", row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
-                : definition.defaults
-            : row[field]
-        );
+                : definition.defaults : row[field]);
 
         // In a return, break and over-indent:
         if (short) {
             return foo ? 1 : 2;
         }
-        return
-            row[aVeryLongFieldName] != "undefined" ? row[aVeryLongFieldName]
-            : "null";
+        return row[aVeryLongFieldName] != "undefined" ? row[aVeryLongFieldName]
+        : "null";
     }
 
     function examples2() {
@@ -393,26 +386,18 @@ contract Conditional {
 
         string storage typeofExample =
             definition.encode ?
-                definition.encode(
-                    row[field] != "undefined" ?
-                        row[field]
+                definition.encode(row[field] != "undefined" ? row[field]
                     : definition.defaults != "undefined" ? definition.defaults
-                    : "null"
-                )
+                    : "null")
             : row[field] != "undefined" ? row[field]
             : definition.defaults != "undefined" ? definition.defaults
             : "null";
 
         // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
         string storage typeofExampleFlipped =
-            definition.encode ?
-                definition.encode(
-                    row[field] == "undefined" ?
-
+            definition.encode ? definition.encode(row[field] == "undefined" ?
                         definition.defaults == "undefined" ? "null"
-                        : definition.defaults
-                    : row[field]
-                )
+                        : definition.defaults : row[field])
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
                 : definition.defaults

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -151,6 +151,12 @@ contract Conditional {
         : row[field]
         );
 
+        // Conditional as a condition
+        (((foo ? 1 : bar))) ? 3 : 4;
+        (isCat() ? meow()
+        : isDog() ? bark()
+        : silent()) ? 1: 2;
+
         // In a return, break and over-indent:
         if (short) {
             return foo ? 1 : 2;
@@ -358,6 +364,23 @@ contract Conditional {
                 : definition.defaults
             : row[field]
         );
+
+        // Conditional as a condition
+        (
+            foo ?
+                1
+            : bar
+        ) ?
+            3
+        : 4;
+        (
+            isCat() ?
+                meow()
+            : isDog() ? bark()
+            : silent()
+        ) ?
+            1
+        : 2;
 
         // In a return, break and over-indent:
         if (short) {
@@ -570,6 +593,12 @@ contract Conditional {
         : row[field]
         );
 
+        // Conditional as a condition
+        (((foo ? 1 : bar))) ? 3 : 4;
+        (isCat() ? meow()
+        : isDog() ? bark()
+        : silent()) ? 1: 2;
+
         // In a return, break and over-indent:
         if (short) {
             return foo ? 1 : 2;
@@ -773,6 +802,18 @@ contract Conditional {
                     : definition.defaults
                 : row[field]
         );
+
+        // Conditional as a condition
+        (foo ? 1 : bar) ? 3 : 4;
+        (
+            isCat()
+                ? meow()
+                : isDog()
+                    ? bark()
+                    : silent()
+        )
+            ? 1
+            : 2;
 
         // In a return, break and over-indent:
         if (short) {

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -272,13 +272,17 @@ contract Conditional {
 
         // multiline conditions and consequents/alternates:
         string storage multilineConditionsConsequentsAndAlternates =
-            isAnAdorableKittyCat() &&
-                (someReallyLongCondition || moreInThisLongCondition) ?
+            (
+                isAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)
+            ) ?
                 someReallyLargeExpression
                     .thatWouldCauseALineBreak()
                     .willCauseAnIndentButNotParens()
-            : isNotAnAdorableKittyCat() &&
-                (someReallyLongCondition || moreInThisLongCondition) ?
+            : (
+                isNotAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)
+            ) ?
                 bark()
             : shortCondition() ? shortConsequent()
             : someReallyLargeExpression
@@ -286,13 +290,17 @@ contract Conditional {
                 .willCauseAnIndentButNotParens();
 
         // Assignment also groups and indents as Variable Declaration:
-        assignment = isAnAdorableKittyCat() &&
-            (someReallyLongCondition || moreInThisLongCondition) ?
+        assignment = (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
             someReallyLargeExpression
                 .thatWouldCauseALineBreak()
                 .willCauseAnIndentButNotParens()
-        : isNotAnAdorableKittyCat() &&
-            (someReallyLongCondition || moreInThisLongCondition) ?
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
             bark()
         : shortCondition() ? shortConsequent()
         : someReallyLargeExpression
@@ -304,31 +312,37 @@ contract Conditional {
             x == 1 ? "one"
             : x == 2 ? "two"
             : x == 3 ? "three"
-            : x == 5 &&
+            : (
+                x == 5 &&
                 y == 7 &&
-                someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition() ?
+                someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+            ) ?
                 "four"
             : x == 6 ? "six"
             : "idk";
 
         // long conditional, short consequent/alternate, not chained - do indent after ?
         string storage longConditional =
-            bifornCringerMoshedPerplexSawder ==
-                2 / askTrovenaBeenaDependsRowans &&
+            (
+                bifornCringerMoshedPerplexSawder ==
+                    2 / askTrovenaBeenaDependsRowans &&
                 glimseGlyphsHazardNoopsTieTie >=
                 averredBathersBoxroomBuggyNurl()
-                    .anodyneCondosMalateOverateRetinol() ?
+                    .anodyneCondosMalateOverateRetinol()
+            ) ?
                 "foo"
             : "bar";
 
         // long conditional, short consequent/alternate, chained
         // (break on short consequents iff in chained ternary and its conditional broke)
         string storage longConditionalChained =
-            bifornCringerMoshedPerplexSawder ==
-                2 / askTrovenaBeenaDependsRowans &&
+            (
+                bifornCringerMoshedPerplexSawder ==
+                    2 / askTrovenaBeenaDependsRowans &&
                 glimseGlyphsHazardNoopsTieTie >=
                 averredBathersBoxroomBuggyNurl()
-                    .anodyneCondosMalateOverateRetinol() ?
+                    .anodyneCondosMalateOverateRetinol()
+            ) ?
                 "foo"
             : anotherCondition ? "bar"
             : "baz";

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -56,6 +56,14 @@ contract Conditional {
             makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
         : silent();
 
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+         isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
         isLoudReallyReallyReallyReallyLoud() ? silent() : (
@@ -296,6 +304,14 @@ contract Conditional {
    isLoudReallyReallyReallyReallyLoud() ?
     makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
    : silent();
+
+  // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+  string storage indentationInFalseExpression =
+   isLoudReallyReallyReallyReallyLoud() ?
+    makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+   : someReallyLargeExpression
+     .thatWouldCauseALineBreak()
+     .willCauseAnIndentButNotParens();
 
   // unless the consequent is short (less than ten characters long):
   string storage shortSoCase =
@@ -550,6 +566,14 @@ contract Conditional {
             makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
         : silent();
 
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+         isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
         isLoudReallyReallyReallyReallyLoud() ? silent() : (
@@ -790,6 +814,14 @@ contract Conditional {
 			isLoudReallyReallyReallyReallyLoud() ?
 				makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
 			:	silent();
+
+		// if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+		string storage indentationInFalseExpression =
+			isLoudReallyReallyReallyReallyLoud() ?
+				makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+			:	someReallyLargeExpression
+					.thatWouldCauseALineBreak()
+					.willCauseAnIndentButNotParens();
 
 		// unless the consequent is short (less than ten characters long):
 		string storage shortSoCase =
@@ -1047,6 +1079,14 @@ contract Conditional {
             makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
         : silent();
 
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+         isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
         isLoudReallyReallyReallyReallyLoud() ? silent() : (
@@ -1287,6 +1327,14 @@ contract Conditional {
             isLoudReallyReallyReallyReallyLoud() ?
                 makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
             :   silent();
+
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+            isLoudReallyReallyReallyReallyLoud() ?
+                makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+            :   someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens();
 
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
@@ -1543,6 +1591,14 @@ contract Conditional {
             makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
         : silent();
 
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string storage indentationInFalseExpression =
+         isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase =
         isLoudReallyReallyReallyReallyLoud() ? silent() : (
@@ -1787,6 +1843,14 @@ contract Conditional {
         string storage andIndented = isLoudReallyReallyReallyReallyLoud()
             ? makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
             : silent();
+
+        // if we need to add spaces to the falseExpression to fill a tab, we indent it as well:
+        string
+            storage indentationInFalseExpression = isLoudReallyReallyReallyReallyLoud()
+                ? makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+                : someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens();
 
         // unless the consequent is short (less than ten characters long):
         string storage shortSoCase = isLoudReallyReallyReallyReallyLoud()

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -260,7 +260,8 @@ contract Conditional {
         // nested ternary in consequent always breaks:
         string storage chainedWithTernaryConsequent =
             isCat() ?
-                aNestedCondition ? theResult()
+                aNestedCondition ?
+                    theResult()
                 : theAlternate()
             : isDog() ? bark()
             : silent();
@@ -359,15 +360,15 @@ contract Conditional {
             : definition.defaults != "undefined" ? definition.defaults
             : "null",
             row[field] == "undefined" ?
-                definition.defaults == "undefined" ? "null"
+                definition.defaults == "undefined" ?
+                    "null"
                 : definition.defaults
             : row[field]
         );
 
         // Conditional as a condition
         (
-            foo ? 1
-            : bar
+            foo ? 1 : bar
         ) ?
             3
         : 4;
@@ -425,12 +426,14 @@ contract Conditional {
             definition.encode ?
                 definition.encode(
                     row[field] == "undefined" ?
-                        definition.defaults == "undefined" ? "null"
+                        definition.defaults == "undefined" ?
+                            "null"
                         : definition.defaults
                     : row[field]
                 )
             : row[field] == "undefined" ?
-                definition.defaults == "undefined" ? "null"
+                definition.defaults == "undefined" ?
+                    "null"
                 : definition.defaults
             : row[field];
     }

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -84,6 +84,25 @@ contract Conditional {
             .thatWouldCauseALineBreak()
             .willCauseAnIndentButNotParens();
 
+        // Assignment also groups and indents as Variable Declaration:
+        assignment =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // illustrating case of mostly short conditionals
         string storage mostlyShort =
         x == 1 ? "one"
@@ -253,69 +272,79 @@ contract Conditional {
 
         // multiline conditions and consequents/alternates:
         string storage multilineConditionsConsequentsAndAlternates =
-            (
-                isAnAdorableKittyCat() &&
-                    (someReallyLongCondition || moreInThisLongCondition)
-            ) ?
+            isAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition) ?
                 someReallyLargeExpression
                     .thatWouldCauseALineBreak()
                     .willCauseAnIndentButNotParens()
-            : (
-                isNotAnAdorableKittyCat() &&
-                    (someReallyLongCondition || moreInThisLongCondition)
-            ) ?
+            : isNotAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition) ?
                 bark()
             : shortCondition() ? shortConsequent()
             : someReallyLargeExpression
                 .thatWouldCauseALineBreak()
                 .willCauseAnIndentButNotParens();
 
+        // Assignment also groups and indents as Variable Declaration:
+        assignment = isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition) ?
+            someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens()
+        : isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
         // illustrating case of mostly short conditionals
         string storage mostlyShort =
             x == 1 ? "one"
             : x == 2 ? "two"
             : x == 3 ? "three"
-            : (
-                x == 5 &&
-                    y == 7 &&
-                    someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
-            ) ?
+            : x == 5 &&
+                y == 7 &&
+                someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition() ?
                 "four"
             : x == 6 ? "six"
             : "idk";
 
         // long conditional, short consequent/alternate, not chained - do indent after ?
         string storage longConditional =
-            (
-                bifornCringerMoshedPerplexSawder ==
-                    2 / askTrovenaBeenaDependsRowans &&
-                    glimseGlyphsHazardNoopsTieTie >=
-                    averredBathersBoxroomBuggyNurl()
-                        .anodyneCondosMalateOverateRetinol()
-            ) ?
+            bifornCringerMoshedPerplexSawder ==
+                2 / askTrovenaBeenaDependsRowans &&
+                glimseGlyphsHazardNoopsTieTie >=
+                averredBathersBoxroomBuggyNurl()
+                    .anodyneCondosMalateOverateRetinol() ?
                 "foo"
             : "bar";
 
         // long conditional, short consequent/alternate, chained
         // (break on short consequents iff in chained ternary and its conditional broke)
         string storage longConditionalChained =
-            (
-                bifornCringerMoshedPerplexSawder ==
-                    2 / askTrovenaBeenaDependsRowans &&
-                    glimseGlyphsHazardNoopsTieTie >=
-                    averredBathersBoxroomBuggyNurl()
-                        .anodyneCondosMalateOverateRetinol()
-            ) ?
+            bifornCringerMoshedPerplexSawder ==
+                2 / askTrovenaBeenaDependsRowans &&
+                glimseGlyphsHazardNoopsTieTie >=
+                averredBathersBoxroomBuggyNurl()
+                    .anodyneCondosMalateOverateRetinol() ?
                 "foo"
             : anotherCondition ? "bar"
             : "baz";
 
         // As a function parameter, don't add an extra indent:
-        definition.encode(row[field] != "undefined" ? row[field]
+        definition.encode(
+            row[field] != "undefined" ?
+                row[field]
             : definition.defaults != "undefined" ? definition.defaults
-            : "null", row[field] == "undefined" ?
+            : "null",
+            row[field] == "undefined" ?
+
                 definition.defaults == "undefined" ? "null"
-                : definition.defaults : row[field]);
+                : definition.defaults
+            : row[field]
+        );
 
         // In a return, break and over-indent:
         if (short) {
@@ -350,22 +379,457 @@ contract Conditional {
 
         string storage typeofExample =
             definition.encode ?
-                definition.encode(row[field] != "undefined" ? row[field]
+                definition.encode(
+                    row[field] != "undefined" ?
+                        row[field]
                     : definition.defaults != "undefined" ? definition.defaults
-                    : "null")
+                    : "null"
+                )
             : row[field] != "undefined" ? row[field]
             : definition.defaults != "undefined" ? definition.defaults
             : "null";
 
         // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
         string storage typeofExampleFlipped =
-            definition.encode ? definition.encode(row[field] == "undefined" ?
+            definition.encode ?
+                definition.encode(
+                    row[field] == "undefined" ?
+
                         definition.defaults == "undefined" ? "null"
-                        : definition.defaults : row[field])
+                        : definition.defaults
+                    : row[field]
+                )
             : row[field] == "undefined" ?
                 definition.defaults == "undefined" ? "null"
                 : definition.defaults
             : row[field];
+    }
+}
+
+================================================================================
+`;
+
+exports[`ExperimentalTernaries.sol format 1`] = `
+====================================options=====================================
+parsers: ["solidity-parse"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+        isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+        isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+        isLoudReallyReallyReallyReallyLoud() ? silent() : (
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        );
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+        isCat() ? meow()
+        : isDog() ? bark()
+        : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+        isCat() ?
+            aNestedCondition ? theResult()
+            : theAlternate()
+        : isDog() ? bark()
+        : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // Assignment also groups and indents as Variable Declaration:
+        assignment =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+        x == 1 ? "one"
+        : x == 2 ? "two"
+        : x == 3 ? "three"
+        : (
+            x == 5 &&
+            y == 7 &&
+            someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+        ) ?
+            "four"
+        : x == 6 ? "six"
+        : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : anotherCondition ? "bar"
+        : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+        row[field] != "undefined" ? row[field]
+        : definition.defaults != "undefined" ? definition.defaults
+        : "null",
+        row[field] == "undefined" ?
+            definition.defaults == "undefined" ?
+            "null"
+            : definition.defaults
+        : row[field]
+        );
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return row[aVeryLongFieldName] != "undefined" ?
+            row[aVeryLongFieldName]
+            : "null";
+    }
+
+
+    function examples2() {string storage message =
+  i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+  : i % 3 == 0 ? "fizz"
+  : i % 5 == 0 ? "buzz"
+  : String(i);
+
+string storage paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage typeofExample =
+  definition.encode ?
+    definition.encode(
+      row[field] != "undefined" ? row[field]
+      : definition.defaults != "undefined" ? definition.defaults
+      : "null"
+    )
+  : row[field] != "undefined" ? row[field]
+  : definition.defaults != "undefined" ? definition.defaults
+  : "null";
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+string storage typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      row[field] == "undefined" ?
+        definition.defaults == "undefined" ?
+          "null"
+        : definition.defaults
+      : row[field]
+    )
+  : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+      "null"
+    : definition.defaults
+  : row[field];
+    }
+}
+
+
+
+=====================================output=====================================
+pragma solidity ^0.4.24;
+
+contract Conditional {
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort = isLoudReallyLoud()
+            ? makeNoiseReallyLoudly.omgSoLoud()
+            : silent();
+
+        // next, indent the consequent:
+        string storage andIndented = isLoudReallyReallyReallyReallyLoud()
+            ? makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+            : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase = isLoudReallyReallyReallyReallyLoud()
+            ? silent()
+            : (makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud());
+
+        // if chained, always break and put after the =
+        string storage chainedShort = isCat()
+            ? meow()
+            : isDog()
+                ? bark()
+                : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent = isCat()
+            ? someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens()
+            : isDog()
+                ? bark()
+                : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent = isCat()
+            ? aNestedCondition
+                ? theResult()
+                : theAlternate()
+            : isDog()
+                ? bark()
+                : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak = isCat()
+            ? someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens()
+            : isDog()
+                ? bark()
+                : someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string
+            storage multilineConditionsConsequentsAndAlternates = isAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)
+                ? someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens()
+                : isNotAnAdorableKittyCat() &&
+                    (someReallyLongCondition || moreInThisLongCondition)
+                    ? bark()
+                    : shortCondition()
+                        ? shortConsequent()
+                        : someReallyLargeExpression
+                            .thatWouldCauseALineBreak()
+                            .willCauseAnIndentButNotParens();
+
+        // Assignment also groups and indents as Variable Declaration:
+        assignment = isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+            ? someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens()
+            : isNotAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)
+                ? bark()
+                : shortCondition()
+                    ? shortConsequent()
+                    : someReallyLargeExpression
+                        .thatWouldCauseALineBreak()
+                        .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort = x == 1
+            ? "one"
+            : x == 2
+                ? "two"
+                : x == 3
+                    ? "three"
+                    : x == 5 &&
+                        y == 7 &&
+                        someOtherThing
+                            .thatIsSoLong
+                            .thatItBreaksTheTestCondition()
+                        ? "four"
+                        : x == 6
+                            ? "six"
+                            : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional = bifornCringerMoshedPerplexSawder ==
+            2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+            ? "foo"
+            : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string
+            storage longConditionalChained = bifornCringerMoshedPerplexSawder ==
+                2 / askTrovenaBeenaDependsRowans &&
+                glimseGlyphsHazardNoopsTieTie >=
+                averredBathersBoxroomBuggyNurl()
+                    .anodyneCondosMalateOverateRetinol()
+                ? "foo"
+                : anotherCondition
+                    ? "bar"
+                    : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+            row[field] != "undefined"
+                ? row[field]
+                : definition.defaults != "undefined"
+                    ? definition.defaults
+                    : "null",
+            row[field] == "undefined"
+                ? definition.defaults == "undefined"
+                    ? "null"
+                    : definition.defaults
+                : row[field]
+        );
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return
+            row[aVeryLongFieldName] != "undefined"
+                ? row[aVeryLongFieldName]
+                : "null";
+    }
+
+    function examples2() {
+        string storage message = i % 3 == 0 && i % 5 == 0
+            ? "fizzbuzz"
+            : i % 3 == 0
+                ? "fizz"
+                : i % 5 == 0
+                    ? "buzz"
+                    : String(i);
+
+        string storage paymentMessageShort = state == "success"
+            ? "Payment completed successfully"
+            : state == "processing"
+                ? "Payment processing"
+                : state == "invalid_cvc"
+                    ? "There was an issue with your CVC number"
+                    : state == "invalid_expiry"
+                        ? "Expiry must be sometime in the past."
+                        : "There was an issue with the payment.  Please contact support.";
+
+        string storage paymentMessageWithABreak = state == "success"
+            ? "Payment completed successfully"
+            : state == "processing"
+                ? "Payment processing"
+                : state == "invalid_cvc"
+                    ? "There was an issue with your CVC number, and you need to take a prompt action on it."
+                    : state == "invalid_expiry"
+                        ? "Expiry must be sometime in the past."
+                        : "There was an issue with the payment.  Please contact support.";
+
+        string storage typeofExample = definition.encode
+            ? definition.encode(
+                row[field] != "undefined"
+                    ? row[field]
+                    : definition.defaults != "undefined"
+                        ? definition.defaults
+                        : "null"
+            )
+            : row[field] != "undefined"
+                ? row[field]
+                : definition.defaults != "undefined"
+                    ? definition.defaults
+                    : "null";
+
+        // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+        string storage typeofExampleFlipped = definition.encode
+            ? definition.encode(
+                row[field] == "undefined"
+                    ? definition.defaults == "undefined"
+                        ? "null"
+                        : definition.defaults
+                    : row[field]
+            )
+            : row[field] == "undefined"
+                ? definition.defaults == "undefined"
+                    ? "null"
+                    : definition.defaults
+                : row[field];
     }
 }
 

--- a/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,364 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["solidity-parse"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+pragma solidity ^0.4.24;
+
+
+contract Conditional {
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+        isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+        isLoudReallyReallyReallyReallyLoud() ?
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+        isLoudReallyReallyReallyReallyLoud() ? silent() : (
+            makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+        );
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+        isCat() ? meow()
+        : isDog() ? bark()
+        : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+        isCat() ?
+            aNestedCondition ? theResult()
+            : theAlternate()
+        : isDog() ? bark()
+        : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+        isCat() ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : isDog() ? bark()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+        (
+            isAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens()
+        : (
+            isNotAnAdorableKittyCat() &&
+            (someReallyLongCondition || moreInThisLongCondition)
+        ) ?
+            bark()
+        : shortCondition() ? shortConsequent()
+        : someReallyLargeExpression
+            .thatWouldCauseALineBreak()
+            .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+        x == 1 ? "one"
+        : x == 2 ? "two"
+        : x == 3 ? "three"
+        : (
+            x == 5 &&
+            y == 7 &&
+            someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+        ) ?
+            "four"
+        : x == 6 ? "six"
+        : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+        (
+            bifornCringerMoshedPerplexSawder == 2 / askTrovenaBeenaDependsRowans &&
+            glimseGlyphsHazardNoopsTieTie >=
+            averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+        ) ?
+            "foo"
+        : anotherCondition ? "bar"
+        : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(
+        row[field] != "undefined" ? row[field]
+        : definition.defaults != "undefined" ? definition.defaults
+        : "null",
+        row[field] == "undefined" ?
+            definition.defaults == "undefined" ?
+            "null"
+            : definition.defaults
+        : row[field]
+        );
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return row[aVeryLongFieldName] != "undefined" ?
+            row[aVeryLongFieldName]
+            : "null";
+    }
+
+
+    function examples2() {string storage message =
+  i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+  : i % 3 == 0 ? "fizz"
+  : i % 5 == 0 ? "buzz"
+  : String(i);
+
+string storage paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+string storage typeofExample =
+  definition.encode ?
+    definition.encode(
+      row[field] != "undefined" ? row[field]
+      : definition.defaults != "undefined" ? definition.defaults
+      : "null"
+    )
+  : row[field] != "undefined" ? row[field]
+  : definition.defaults != "undefined" ? definition.defaults
+  : "null";
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+string storage typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      row[field] == "undefined" ?
+        definition.defaults == "undefined" ?
+          "null"
+        : definition.defaults
+      : row[field]
+    )
+  : row[field] == "undefined" ?
+    definition.defaults == "undefined" ?
+      "null"
+    : definition.defaults
+  : row[field];
+    }
+}
+
+
+
+=====================================output=====================================
+pragma solidity ^0.4.24;
+
+contract Conditional {
+    function examples1() {
+        // remain on one line if possible:
+        string storage short = isLoud() ? makeNoise() : silent();
+
+        // next, put everything after the =
+        string storage lessShort =
+            isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+        // next, indent the consequent:
+        string storage andIndented =
+            isLoudReallyReallyReallyReallyLoud() ?
+                makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+            : silent();
+
+        // unless the consequent is short (less than ten characters long):
+        string storage shortSoCase =
+            isLoudReallyReallyReallyReallyLoud() ? silent()
+            : (makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud());
+
+        // if chained, always break and put after the =
+        string storage chainedShort =
+            isCat() ? meow()
+            : isDog() ? bark()
+            : silent();
+
+        // when a consequent breaks in a chain:
+        string storage chainedWithLongConsequent =
+            isCat() ?
+                someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens()
+            : isDog() ? bark()
+            : silent();
+
+        // nested ternary in consequent always breaks:
+        string storage chainedWithTernaryConsequent =
+            isCat() ? aNestedCondition ? theResult()
+                : theAlternate()
+            : isDog() ? bark()
+            : silent();
+
+        // consequent and terminal alternate break:
+        string storage consequentAndTerminalAlternateBreak =
+            isCat() ?
+                someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens()
+            : isDog() ? bark()
+            : someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens();
+
+        // multiline conditions and consequents/alternates:
+        string storage multilineConditionsConsequentsAndAlternates =
+            (isAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)) ?
+                someReallyLargeExpression
+                    .thatWouldCauseALineBreak()
+                    .willCauseAnIndentButNotParens()
+            : (isNotAnAdorableKittyCat() &&
+                (someReallyLongCondition || moreInThisLongCondition)) ? bark()
+            : shortCondition() ? shortConsequent()
+            : someReallyLargeExpression
+                .thatWouldCauseALineBreak()
+                .willCauseAnIndentButNotParens();
+
+        // illustrating case of mostly short conditionals
+        string storage mostlyShort =
+            x == 1 ? "one"
+            : x == 2 ? "two"
+            : x == 3 ? "three"
+            : (x == 5 &&
+                y == 7 &&
+                someOtherThing
+                    .thatIsSoLong
+                    .thatItBreaksTheTestCondition()) ? "four"
+            : x == 6 ? "six"
+            : "idk";
+
+        // long conditional, short consequent/alternate, not chained - do indent after ?
+        string storage longConditional =
+            (bifornCringerMoshedPerplexSawder ==
+                2 / askTrovenaBeenaDependsRowans &&
+                glimseGlyphsHazardNoopsTieTie >=
+                averredBathersBoxroomBuggyNurl()
+                    .anodyneCondosMalateOverateRetinol()) ? "foo" : "bar";
+
+        // long conditional, short consequent/alternate, chained
+        // (break on short consequents iff in chained ternary and its conditional broke)
+        string storage longConditionalChained =
+            (bifornCringerMoshedPerplexSawder ==
+                2 / askTrovenaBeenaDependsRowans &&
+                glimseGlyphsHazardNoopsTieTie >=
+                averredBathersBoxroomBuggyNurl()
+                    .anodyneCondosMalateOverateRetinol()) ? "foo"
+            : anotherCondition ? "bar"
+            : "baz";
+
+        // As a function parameter, don't add an extra indent:
+        definition.encode(row[field] != "undefined" ? row[field]
+            : definition.defaults != "undefined" ? definition.defaults
+            : "null", row[field] == "undefined" ?
+                definition.defaults == "undefined" ? "null"
+                : definition.defaults
+            : row[field]);
+
+        // In a return, break and over-indent:
+        if (short) {
+            return foo ? 1 : 2;
+        }
+        return
+            row[aVeryLongFieldName] != "undefined" ? row[aVeryLongFieldName]
+            : "null";
+    }
+
+    function examples2() {
+        string storage message =
+            i % 3 == 0 && i % 5 == 0 ? "fizzbuzz"
+            : i % 3 == 0 ? "fizz"
+            : i % 5 == 0 ? "buzz"
+            : String(i);
+
+        string storage paymentMessageShort =
+            state == "success" ? "Payment completed successfully"
+            : state == "processing" ? "Payment processing"
+            : state == "invalid_cvc" ? "There was an issue with your CVC number"
+            : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+            : "There was an issue with the payment.  Please contact support.";
+
+        string storage paymentMessageWithABreak =
+            state == "success" ? "Payment completed successfully"
+            : state == "processing" ? "Payment processing"
+            : state ==
+                "invalid_cvc" ? "There was an issue with your CVC number, and you need to take a prompt action on it."
+            : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+            : "There was an issue with the payment.  Please contact support.";
+
+        string storage typeofExample =
+            definition.encode ?
+                definition.encode(row[field] != "undefined" ? row[field]
+                    : definition.defaults != "undefined" ? definition.defaults
+                    : "null")
+            : row[field] != "undefined" ? row[field]
+            : definition.defaults != "undefined" ? definition.defaults
+            : "null";
+
+        // (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+        string storage typeofExampleFlipped =
+            definition.encode ?
+                definition.encode(
+                    row[field] == "undefined" ?
+                        definition.defaults == "undefined" ? "null"
+                        : definition.defaults
+                    : row[field]
+                )
+            : row[field] == "undefined" ?
+                definition.defaults == "undefined" ? "null"
+                : definition.defaults
+            : row[field];
+    }
+}
+
+================================================================================
+`;

--- a/tests/format/ExperimentalTernaries/jsfmt.spec.js
+++ b/tests/format/ExperimentalTernaries/jsfmt.spec.js
@@ -1,1 +1,2 @@
+run_spec(import.meta, ['solidity-parse']);
 run_spec(import.meta, ['solidity-parse'], { experimentalTernaries: true });

--- a/tests/format/ExperimentalTernaries/jsfmt.spec.js
+++ b/tests/format/ExperimentalTernaries/jsfmt.spec.js
@@ -1,2 +1,10 @@
 run_spec(import.meta, ['solidity-parse']);
 run_spec(import.meta, ['solidity-parse'], { experimentalTernaries: true });
+run_spec(import.meta, ['solidity-parse'], {
+  experimentalTernaries: true,
+  tabWidth: 1
+});
+run_spec(import.meta, ['solidity-parse'], {
+  experimentalTernaries: true,
+  useTabs: true
+});

--- a/tests/format/ExperimentalTernaries/jsfmt.spec.js
+++ b/tests/format/ExperimentalTernaries/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ['solidity-parse'], { experimentalTernaries: true });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,13 +59,10 @@ export default (webpackEnv) => {
       filename: 'standalone.cjs',
       clean: true,
       globalObject: `
-        typeof globalThis !== "undefined"
-          ? globalThis
-          : typeof global !== "undefined"
-          ? global
-          : typeof self !== "undefined"
-          ? self
-          : this || {}
+        typeof globalThis !== 'undefined' ? globalThis
+        : typeof global !== 'undefined' ? global
+        : typeof self !== 'undefined' ? self
+        : this || {};
       `,
       library: {
         export: 'default',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ export default (webpackEnv) => {
         typeof globalThis !== 'undefined' ? globalThis
         : typeof global !== 'undefined' ? global
         : typeof self !== 'undefined' ? self
-        : this || {};
+        : this || {}
       `,
       library: {
         export: 'default',


### PR DESCRIPTION
I really liked Prettier's [`experimentalTernaries`](https://prettier.io/blog/2023/11/13/curious-ternaries) and would like to propose it for this plugin as well.

I took the same examples from prettier's tests.

There is one detail that makes this approach slightly different and that is that the length of the indentation in javascript is 2 and that makes the true and false expressions align.

```Javascript
condition ?
  trueExpression
: falseExpression;
```

with 4 spaces in solidity the code looks like this

```Solidity
condition ?
    trueExpression
: falseExpression;
```

I could force this indentation to be 2 only for this one case but would love to see how the community reacts to this.