### PR TITLE
Improving printing performance

### DIFF
--- a/src/binary-operator-printers/assignment.js
+++ b/src/binary-operator-printers/assignment.js
@@ -19,8 +19,7 @@ export const assignment = {
     ].includes(op),
   print: (node, path, print) => [
     path.call(print, 'left'),
-    ' ',
-    node.operator,
+    ` ${node.operator}`,
     node.right.type === 'BinaryOperation'
       ? group(indent([line, path.call(print, 'right')]))
       : [' ', path.call(print, 'right')]

--- a/src/binary-operator-printers/exponentiation.js
+++ b/src/binary-operator-printers/exponentiation.js
@@ -5,7 +5,7 @@ const { group, indent, line } = doc.builders;
 export const exponentiation = {
   match: (op) => op === '**',
   print: (node, path, print) => {
-    const right = [' ', node.operator, line, path.call(print, 'right')];
+    const right = [` ${node.operator}`, line, path.call(print, 'right')];
     // If it's a single binary operation, avoid having a small right
     // operand like - 1 on its own line
     const shouldGroup =

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -8,7 +8,7 @@ import {
 const { group, indent, join, line, softline, hardline } = doc.builders;
 
 export const printComments = (node, path, options, filter = () => true) => {
-  if (!node.comments) return '';
+  if (!node.comments) return [];
   const document = join(
     line,
     path

--- a/src/common/printer-helpers.js
+++ b/src/common/printer-helpers.js
@@ -37,35 +37,27 @@ export const printComments = (node, path, options, filter = () => true) => {
 };
 
 export function printPreservingEmptyLines(path, key, options, print) {
-  const parts = [];
-  path.each((childPath, index) => {
+  return path.map((childPath, index) => {
     const node = childPath.getValue();
-    const nodeType = node.type;
 
-    if (
-      // Avoid adding a hardline at the beginning of the document.
-      parts.length !== 0 &&
+    return [
+      // Only attempt to prepend an empty line if `node` is not the first item
+      index > 0 &&
       // LabelDefinition adds a dedented line so we don't have to prepend a
       // hardline.
-      nodeType !== 'LabelDefinition'
-    ) {
-      parts.push(hardline);
-    }
-
-    parts.push(print(childPath));
-
-    // Only attempt to append an empty line if `node` is not the last item
-    if (
+      node.type !== 'LabelDefinition'
+        ? hardline
+        : '',
+      print(childPath),
+      // Only attempt to append an empty line if `node` is not the last item
       !isLast(childPath, key, index) &&
+      // Append an empty line if the original text already had an one after the
+      // current `node`
       isNextLineEmpty(options.originalText, options.locEnd(node) + 1)
-    ) {
-      // Append an empty line if the original text already had an one after
-      // the current `node`
-      parts.push(hardline);
-    }
+        ? hardline
+        : ''
+    ];
   }, key);
-
-  return parts;
 }
 
 // This function will add an indentation to the `item` and separate it from the
@@ -77,10 +69,10 @@ export const printSeparatedItem = (
     lastSeparator = firstSeparator,
     grouped = true
   } = {}
-) => {
-  const document = [indent([firstSeparator, item]), lastSeparator];
-  return grouped ? group(document) : document;
-};
+) =>
+  grouped
+    ? group([indent([firstSeparator, item]), lastSeparator])
+    : [indent([firstSeparator, item]), lastSeparator];
 
 // This function will add an indentation to the `list` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/nodes/AssemblyCall.js
+++ b/src/nodes/AssemblyCall.js
@@ -6,8 +6,7 @@ export const AssemblyCall = {
     options.originalText.charAt(options.locEnd(node)) !== ')'
       ? node.functionName
       : [
-          node.functionName,
-          '(',
+          `${node.functionName}(`,
           printSeparatedList(path.map(print, 'arguments')),
           ')'
         ]

--- a/src/nodes/AssemblyFunctionDefinition.js
+++ b/src/nodes/AssemblyFunctionDefinition.js
@@ -8,9 +8,7 @@ const { line } = doc.builders;
 
 export const AssemblyFunctionDefinition = {
   print: ({ node, path, print }) => [
-    'function ',
-    node.name,
-    '(',
+    `function ${node.name}(`,
     printSeparatedList(path.map(print, 'arguments')),
     ')',
     node.returnArguments.length === 0

--- a/src/nodes/AssemblyLocalDefinition.js
+++ b/src/nodes/AssemblyLocalDefinition.js
@@ -4,17 +4,9 @@ import { printSeparatedList } from '../common/printer-helpers.js';
 const { line } = doc.builders;
 
 export const AssemblyLocalDefinition = {
-  print: ({ node, path, print }) => {
-    const parts = [
-      'let',
-      printSeparatedList(path.map(print, 'names'), { firstSeparator: line })
-    ];
-
-    if (node.expression !== null) {
-      parts.push(':= ');
-      parts.push(path.call(print, 'expression'));
-    }
-
-    return parts;
-  }
+  print: ({ node, path, print }) => [
+    'let',
+    printSeparatedList(path.map(print, 'names'), { firstSeparator: line }),
+    node.expression ? [':= ', path.call(print, 'expression')] : ''
+  ]
 };

--- a/src/nodes/AssemblyStackAssignment.js
+++ b/src/nodes/AssemblyStackAssignment.js
@@ -1,7 +1,6 @@
 export const AssemblyStackAssignment = {
   print: ({ node, path, print }) => [
     path.call(print, 'expression'),
-    ' =: ',
-    node.name
+    ` =: ${node.name}`
   ]
 };

--- a/src/nodes/Block.js
+++ b/src/nodes/Block.js
@@ -1,10 +1,11 @@
 import { doc } from 'prettier';
 import {
   printComments,
-  printPreservingEmptyLines
+  printPreservingEmptyLines,
+  printSeparatedItem
 } from '../common/printer-helpers.js';
 
-const { hardline, indent } = doc.builders;
+const { hardline } = doc.builders;
 
 export const Block = {
   print: ({ node, options, path, print }) =>
@@ -13,12 +14,13 @@ export const Block = {
       ? '{}'
       : [
           '{',
-          indent([
-            hardline,
-            printPreservingEmptyLines(path, 'statements', options, print),
-            printComments(node, path, options)
-          ]),
-          hardline,
+          printSeparatedItem(
+            [
+              printPreservingEmptyLines(path, 'statements', options, print),
+              printComments(node, path, options)
+            ],
+            { firstSeparator: hardline, grouped: false }
+          ),
           '}'
         ]
 };

--- a/src/nodes/CatchClause.js
+++ b/src/nodes/CatchClause.js
@@ -3,8 +3,7 @@ import { printSeparatedList } from '../common/printer-helpers.js';
 const parameters = (node, path, print) =>
   node.parameters
     ? [
-        node.kind || '',
-        '(',
+        `${node.kind || ''}(`,
         printSeparatedList(path.map(print, 'parameters')),
         ') '
       ]

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -20,7 +20,7 @@ const inheritance = (node, path, print) =>
 
 const body = (node, path, options, print) => {
   const comments = printComments(node, path, options);
-  return node.subNodes.length > 0 || comments?.length
+  return node.subNodes.length > 0 || comments.length
     ? printSeparatedItem(
         [printPreservingEmptyLines(path, 'subNodes', options, print), comments],
         { firstSeparator: hardline, grouped: false }
@@ -31,9 +31,7 @@ const body = (node, path, options, print) => {
 export const ContractDefinition = {
   print: ({ node, options, path, print }) => [
     group([
-      node.kind === 'abstract' ? 'abstract contract' : node.kind,
-      ' ',
-      node.name,
+      node.kind + (node.kind === 'abstract' ? ' contract ' : ' ') + node.name,
       inheritance(node, path, print),
       '{'
     ]),

--- a/src/nodes/ContractDefinition.js
+++ b/src/nodes/ContractDefinition.js
@@ -31,7 +31,9 @@ const body = (node, path, options, print) => {
 export const ContractDefinition = {
   print: ({ node, options, path, print }) => [
     group([
-      node.kind + (node.kind === 'abstract' ? ' contract ' : ' ') + node.name,
+      `${node.kind}${node.kind === 'abstract' ? ' contract ' : ' '}${
+        node.name
+      }`,
       inheritance(node, path, print),
       '{'
     ]),

--- a/src/nodes/CustomErrorDefinition.js
+++ b/src/nodes/CustomErrorDefinition.js
@@ -7,9 +7,7 @@ const parameters = (node, path, print) =>
 
 export const CustomErrorDefinition = {
   print: ({ node, path, print }) => [
-    'error ',
-    node.name,
-    '(',
+    `error ${node.name}(`,
     parameters(node, path, print),
     ');'
   ]

--- a/src/nodes/ElementaryTypeName.js
+++ b/src/nodes/ElementaryTypeName.js
@@ -1,5 +1,5 @@
 const stateMutability = (node) =>
-  node.stateMutability?.length > 0 ? [' ', node.stateMutability] : '';
+  node.stateMutability?.length > 0 ? ` ${node.stateMutability}` : '';
 
 export const ElementaryTypeName = {
   print: ({ node }) => [node.name, stateMutability(node)]

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -1,17 +1,16 @@
 import { doc } from 'prettier';
 import { printSeparatedList } from '../common/printer-helpers.js';
 
-const { group, hardline } = doc.builders;
+const { hardline } = doc.builders;
 
 export const EnumDefinition = {
-  print: ({ node, path, print }) =>
-    group([
-      'enum ',
-      node.name,
-      ' {',
-      printSeparatedList(path.map(print, 'members'), {
-        firstSeparator: hardline
-      }),
-      '}'
-    ])
+  print: ({ node, path, print }) => [
+    'enum ',
+    node.name,
+    ' {',
+    printSeparatedList(path.map(print, 'members'), {
+      firstSeparator: hardline
+    }),
+    '}'
+  ]
 };

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -5,9 +5,7 @@ const { hardline } = doc.builders;
 
 export const EnumDefinition = {
   print: ({ node, path, print }) => [
-    'enum ',
-    node.name,
-    ' {',
+    `enum ${node.name} {`,
     printSeparatedList(path.map(print, 'members'), {
       firstSeparator: hardline,
       grouped: false

--- a/src/nodes/EnumDefinition.js
+++ b/src/nodes/EnumDefinition.js
@@ -9,7 +9,8 @@ export const EnumDefinition = {
     node.name,
     ' {',
     printSeparatedList(path.map(print, 'members'), {
-      firstSeparator: hardline
+      firstSeparator: hardline,
+      grouped: false
     }),
     '}'
   ]

--- a/src/nodes/EventDefinition.js
+++ b/src/nodes/EventDefinition.js
@@ -7,12 +7,8 @@ const parameters = (node, path, print) =>
 
 export const EventDefinition = {
   print: ({ node, path, print }) => [
-    'event ',
-    node.name,
-    '(',
+    `event ${node.name}(`,
     parameters(node, path, print),
-    ')',
-    node.isAnonymous ? ' anonymous' : '',
-    ';'
+    `)${node.isAnonymous ? ' anonymous' : ''};`
   ]
 };

--- a/src/nodes/ExpressionStatement.js
+++ b/src/nodes/ExpressionStatement.js
@@ -5,23 +5,15 @@ const { hardline } = doc.builders;
 
 export const ExpressionStatement = {
   print: ({ node, options, path, print }) => {
-    const parts = [];
+    const comments =
+      path.getParentNode().type === 'IfStatement'
+        ? printComments(node, path, options)
+        : [];
 
-    const parent = path.getParentNode();
-
-    if (parent.type === 'IfStatement') {
-      if (node.comments?.length) {
-        const comments = printComments(node, path, options);
-        if (comments?.length) {
-          parts.push(comments);
-          parts.push(hardline);
-        }
-      }
-    }
-
-    parts.push(path.call(print, 'expression'));
-    parts.push(node.omitSemicolon ? [] : ';');
-
-    return parts;
+    return [
+      comments.length ? [comments, hardline] : '',
+      path.call(print, 'expression'),
+      node.omitSemicolon ? '' : ';'
+    ];
   }
 };

--- a/src/nodes/ExpressionStatement.js
+++ b/src/nodes/ExpressionStatement.js
@@ -20,7 +20,7 @@ export const ExpressionStatement = {
     }
 
     parts.push(path.call(print, 'expression'));
-    parts.push(node.omitSemicolon ? '' : ';');
+    parts.push(node.omitSemicolon ? [] : ';');
 
     return parts;
   }

--- a/src/nodes/FunctionDefinition.js
+++ b/src/nodes/FunctionDefinition.js
@@ -98,8 +98,8 @@ export const FunctionDefinition = {
       '(',
       parameters('parameters', node, path, print, options),
       ')',
-      indent(
-        group([
+      group(
+        indent([
           // TODO: sort comments for modifiers and return parameters
           printComments(node, path, options),
           visibility(node),

--- a/src/nodes/FunctionTypeName.js
+++ b/src/nodes/FunctionTypeName.js
@@ -28,8 +28,8 @@ export const FunctionTypeName = {
     'function(',
     printSeparatedList(path.map(print, 'parameterTypes')),
     ')',
-    indent(
-      group([
+    group(
+      indent([
         visibility(node),
         stateMutability(node),
         returnTypes(node, path, print)

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -6,26 +6,25 @@ import {
 
 const { group, hardline, indent, line } = doc.builders;
 
-const printTrueBody = (node, path, print) => {
-  if (node.trueBody.type === 'Block') {
-    return [' ', path.call(print, 'trueBody')];
-  }
-
-  return group(indent([line, path.call(print, 'trueBody')]), {
-    shouldBreak: node.trueBody.type === 'IfStatement' // `if` within `if`
-  });
-};
+const printTrueBody = (node, path, print) =>
+  node.trueBody.type === 'Block'
+    ? [' ', path.call(print, 'trueBody')]
+    : group(indent([line, path.call(print, 'trueBody')]), {
+        shouldBreak: node.trueBody.type === 'IfStatement' // `if` within `if`
+      });
 
 const printFalseBody = (node, path, print) =>
   node.falseBody.type === 'Block' || node.falseBody.type === 'IfStatement'
     ? [' ', path.call(print, 'falseBody')]
     : group(indent([line, path.call(print, 'falseBody')]));
 
-const printElse = (node, path, print, commentsBetweenIfAndElse) => {
+const printElse = (node, path, print, options) => {
   if (node.falseBody) {
+    const comments = printComments(node, path, options);
     return [
-      node.trueBody.type !== 'Block' || commentsBetweenIfAndElse.length > 0 // `else` on new line
-        ? hardline
+      comments.length ? [hardline, comments] : '',
+      node.trueBody.type !== 'Block' || comments.length > 0
+        ? hardline // `else` on new line
         : ' ',
       'else',
       printFalseBody(node, path, print)
@@ -35,22 +34,11 @@ const printElse = (node, path, print, commentsBetweenIfAndElse) => {
 };
 
 export const IfStatement = {
-  print: ({ node, options, path, print }) => {
-    const comments = node.comments || [];
-    const commentsBetweenIfAndElse = comments.filter(
-      (comment) => !comment.leading && !comment.trailing
-    );
-
-    const parts = [];
-
-    parts.push('if (', printSeparatedItem(path.call(print, 'condition')), ')');
-    parts.push(printTrueBody(node, path, print));
-    if (commentsBetweenIfAndElse.length && node.falseBody) {
-      parts.push(hardline);
-      parts.push(printComments(node, path, options));
-    }
-    parts.push(printElse(node, path, print, commentsBetweenIfAndElse));
-
-    return parts;
-  }
+  print: ({ node, options, path, print }) => [
+    'if (',
+    printSeparatedItem(path.call(print, 'condition')),
+    ')',
+    printTrueBody(node, path, print),
+    printElse(node, path, print, options)
+  ]
 };

--- a/src/nodes/IfStatement.js
+++ b/src/nodes/IfStatement.js
@@ -11,10 +11,9 @@ const printTrueBody = (node, path, print) => {
     return [' ', path.call(print, 'trueBody')];
   }
 
-  const ifWithinIf = node.trueBody.type === 'IfStatement';
-  return group(
-    indent([ifWithinIf ? hardline : line, path.call(print, 'trueBody')])
-  );
+  return group(indent([line, path.call(print, 'trueBody')]), {
+    shouldBreak: node.trueBody.type === 'IfStatement' // `if` within `if`
+  });
 };
 
 const printFalseBody = (node, path, print) =>
@@ -24,10 +23,10 @@ const printFalseBody = (node, path, print) =>
 
 const printElse = (node, path, print, commentsBetweenIfAndElse) => {
   if (node.falseBody) {
-    const elseOnSameLine =
-      node.trueBody.type === 'Block' && commentsBetweenIfAndElse.length === 0;
     return [
-      elseOnSameLine ? ' ' : hardline,
+      node.trueBody.type !== 'Block' || commentsBetweenIfAndElse.length > 0 // `else` on new line
+        ? hardline
+        : ' ',
       'else',
       printFalseBody(node, path, print)
     ];

--- a/src/nodes/ImportDirective.js
+++ b/src/nodes/ImportDirective.js
@@ -13,7 +13,7 @@ export const ImportDirective = {
 
     if (node.unitAlias) {
       // import "./Foo.sol" as Foo;
-      document = [importPath, ' as ', node.unitAlias];
+      document = `${importPath} as ${node.unitAlias}`;
     } else if (node.symbolAliases) {
       // import { Foo, Bar as Qux } from "./Foo.sol";
       const compiler = coerce(options.compiler);
@@ -38,8 +38,7 @@ export const ImportDirective = {
       document = [
         '{',
         printSeparatedList(symbolAliases, { firstSeparator, separator }),
-        '} from ',
-        importPath
+        `} from ${importPath}`
       ];
     } else {
       // import "./Foo.sol";

--- a/src/nodes/InlineAssemblyStatement.js
+++ b/src/nodes/InlineAssemblyStatement.js
@@ -4,8 +4,9 @@ import { printSeparatedList } from '../common/printer-helpers.js';
 
 export const InlineAssemblyStatement = {
   print: ({ node, path, print, options }) => [
-    'assembly ',
-    node.language ? `${printString(node.language, options)} ` : '',
+    `assembly ${
+      node.language ? `${printString(node.language, options)} ` : ''
+    }`,
     node.flags?.length > 0
       ? [
           '(',

--- a/src/nodes/LabelDefinition.js
+++ b/src/nodes/LabelDefinition.js
@@ -3,5 +3,5 @@ import { doc } from 'prettier';
 const { dedent, line } = doc.builders;
 
 export const LabelDefinition = {
-  print: ({ node }) => [dedent(line), node.name, ':']
+  print: ({ node }) => [dedent(line), `${node.name}:`]
 };

--- a/src/nodes/MemberAccess.js
+++ b/src/nodes/MemberAccess.js
@@ -102,7 +102,7 @@ const processChain = (chain) => {
 
   // We wrap the expression in a label in case there is an IndexAccess or
   // a FunctionCall following this MemberAccess.
-  return label('MemberAccessChain', group([firstExpression, restOfChain]));
+  return label('MemberAccessChain', [firstExpression, restOfChain]);
 };
 
 export const MemberAccess = {

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -36,11 +36,8 @@ const override = (node, path, print) => {
   ];
 };
 
-const body = (node, path, print) => {
-  if (!node.body) return ';';
-  if (node.isVirtual) return group([' ', path.call(print, 'body')]); // TODO: review why this has to be a group since it doesn't affect the tests
-  return [' ', path.call(print, 'body')];
-};
+const body = (node, path, print) =>
+  node.body ? [' ', path.call(print, 'body')] : ';';
 
 export const ModifierDefinition = {
   print: ({ node, path, print }) => [

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -38,7 +38,7 @@ const override = (node, path, print) => {
 
 const body = (node, path, print) => {
   if (!node.body) return ';';
-  if (node.isVirtual) return group([' ', path.call(print, 'body')]);
+  if (node.isVirtual) return group([' ', path.call(print, 'body')]); // TODO: review why this has to be a group since it doesn't affect the tests
   return [' ', path.call(print, 'body')];
 };
 

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -5,16 +5,15 @@ const { group, hardline, indent, line } = doc.builders;
 
 const modifierParameters = (node, path, print) => {
   if (node.parameters?.length > 0) {
+    // To keep consistency any list of parameters will split if it's longer than 2.
+    // For more information see:
+    // https://github.com/prettier-solidity/prettier-plugin-solidity/issues/256
+    const shouldBreak = node.parameters.length > 2;
     return [
       '(',
       printSeparatedList(path.map(print, 'parameters'), {
-        separator: [
-          ',',
-          // To keep consistency any list of parameters will split if it's longer than 2.
-          // For more information see:
-          // https://github.com/prettier-solidity/prettier-plugin-solidity/issues/256
-          node.parameters.length > 2 ? hardline : line
-        ]
+        separator: [',', shouldBreak ? hardline : line],
+        grouped: !shouldBreak
       }),
       ')'
     ];

--- a/src/nodes/ModifierDefinition.js
+++ b/src/nodes/ModifierDefinition.js
@@ -40,8 +40,7 @@ const body = (node, path, print) =>
 
 export const ModifierDefinition = {
   print: ({ node, path, print }) => [
-    'modifier ',
-    node.name,
+    `modifier ${node.name}`,
     modifierParameters(node, path, print),
     group(indent([virtual(node), override(node, path, print)])),
     body(node, path, print)

--- a/src/nodes/NameValueList.js
+++ b/src/nodes/NameValueList.js
@@ -8,7 +8,7 @@ export const NameValueList = {
     printSeparatedList(
       path
         .map(print, 'arguments')
-        .map((argument, index) => [node.names[index], ': ', argument]),
+        .map((argument, index) => [`${node.names[index]}: `, argument]),
       {
         firstSeparator: options.bracketSpacing ? line : softline
       }

--- a/src/nodes/NumberLiteral.js
+++ b/src/nodes/NumberLiteral.js
@@ -1,6 +1,6 @@
 export const NumberLiteral = {
   print: ({ node }) =>
     node.subdenomination
-      ? [node.number, ' ', node.subdenomination]
+      ? `${node.number} ${node.subdenomination}`
       : node.number
 };

--- a/src/nodes/PragmaDirective.js
+++ b/src/nodes/PragmaDirective.js
@@ -1,3 +1,3 @@
 export const PragmaDirective = {
-  print: ({ node }) => ['pragma ', node.name, ' ', node.value, ';']
+  print: ({ node }) => `pragma ${node.name} ${node.value};`
 };

--- a/src/nodes/StateVariableDeclaration.js
+++ b/src/nodes/StateVariableDeclaration.js
@@ -16,7 +16,7 @@ const initialValue = (node, path, print) => {
 
 export const StateVariableDeclaration = {
   print: ({ node, path, print }) => [
-    ...path.map(print, 'variables'),
+    path.map(print, 'variables'),
     initialValue(node, path, print),
     ';'
   ]

--- a/src/nodes/StringLiteral.js
+++ b/src/nodes/StringLiteral.js
@@ -9,7 +9,7 @@ export const StringLiteral = {
       (part, index) =>
         // node.isUnicode is an array of the same length as node.parts
         // that indicates if that string fragment has the unicode prefix
-        (node.isUnicode[index] ? 'unicode' : '') + printString(part, options)
+        `${node.isUnicode[index] ? 'unicode' : ''}${printString(part, options)}`
     );
 
     return join(hardline, list);

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -12,7 +12,8 @@ export const StructDefinition = {
       ? printSeparatedList(path.map(print, 'members'), {
           firstSeparator: hardline,
           separator: [';', hardline],
-          lastSeparator: [';', hardline]
+          lastSeparator: [';', hardline],
+          grouped: false
         })
       : '',
     '}'

--- a/src/nodes/StructDefinition.js
+++ b/src/nodes/StructDefinition.js
@@ -5,9 +5,7 @@ const { hardline } = doc.builders;
 
 export const StructDefinition = {
   print: ({ node, path, print }) => [
-    'struct ',
-    node.name,
-    ' {',
+    `struct ${node.name} {`,
     node.members.length > 0
       ? printSeparatedList(path.map(print, 'members'), {
           firstSeparator: hardline,

--- a/src/nodes/TryStatement.js
+++ b/src/nodes/TryStatement.js
@@ -11,30 +11,19 @@ const returnParameters = (node, path, print) =>
     ? [
         'returns (',
         printSeparatedList(path.map(print, 'returnParameters')),
-        ')'
+        ') '
       ]
     : '';
 
 export const TryStatement = {
-  print: ({ node, path, print }) => {
-    let parts = [
-      'try',
-      printSeparatedItem(path.call(print, 'expression'), {
-        firstSeparator: line
-      })
-    ];
-
-    const formattedReturnParameters = returnParameters(node, path, print);
-    if (formattedReturnParameters) {
-      parts = parts.concat([formattedReturnParameters, ' ']);
-    }
-
-    parts = parts.concat([
-      path.call(print, 'body'),
-      ' ',
-      join(' ', path.map(print, 'catchClauses'))
-    ]);
-
-    return parts;
-  }
+  print: ({ node, path, print }) => [
+    'try',
+    printSeparatedItem(path.call(print, 'expression'), {
+      firstSeparator: line
+    }),
+    returnParameters(node, path, print),
+    path.call(print, 'body'),
+    ' ',
+    join(' ', path.map(print, 'catchClauses'))
+  ]
 };

--- a/src/nodes/TupleExpression.js
+++ b/src/nodes/TupleExpression.js
@@ -1,7 +1,4 @@
-import { doc } from 'prettier';
 import { printSeparatedList } from '../common/printer-helpers.js';
-
-const { group } = doc.builders;
 
 const contents = (node, path, print) =>
   node.components?.length === 1 && node.components[0].type === 'BinaryOperation'
@@ -9,10 +6,9 @@ const contents = (node, path, print) =>
     : printSeparatedList(path.map(print, 'components'));
 
 export const TupleExpression = {
-  print: ({ node, path, print }) =>
-    group([
-      node.isArray ? '[' : '(',
-      contents(node, path, print),
-      node.isArray ? ']' : ')'
-    ])
+  print: ({ node, path, print }) => [
+    node.isArray ? '[' : '(',
+    contents(node, path, print),
+    node.isArray ? ']' : ')'
+  ]
 };

--- a/src/nodes/TypeDefinition.js
+++ b/src/nodes/TypeDefinition.js
@@ -1,3 +1,3 @@
 export const TypeDefinition = {
-  print: ({ node }) => ['type ', node.name, ' is ', node.definition.name, ';']
+  print: ({ node }) => `type ${node.name} is ${node.definition.name};`
 };

--- a/src/nodes/UnaryOperation.js
+++ b/src/nodes/UnaryOperation.js
@@ -2,7 +2,7 @@ export const UnaryOperation = {
   print: ({ node, path, print }) =>
     node.isPrefix
       ? [
-          node.operator + (node.operator === 'delete' ? ' ' : ''),
+          `${node.operator}${node.operator === 'delete' ? ' ' : ''}`,
           path.call(print, 'subExpression')
         ]
       : [path.call(print, 'subExpression'), node.operator]

--- a/src/nodes/UnaryOperation.js
+++ b/src/nodes/UnaryOperation.js
@@ -2,8 +2,7 @@ export const UnaryOperation = {
   print: ({ node, path, print }) =>
     node.isPrefix
       ? [
-          node.operator,
-          node.operator === 'delete' ? ' ' : '',
+          node.operator + (node.operator === 'delete' ? ' ' : ''),
           path.call(print, 'subExpression')
         ]
       : [path.call(print, 'subExpression'), node.operator]

--- a/src/nodes/UncheckedStatement.js
+++ b/src/nodes/UncheckedStatement.js
@@ -1,7 +1,3 @@
-import { doc } from 'prettier';
-
-const { group } = doc.builders;
-
 export const UncheckedStatement = {
-  print: ({ path, print }) => group(['unchecked ', path.call(print, 'block')])
+  print: ({ path, print }) => ['unchecked ', path.call(print, 'block')]
 };

--- a/src/nodes/UsingForDeclaration.js
+++ b/src/nodes/UsingForDeclaration.js
@@ -12,7 +12,7 @@ export const UsingForDeclaration = {
           printSeparatedList(
             node.functions.map((functionName, i) =>
               node.operators[i]
-                ? [functionName, ' as ', node.operators[i]]
+                ? `${functionName} as ${node.operators[i]}`
                 : functionName
             ),
             {


### PR DESCRIPTION
Removing `group`s that will always break:

- UncheckedStatement
- EnumDefinition
- ModifierDefinition

Removing `group` that just affect a closing bracket `)` or `]` that will be outside the `tabWidth`

- TupleExpression

Member Access Chain is already properly `group`ed

- MemberAccess

Just reordering the `group` `indent` calls:

- FunctionDefinition
- FunctionTypeName

Prefer using `shouldBreak` at the `group` level instead of choosing between `hardline` and `line`
- IfStatement

The rest is wrapping strings together whenever possible.
Finally I rebased some functions that would `push` and `concat` into a variable and returned an built array instead.