### PR TITLE
Bump @solidity-parser/parser from 0.17.0 to 0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@solidity-parser/parser": "^0.17.0",
-        "semver": "^7.5.4",
-        "solidity-comments-extractor": "^0.0.8"
+        "@solidity-parser/parser": "^0.18.0",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@babel/code-frame": "^7.22.10",
@@ -23,7 +22,6 @@
         "eslint-plugin-import": "^2.28.1",
         "esm-utils": "^4.1.2",
         "esmock": "^2.3.8",
-        "exports-loader": "^5.0.0",
         "jest": "^29.6.3",
         "jest-light-runner": "^0.6.0",
         "jest-snapshot-serializer-ansi": "^2.1.0",
@@ -1347,9 +1345,9 @@
       }
     },
     "node_modules/@solidity-parser/parser": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.17.0.tgz",
-      "integrity": "sha512-Nko8R0/kUo391jsEHHxrGM07QFdnPGvlmox4rmH0kNiNAashItAilhy4Mv4pK5gQmW5f4sXAF58fwJbmlkGcVw=="
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.18.0.tgz",
+      "integrity": "sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
@@ -3240,25 +3238,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/exports-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-5.0.0.tgz",
-      "integrity": "sha512-W15EyyytBwd30yCCieTCqZSCUvU/o3etj2IUItSMjVQEzAf5xOQx8JL9iMo7ERnuAzIA6eapGSFWl7E9F+Wy9g==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -6918,11 +6897,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/solidity-comments-extractor": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.8.tgz",
-      "integrity": "sha512-htM7Vn6LhHreR+EglVMd2s+sZhcXAirB1Zlyrv5zBuTxieCvjfnRpd7iZk75m/u6NOlEyQ94C6TWbBn2cY7w8g=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-import": "^2.28.1",
     "esm-utils": "^4.1.2",
     "esmock": "^2.3.8",
-    "exports-loader": "^5.0.0",
     "jest": "^29.6.3",
     "jest-light-runner": "^0.6.0",
     "jest-snapshot-serializer-ansi": "^2.1.0",
@@ -110,9 +109,8 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@solidity-parser/parser": "^0.17.0",
-    "semver": "^7.5.4",
-    "solidity-comments-extractor": "^0.0.8"
+    "@solidity-parser/parser": "^0.18.0",
+    "semver": "^7.5.4"
   },
   "peerDependencies": {
     "prettier": ">=2.3.0"

--- a/src/comments/printer.js
+++ b/src/comments/printer.js
@@ -7,12 +7,12 @@ function isIndentableBlockComment(comment) {
   // we can fix the indentation of each line. The stars in the `/*` and
   // `*/` delimiters are not included in the comment value, so add them
   // back first.
-  const lines = `*${comment.raw}*`.split('\n');
+  const lines = `*${comment.value}*`.split('\n');
   return lines.length > 1 && lines.every((line) => line.trim()[0] === '*');
 }
 
 function printIndentableBlockComment(comment) {
-  const lines = comment.raw.split('\n');
+  const lines = comment.value.split('\n');
 
   return [
     '/*',
@@ -49,10 +49,10 @@ export function printComment(commentPath, options) {
         return printed;
       }
 
-      return `/*${comment.raw}*/`;
+      return `/*${comment.value}*/`;
     }
     case 'LineComment':
-      return `//${comment.raw.trimEnd()}`;
+      return `//${comment.value.trimEnd()}`;
     default:
       throw new Error(`Not a comment: ${JSON.stringify(comment)}`);
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,4 +1,3 @@
-import extractComments from 'solidity-comments-extractor';
 // https://prettier.io/docs/en/plugins.html#parsers
 import parser from '@solidity-parser/parser';
 import coerce from 'semver/functions/coerce.js';
@@ -16,8 +15,7 @@ const tryHug = (node, operators) => {
 
 function parse(text, _parsers, options = _parsers) {
   const compiler = coerce(options.compiler);
-  const parsed = parser.parse(text, { loc: true, range: true });
-  parsed.comments = extractComments(text);
+  const parsed = parser.parse(text, { loc: true, range: true, comments: true });
 
   parser.visit(parsed, {
     PragmaDirective(ctx) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 import path from 'node:path';
-import { createRequire } from 'node:module';
 import createEsmUtils from 'esm-utils';
 
-const require = createRequire(import.meta.url);
 const { __dirname } = createEsmUtils(import.meta);
 
 // This is the production and development configuration.
@@ -29,27 +27,6 @@ export default (webpackEnv) => {
     bail: isEnvProduction,
     devtool: 'source-map',
 
-    // We tell webpack to use the browser friendly package.
-    resolve: {
-      alias: {
-        '@solidity-parser/parser': '@solidity-parser/parser/dist/index.iife.js'
-      }
-    },
-
-    module: {
-      rules: [
-        {
-          // We tell webpack to append "module.exports = SolidityParser;" at the
-          // end of the file.
-          test: require.resolve('@solidity-parser/parser/dist/index.iife.js'),
-          loader: 'exports-loader',
-          options: {
-            type: 'commonjs',
-            exports: 'single SolidityParser'
-          }
-        }
-      ]
-    },
     optimization: {
       minimize: isEnvProduction
     },


### PR DESCRIPTION
- Removed the additional `webpack` configuration since it's no longer needed. 
  - Dropped `exports-loader` since it's no longer needed.
- Using the `comments` directly exported by the parser.
  - Dropped `solidity-comments-extractor` since it's no longer needed.
