### PR TITLE
storing offsets in a Map instead of passing them down through an array

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,13 +2,9 @@ const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const testMatch = ['<rootDir>/tests/format/**/format.test.js'];
 
 if (TEST_STANDALONE) {
-  testMatch.push(
-    '<rootDir>/tests/integration/**/*.test.js',
-    '<rootDir>/tests/unit/prettier-version/**/*.test.js'
-  );
+  testMatch.push('<rootDir>/tests/integration/**/*.test.js');
 } else {
   testMatch.push('<rootDir>/tests/unit/**/*.test.js');
-  testMatch.push('<rootDir>/tests/unit/**/*.test.ts');
 }
 
 export default {

--- a/src/slang-nodes/AbicoderPragma.ts
+++ b/src/slang-nodes/AbicoderPragma.ts
@@ -15,11 +15,10 @@ export class AbicoderPragma implements SlangNode {
 
   version: Identifier;
 
-  constructor(ast: ast.AbicoderPragma, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.AbicoderPragma) {
+    const metadata = getNodeMetadata(ast);
 
-    this.version = new Identifier(ast.version, offsets[0]);
+    this.version = new Identifier(ast.version);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -24,17 +24,12 @@ export class AdditiveExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.AdditiveExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.AdditiveExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/AddressType.ts
+++ b/src/slang-nodes/AddressType.ts
@@ -15,8 +15,8 @@ export class AddressType implements SlangNode {
 
   payableKeyword?: string;
 
-  constructor(ast: ast.AddressType, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.AddressType) {
+    const metadata = getNodeMetadata(ast);
 
     this.payableKeyword = ast.payableKeyword?.unparse();
 

--- a/src/slang-nodes/AndExpression.ts
+++ b/src/slang-nodes/AndExpression.ts
@@ -21,17 +21,12 @@ export class AndExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.AndExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.AndExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -17,26 +17,19 @@ export class ArgumentsDeclaration implements SlangNode {
 
   variant: PositionalArgumentsDeclaration | NamedArgumentsDeclaration;
 
-  constructor(
-    ast: ast.ArgumentsDeclaration,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ArgumentsDeclaration, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.PositionalArgumentsDeclaration:
         this.variant = new PositionalArgumentsDeclaration(
           ast.variant as ast.PositionalArgumentsDeclaration,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.NamedArgumentsDeclaration:
         this.variant = new NamedArgumentsDeclaration(
           ast.variant as ast.NamedArgumentsDeclaration,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/ArrayExpression.ts
+++ b/src/slang-nodes/ArrayExpression.ts
@@ -19,15 +19,10 @@ export class ArrayExpression implements SlangNode {
 
   items: ArrayValues;
 
-  constructor(
-    ast: ast.ArrayExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ArrayExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.items = new ArrayValues(ast.items, offsets[0], options);
+    this.items = new ArrayValues(ast.items, options);
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -19,17 +19,12 @@ export class ArrayTypeName implements SlangNode {
 
   index?: Expression;
 
-  constructor(
-    ast: ast.ArrayTypeName,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ArrayTypeName, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new TypeName(ast.operand, offsets[0], options);
+    this.operand = new TypeName(ast.operand, options);
     if (ast.index) {
-      this.index = new Expression(ast.index, offsets[1], options);
+      this.index = new Expression(ast.index, options);
     }
 
     metadata = updateMetadata(metadata, [this.operand, this.index]);

--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -19,17 +19,10 @@ export class ArrayValues implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.ArrayValues,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ArrayValues, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new Expression(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new Expression(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/AssemblyFlags.ts
+++ b/src/slang-nodes/AssemblyFlags.ts
@@ -19,17 +19,10 @@ export class AssemblyFlags implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.AssemblyFlags,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.AssemblyFlags, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new StringLiteral(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new StringLiteral(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/AssemblyFlagsDeclaration.ts
+++ b/src/slang-nodes/AssemblyFlagsDeclaration.ts
@@ -18,13 +18,11 @@ export class AssemblyFlagsDeclaration implements SlangNode {
 
   constructor(
     ast: ast.AssemblyFlagsDeclaration,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.flags = new AssemblyFlags(ast.flags, offsets[0], options);
+    this.flags = new AssemblyFlags(ast.flags, options);
 
     metadata = updateMetadata(metadata, [this.flags]);
 

--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -23,24 +23,16 @@ export class AssemblyStatement implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.AssemblyStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.AssemblyStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.label) {
-      this.label = new StringLiteral(ast.label, offsets[i], options);
-      i += 1;
+      this.label = new StringLiteral(ast.label, options);
     }
     if (ast.flags) {
-      this.flags = new AssemblyFlagsDeclaration(ast.flags, offsets[i], options);
-      i += 1;
+      this.flags = new AssemblyFlagsDeclaration(ast.flags, options);
     }
-    this.body = new YulBlock(ast.body, offsets[i], options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.label, this.flags, this.body]);
 

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -24,17 +24,12 @@ export class AssignmentExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.AssignmentExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.AssignmentExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -24,17 +24,12 @@ export class BitwiseAndExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.BitwiseAndExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.BitwiseAndExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -34,17 +34,12 @@ export class BitwiseOrExpression implements SlangNode {
 
   rightOperand;
 
-  constructor(
-    ast: ast.BitwiseOrExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.BitwiseOrExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -24,17 +24,12 @@ export class BitwiseXorExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.BitwiseXorExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.BitwiseXorExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/Block.ts
+++ b/src/slang-nodes/Block.ts
@@ -16,11 +16,10 @@ export class Block implements SlangNode {
 
   statements: Statements;
 
-  constructor(ast: ast.Block, offset: number, options: ParserOptions<AstNode>) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.Block, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.statements = new Statements(ast.statements, offsets[0], options);
+    this.statements = new Statements(ast.statements, options);
 
     metadata = updateMetadata(metadata, [this.statements]);
 

--- a/src/slang-nodes/BreakStatement.ts
+++ b/src/slang-nodes/BreakStatement.ts
@@ -12,8 +12,8 @@ export class BreakStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.BreakStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.BreakStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -22,17 +22,10 @@ export class CallOptions implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.CallOptions,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.CallOptions, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new NamedArgument(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new NamedArgument(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -19,16 +19,11 @@ export class CallOptionsExpression implements SlangNode {
 
   options: CallOptions;
 
-  constructor(
-    ast: ast.CallOptionsExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.CallOptionsExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
-    this.options = new CallOptions(ast.options, offsets[1], options);
+    this.operand = new Expression(ast.operand, options);
+    this.options = new CallOptions(ast.options, options);
 
     metadata = updateMetadata(metadata, [this.operand, this.options]);
 

--- a/src/slang-nodes/CatchClause.ts
+++ b/src/slang-nodes/CatchClause.ts
@@ -19,20 +19,13 @@ export class CatchClause implements SlangNode {
 
   body: Block;
 
-  constructor(
-    ast: ast.CatchClause,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.CatchClause, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.error) {
-      this.error = new CatchClauseError(ast.error, offsets[i], options);
-      i += 1;
+      this.error = new CatchClauseError(ast.error, options);
     }
-    this.body = new Block(ast.body, offsets[i], options);
+    this.body = new Block(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.error, this.body]);
 

--- a/src/slang-nodes/CatchClauseError.ts
+++ b/src/slang-nodes/CatchClauseError.ts
@@ -22,24 +22,13 @@ export class CatchClauseError implements SlangNode {
 
   parameters: ParametersDeclaration;
 
-  constructor(
-    ast: ast.CatchClauseError,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.CatchClauseError, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[i]);
-      i += 1;
+      this.name = new Identifier(ast.name);
     }
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[i],
-      options
-    );
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
 
     metadata = updateMetadata(metadata, [this.parameters]);
 

--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -19,17 +19,10 @@ export class CatchClauses implements SlangNode {
 
   items: CatchClause[];
 
-  constructor(
-    ast: ast.CatchClauses,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.CatchClauses, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new CatchClause(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new CatchClause(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/ComparisonExpression.ts
+++ b/src/slang-nodes/ComparisonExpression.ts
@@ -21,17 +21,12 @@ export class ComparisonExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.ComparisonExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ComparisonExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -116,25 +116,12 @@ export class ConditionalExpression implements SlangNode {
 
   falseExpression: Expression;
 
-  constructor(
-    ast: ast.ConditionalExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ConditionalExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
-    this.trueExpression = new Expression(
-      ast.trueExpression,
-      offsets[1],
-      options
-    );
-    this.falseExpression = new Expression(
-      ast.falseExpression,
-      offsets[2],
-      options
-    );
+    this.operand = new Expression(ast.operand, options);
+    this.trueExpression = new Expression(ast.trueExpression, options);
+    this.falseExpression = new Expression(ast.falseExpression, options);
 
     metadata = updateMetadata(metadata, [
       this.operand,

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -22,17 +22,12 @@ export class ConstantDefinition implements SlangNode {
 
   value: Expression;
 
-  constructor(
-    ast: ast.ConstantDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ConstantDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
-    this.name = new Identifier(ast.name, offsets[1]);
-    this.value = new Expression(ast.value, offsets[2], options);
+    this.typeName = new TypeName(ast.typeName, options);
+    this.name = new Identifier(ast.name);
+    this.value = new Expression(ast.value, options);
 
     metadata = updateMetadata(metadata, [this.typeName, this.value]);
 

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -16,18 +16,13 @@ export class ConstructorAttribute implements SlangNode {
 
   variant: ModifierInvocation | string;
 
-  constructor(
-    ast: ast.ConstructorAttribute,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ConstructorAttribute, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new ModifierInvocation(ast.variant, offsets[0], options);
+        : new ModifierInvocation(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -20,16 +20,11 @@ export class ConstructorAttributes implements SlangNode {
 
   items: ConstructorAttribute[];
 
-  constructor(
-    ast: ast.ConstructorAttributes,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ConstructorAttributes, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) => new ConstructorAttribute(item, offsets[index], options)
+      (item) => new ConstructorAttribute(item, options)
     );
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/ConstructorDefinition.ts
+++ b/src/slang-nodes/ConstructorDefinition.ts
@@ -23,25 +23,12 @@ export class ConstructorDefinition implements SlangNode {
 
   body: Block;
 
-  constructor(
-    ast: ast.ConstructorDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ConstructorDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[0],
-      options
-    );
-    this.attributes = new ConstructorAttributes(
-      ast.attributes,
-      offsets[1],
-      options
-    );
-    this.body = new Block(ast.body, offsets[2], options);
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new ConstructorAttributes(ast.attributes, options);
+    this.body = new Block(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/ContinueStatement.ts
+++ b/src/slang-nodes/ContinueStatement.ts
@@ -12,8 +12,8 @@ export class ContinueStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.ContinueStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.ContinueStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -28,26 +28,15 @@ export class ContractDefinition implements SlangNode {
 
   members: ContractMembers;
 
-  constructor(
-    ast: ast.ContractDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ContractDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.abstractKeyword = ast.abstractKeyword?.unparse();
-    this.name = new Identifier(ast.name, offsets[0]);
-    let i = 1;
+    this.name = new Identifier(ast.name);
     if (ast.inheritance) {
-      this.inheritance = new InheritanceSpecifier(
-        ast.inheritance,
-        offsets[i],
-        options
-      );
-      i += 1;
+      this.inheritance = new InheritanceSpecifier(ast.inheritance, options);
     }
-    this.members = new ContractMembers(ast.members, offsets[i], options);
+    this.members = new ContractMembers(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.inheritance, this.members]);
 

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -41,102 +41,82 @@ export class ContractMember implements SlangNode {
     | ErrorDefinition
     | UserDefinedValueTypeDefinition;
 
-  constructor(
-    ast: ast.ContractMember,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ContractMember, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.UsingDirective:
         this.variant = new UsingDirective(
           ast.variant as ast.UsingDirective,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.FunctionDefinition:
         this.variant = new FunctionDefinition(
           ast.variant as ast.FunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ConstructorDefinition:
         this.variant = new ConstructorDefinition(
           ast.variant as ast.ConstructorDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ReceiveFunctionDefinition:
         this.variant = new ReceiveFunctionDefinition(
           ast.variant as ast.ReceiveFunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.FallbackFunctionDefinition:
         this.variant = new FallbackFunctionDefinition(
           ast.variant as ast.FallbackFunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.UnnamedFunctionDefinition:
         this.variant = new UnnamedFunctionDefinition(
           ast.variant as ast.UnnamedFunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ModifierDefinition:
         this.variant = new ModifierDefinition(
           ast.variant as ast.ModifierDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.StructDefinition:
         this.variant = new StructDefinition(
           ast.variant as ast.StructDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(
-          ast.variant as ast.EnumDefinition,
-          offsets[0]
-        );
+        this.variant = new EnumDefinition(ast.variant as ast.EnumDefinition);
         break;
       case NonterminalKind.EventDefinition:
         this.variant = new EventDefinition(
           ast.variant as ast.EventDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.StateVariableDefinition:
         this.variant = new StateVariableDefinition(
           ast.variant as ast.StateVariableDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ErrorDefinition:
         this.variant = new ErrorDefinition(
           ast.variant as ast.ErrorDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.UserDefinedValueTypeDefinition:
         this.variant = new UserDefinedValueTypeDefinition(
-          ast.variant as ast.UserDefinedValueTypeDefinition,
-          offsets[0]
+          ast.variant as ast.UserDefinedValueTypeDefinition
         );
         break;
       default:

--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -22,17 +22,10 @@ export class ContractMembers implements SlangNode {
 
   items: ContractMember[];
 
-  constructor(
-    ast: ast.ContractMembers,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ContractMembers, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ContractMember(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new ContractMember(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/DecimalNumberExpression.ts
+++ b/src/slang-nodes/DecimalNumberExpression.ts
@@ -18,13 +18,12 @@ export class DecimalNumberExpression implements SlangNode {
 
   unit?: NumberUnit;
 
-  constructor(ast: ast.DecimalNumberExpression, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.DecimalNumberExpression) {
+    let metadata = getNodeMetadata(ast);
 
     this.literal = ast.literal.unparse();
     if (ast.unit) {
-      this.unit = new NumberUnit(ast.unit, offsets[0]);
+      this.unit = new NumberUnit(ast.unit);
     }
 
     metadata = updateMetadata(metadata, [this.unit]);

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -23,16 +23,11 @@ export class DoWhileStatement implements SlangNode {
 
   condition: Expression;
 
-  constructor(
-    ast: ast.DoWhileStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.DoWhileStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.body = new Statement(ast.body, offsets[0], options);
-    this.condition = new Expression(ast.condition, offsets[1], options);
+    this.body = new Statement(ast.body, options);
+    this.condition = new Expression(ast.condition, options);
 
     metadata = updateMetadata(metadata, [this.body, this.condition]);
 

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -15,14 +15,13 @@ export class ElementaryType implements SlangNode {
 
   variant: AddressType | string;
 
-  constructor(ast: ast.ElementaryType, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ElementaryType) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new AddressType(ast.variant, offsets[0]);
+        : new AddressType(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -25,15 +25,10 @@ export class ElseBranch implements SlangNode {
 
   body: Statement;
 
-  constructor(
-    ast: ast.ElseBranch,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ElseBranch, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.body = new Statement(ast.body, offsets[0], options);
+    this.body = new Statement(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.body]);
 

--- a/src/slang-nodes/EmitStatement.ts
+++ b/src/slang-nodes/EmitStatement.ts
@@ -19,20 +19,11 @@ export class EmitStatement implements SlangNode {
 
   arguments: ArgumentsDeclaration;
 
-  constructor(
-    ast: ast.EmitStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.EmitStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.event = new IdentifierPath(ast.event, offsets[0]);
-    this.arguments = new ArgumentsDeclaration(
-      ast.arguments,
-      offsets[1],
-      options
-    );
+    this.event = new IdentifierPath(ast.event);
+    this.arguments = new ArgumentsDeclaration(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.event, this.arguments]);
 

--- a/src/slang-nodes/EnumDefinition.ts
+++ b/src/slang-nodes/EnumDefinition.ts
@@ -18,12 +18,11 @@ export class EnumDefinition implements SlangNode {
 
   members: EnumMembers;
 
-  constructor(ast: ast.EnumDefinition, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.EnumDefinition) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.members = new EnumMembers(ast.members, offsets[1]);
+    this.name = new Identifier(ast.name);
+    this.members = new EnumMembers(ast.members);
 
     metadata = updateMetadata(metadata, [this.members]);
 

--- a/src/slang-nodes/EnumMembers.ts
+++ b/src/slang-nodes/EnumMembers.ts
@@ -21,13 +21,10 @@ export class EnumMembers implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.EnumMembers, offset: number) {
-    const metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.EnumMembers) {
+    const metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new Identifier(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new Identifier(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -21,17 +21,12 @@ export class EqualityExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.EqualityExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.EqualityExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/ErrorDefinition.ts
+++ b/src/slang-nodes/ErrorDefinition.ts
@@ -19,20 +19,11 @@ export class ErrorDefinition implements SlangNode {
 
   members: ErrorParametersDeclaration;
 
-  constructor(
-    ast: ast.ErrorDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ErrorDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.members = new ErrorParametersDeclaration(
-      ast.members,
-      offsets[1],
-      options
-    );
+    this.name = new Identifier(ast.name);
+    this.members = new ErrorParametersDeclaration(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.members]);
 

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -20,17 +20,12 @@ export class ErrorParameter implements SlangNode {
 
   name?: Identifier;
 
-  constructor(
-    ast: ast.ErrorParameter,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ErrorParameter, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
+    this.typeName = new TypeName(ast.typeName, options);
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[1]);
+      this.name = new Identifier(ast.name);
     }
 
     metadata = updateMetadata(metadata, [this.typeName]);

--- a/src/slang-nodes/ErrorParameters.ts
+++ b/src/slang-nodes/ErrorParameters.ts
@@ -19,17 +19,10 @@ export class ErrorParameters implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.ErrorParameters,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ErrorParameters, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ErrorParameter(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new ErrorParameter(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/ErrorParametersDeclaration.ts
+++ b/src/slang-nodes/ErrorParametersDeclaration.ts
@@ -18,13 +18,11 @@ export class ErrorParametersDeclaration implements SlangNode {
 
   constructor(
     ast: ast.ErrorParametersDeclaration,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ErrorParameters(ast.parameters, offsets[0], options);
+    this.parameters = new ErrorParameters(ast.parameters, options);
 
     metadata = updateMetadata(metadata, [this.parameters]);
 

--- a/src/slang-nodes/EventDefinition.ts
+++ b/src/slang-nodes/EventDefinition.ts
@@ -21,20 +21,11 @@ export class EventDefinition implements SlangNode {
 
   anonymousKeyword?: string;
 
-  constructor(
-    ast: ast.EventDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.EventDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.parameters = new EventParametersDeclaration(
-      ast.parameters,
-      offsets[1],
-      options
-    );
+    this.name = new Identifier(ast.name);
+    this.parameters = new EventParametersDeclaration(ast.parameters, options);
     this.anonymousKeyword = ast.anonymousKeyword?.unparse();
 
     metadata = updateMetadata(metadata, [this.parameters]);

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -22,18 +22,13 @@ export class EventParameter implements SlangNode {
 
   name?: Identifier;
 
-  constructor(
-    ast: ast.EventParameter,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.EventParameter, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
+    this.typeName = new TypeName(ast.typeName, options);
     this.indexedKeyword = ast.indexedKeyword?.unparse();
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[1]);
+      this.name = new Identifier(ast.name);
     }
 
     metadata = updateMetadata(metadata, [this.typeName]);

--- a/src/slang-nodes/EventParameters.ts
+++ b/src/slang-nodes/EventParameters.ts
@@ -19,17 +19,10 @@ export class EventParameters implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.EventParameters,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.EventParameters, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new EventParameter(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new EventParameter(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/EventParametersDeclaration.ts
+++ b/src/slang-nodes/EventParametersDeclaration.ts
@@ -18,13 +18,11 @@ export class EventParametersDeclaration implements SlangNode {
 
   constructor(
     ast: ast.EventParametersDeclaration,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new EventParameters(ast.parameters, offsets[0], options);
+    this.parameters = new EventParameters(ast.parameters, options);
 
     metadata = updateMetadata(metadata, [this.parameters]);
 

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -21,18 +21,13 @@ export class ExperimentalFeature implements SlangNode {
 
   variant: StringLiteral | Identifier;
 
-  constructor(
-    ast: ast.ExperimentalFeature,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ExperimentalFeature, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
-        ? new Identifier(ast.variant, offsets[0])
-        : new StringLiteral(ast.variant, offsets[0], options);
+        ? new Identifier(ast.variant)
+        : new StringLiteral(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/ExperimentalPragma.ts
+++ b/src/slang-nodes/ExperimentalPragma.ts
@@ -16,15 +16,10 @@ export class ExperimentalPragma implements SlangNode {
 
   feature: ExperimentalFeature;
 
-  constructor(
-    ast: ast.ExperimentalPragma,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ExperimentalPragma, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.feature = new ExperimentalFeature(ast.feature, offsets[0], options);
+    this.feature = new ExperimentalFeature(ast.feature, options);
 
     metadata = updateMetadata(metadata, [this.feature]);
 

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -38,15 +38,13 @@ export class ExponentiationExpression implements SlangNode {
 
   constructor(
     ast: ast.ExponentiationExpression,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -75,203 +75,169 @@ export class Expression implements SlangNode {
     | ElementaryType
     | Identifier;
 
-  constructor(
-    ast: ast.Expression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.Expression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
-      this.variant = new Identifier(ast.variant, offsets[0]);
+      this.variant = new Identifier(ast.variant);
     } else {
       switch (ast.variant.cst.kind) {
         case NonterminalKind.AssignmentExpression:
           this.variant = new AssignmentExpression(
             ast.variant as ast.AssignmentExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ConditionalExpression:
           this.variant = new ConditionalExpression(
             ast.variant as ast.ConditionalExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.OrExpression:
           this.variant = new OrExpression(
             ast.variant as ast.OrExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.AndExpression:
           this.variant = new AndExpression(
             ast.variant as ast.AndExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.EqualityExpression:
           this.variant = new EqualityExpression(
             ast.variant as ast.EqualityExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ComparisonExpression:
           this.variant = new ComparisonExpression(
             ast.variant as ast.ComparisonExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.BitwiseOrExpression:
           this.variant = new BitwiseOrExpression(
             ast.variant as ast.BitwiseOrExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.BitwiseXorExpression:
           this.variant = new BitwiseXorExpression(
             ast.variant as ast.BitwiseXorExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.BitwiseAndExpression:
           this.variant = new BitwiseAndExpression(
             ast.variant as ast.BitwiseAndExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ShiftExpression:
           this.variant = new ShiftExpression(
             ast.variant as ast.ShiftExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.AdditiveExpression:
           this.variant = new AdditiveExpression(
             ast.variant as ast.AdditiveExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.MultiplicativeExpression:
           this.variant = new MultiplicativeExpression(
             ast.variant as ast.MultiplicativeExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ExponentiationExpression:
           this.variant = new ExponentiationExpression(
             ast.variant as ast.ExponentiationExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.PostfixExpression:
           this.variant = new PostfixExpression(
             ast.variant as ast.PostfixExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.PrefixExpression:
           this.variant = new PrefixExpression(
             ast.variant as ast.PrefixExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.FunctionCallExpression:
           this.variant = new FunctionCallExpression(
             ast.variant as ast.FunctionCallExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.CallOptionsExpression:
           this.variant = new CallOptionsExpression(
             ast.variant as ast.CallOptionsExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.MemberAccessExpression:
           this.variant = new MemberAccessExpression(
             ast.variant as ast.MemberAccessExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.IndexAccessExpression:
           this.variant = new IndexAccessExpression(
             ast.variant as ast.IndexAccessExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.NewExpression:
           this.variant = new NewExpression(
             ast.variant as ast.NewExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.TupleExpression:
           this.variant = new TupleExpression(
             ast.variant as ast.TupleExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.TypeExpression:
           this.variant = new TypeExpression(
             ast.variant as ast.TypeExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ArrayExpression:
           this.variant = new ArrayExpression(
             ast.variant as ast.ArrayExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.HexNumberExpression:
           this.variant = new HexNumberExpression(
-            ast.variant as ast.HexNumberExpression,
-            offsets[0]
+            ast.variant as ast.HexNumberExpression
           );
           break;
         case NonterminalKind.DecimalNumberExpression:
           this.variant = new DecimalNumberExpression(
-            ast.variant as ast.DecimalNumberExpression,
-            offsets[0]
+            ast.variant as ast.DecimalNumberExpression
           );
           break;
         case NonterminalKind.StringExpression:
           this.variant = new StringExpression(
             ast.variant as ast.StringExpression,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.ElementaryType:
-          this.variant = new ElementaryType(
-            ast.variant as ast.ElementaryType,
-            offsets[0]
-          );
+          this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
           break;
         default:
           throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -16,15 +16,10 @@ export class ExpressionStatement implements SlangNode {
 
   expression: Expression;
 
-  constructor(
-    ast: ast.ExpressionStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ExpressionStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.expression = new Expression(ast.expression, offsets[0], options);
+    this.expression = new Expression(ast.expression, options);
 
     metadata = updateMetadata(metadata, [this.expression]);
 

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -19,11 +19,9 @@ export class FallbackFunctionAttribute implements SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionAttribute,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
@@ -32,14 +30,12 @@ export class FallbackFunctionAttribute implements SlangNode {
         case NonterminalKind.ModifierInvocation:
           this.variant = new ModifierInvocation(
             ast.variant as ast.ModifierInvocation,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.OverrideSpecifier:
           this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier,
-            offsets[0]
+            ast.variant as ast.OverrideSpecifier
           );
           break;
         default:

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -22,15 +22,12 @@ export class FallbackFunctionAttributes implements SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionAttributes,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) =>
-        new FallbackFunctionAttribute(item, offsets[index], options)
+      (item) => new FallbackFunctionAttribute(item, options)
     );
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/FallbackFunctionDefinition.ts
+++ b/src/slang-nodes/FallbackFunctionDefinition.ts
@@ -28,28 +28,16 @@ export class FallbackFunctionDefinition implements SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionDefinition,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[0],
-      options
-    );
-    this.attributes = new FallbackFunctionAttributes(
-      ast.attributes,
-      offsets[1],
-      options
-    );
-    let i = 2;
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new FallbackFunctionAttributes(ast.attributes, options);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, offsets[i], options);
-      i += 1;
+      this.returns = new ReturnsDeclaration(ast.returns, options);
     }
-    this.body = new FunctionBody(ast.body, offsets[i], options);
+    this.body = new FunctionBody(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -29,30 +29,18 @@ export class ForStatement implements SlangNode {
 
   body: Statement;
 
-  constructor(
-    ast: ast.ForStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ForStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.initialization = new ForStatementInitialization(
       ast.initialization,
-      offsets[0],
       options
     );
-    this.condition = new ForStatementCondition(
-      ast.condition,
-      offsets[1],
-      options
-    );
-    let i = 2;
+    this.condition = new ForStatementCondition(ast.condition, options);
     if (ast.iterator) {
-      this.iterator = new Expression(ast.iterator, offsets[i], options);
-      i += 1;
+      this.iterator = new Expression(ast.iterator, options);
     }
-    this.body = new Statement(ast.body, offsets[i], options);
+    this.body = new Statement(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.initialization,

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -16,18 +16,13 @@ export class ForStatementCondition implements SlangNode {
 
   variant: ExpressionStatement | string;
 
-  constructor(
-    ast: ast.ForStatementCondition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ForStatementCondition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new ExpressionStatement(ast.variant, offsets[0], options);
+        : new ExpressionStatement(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -24,11 +24,9 @@ export class ForStatementInitialization implements SlangNode {
 
   constructor(
     ast: ast.ForStatementInitialization,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
@@ -37,21 +35,18 @@ export class ForStatementInitialization implements SlangNode {
         case NonterminalKind.ExpressionStatement:
           this.variant = new ExpressionStatement(
             ast.variant as ast.ExpressionStatement,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.VariableDeclarationStatement:
           this.variant = new VariableDeclarationStatement(
             ast.variant as ast.VariableDeclarationStatement,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.TupleDeconstructionStatement:
           this.variant = new TupleDeconstructionStatement(
             ast.variant as ast.TupleDeconstructionStatement,
-            offsets[0],
             options
           );
           break;

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -17,13 +17,8 @@ export class FunctionAttribute implements SlangNode {
 
   variant: ModifierInvocation | OverrideSpecifier | string;
 
-  constructor(
-    ast: ast.FunctionAttribute,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionAttribute, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
@@ -32,14 +27,12 @@ export class FunctionAttribute implements SlangNode {
         case NonterminalKind.ModifierInvocation:
           this.variant = new ModifierInvocation(
             ast.variant as ast.ModifierInvocation,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.OverrideSpecifier:
           this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier,
-            offsets[0]
+            ast.variant as ast.OverrideSpecifier
           );
           break;
         default:

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -20,17 +20,10 @@ export class FunctionAttributes implements SlangNode {
 
   items: FunctionAttribute[];
 
-  constructor(
-    ast: ast.FunctionAttributes,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionAttributes, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new FunctionAttribute(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new FunctionAttribute(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -16,18 +16,13 @@ export class FunctionBody implements SlangNode {
 
   variant: Block | string;
 
-  constructor(
-    ast: ast.FunctionBody,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionBody, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new Block(ast.variant, offsets[0], options);
+        : new Block(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -25,18 +25,12 @@ export class FunctionCallExpression implements SlangNode {
 
   constructor(
     ast: ast.FunctionCallExpression,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
-    this.arguments = new ArgumentsDeclaration(
-      ast.arguments,
-      offsets[1],
-      options
-    );
+    this.operand = new Expression(ast.operand, options);
+    this.arguments = new ArgumentsDeclaration(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.operand, this.arguments]);
 

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -30,31 +30,16 @@ export class FunctionDefinition implements SlangNode {
 
   body: FunctionBody;
 
-  constructor(
-    ast: ast.FunctionDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new FunctionName(ast.name, offsets[0]);
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[1],
-      options
-    );
-    this.attributes = new FunctionAttributes(
-      ast.attributes,
-      offsets[2],
-      options
-    );
-    let i = 3;
+    this.name = new FunctionName(ast.name);
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new FunctionAttributes(ast.attributes, options);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, offsets[i], options);
-      i += 1;
+      this.returns = new ReturnsDeclaration(ast.returns, options);
     }
-    this.body = new FunctionBody(ast.body, offsets[i], options);
+    this.body = new FunctionBody(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.name,

--- a/src/slang-nodes/FunctionName.ts
+++ b/src/slang-nodes/FunctionName.ts
@@ -15,11 +15,10 @@ export class FunctionName implements SlangNode {
 
   variant: Identifier;
 
-  constructor(ast: ast.FunctionName, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionName) {
+    const metadata = getNodeMetadata(ast);
 
-    this.variant = new Identifier(ast.variant, offsets[0]);
+    this.variant = new Identifier(ast.variant);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/FunctionType.ts
+++ b/src/slang-nodes/FunctionType.ts
@@ -23,22 +23,13 @@ export class FunctionType implements SlangNode {
 
   returns?: ReturnsDeclaration;
 
-  constructor(
-    ast: ast.FunctionType,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionType, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[0],
-      options
-    );
-    this.attributes = new FunctionTypeAttributes(ast.attributes, offsets[1]);
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new FunctionTypeAttributes(ast.attributes);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, offsets[2], options);
+      this.returns = new ReturnsDeclaration(ast.returns, options);
     }
 
     metadata = updateMetadata(metadata, [

--- a/src/slang-nodes/FunctionTypeAttribute.ts
+++ b/src/slang-nodes/FunctionTypeAttribute.ts
@@ -14,8 +14,8 @@ export class FunctionTypeAttribute implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.FunctionTypeAttribute, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.FunctionTypeAttribute) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -19,13 +19,10 @@ export class FunctionTypeAttributes implements SlangNode {
 
   items: FunctionTypeAttribute[];
 
-  constructor(ast: ast.FunctionTypeAttributes, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.FunctionTypeAttributes) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new FunctionTypeAttribute(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new FunctionTypeAttribute(item));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/HexNumberExpression.ts
+++ b/src/slang-nodes/HexNumberExpression.ts
@@ -18,13 +18,12 @@ export class HexNumberExpression implements SlangNode {
 
   unit?: NumberUnit;
 
-  constructor(ast: ast.HexNumberExpression, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.HexNumberExpression) {
+    let metadata = getNodeMetadata(ast);
 
     this.literal = ast.literal.unparse();
     if (ast.unit) {
-      this.unit = new NumberUnit(ast.unit, offsets[0]);
+      this.unit = new NumberUnit(ast.unit);
     }
 
     metadata = updateMetadata(metadata, [this.unit]);

--- a/src/slang-nodes/HexStringLiteral.ts
+++ b/src/slang-nodes/HexStringLiteral.ts
@@ -16,12 +16,8 @@ export class HexStringLiteral implements SlangNode {
 
   variant: string;
 
-  constructor(
-    ast: ast.HexStringLiteral,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.HexStringLiteral, options: ParserOptions<AstNode>) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/HexStringLiterals.ts
+++ b/src/slang-nodes/HexStringLiterals.ts
@@ -19,17 +19,10 @@ export class HexStringLiterals implements SlangNode {
 
   items: HexStringLiteral[];
 
-  constructor(
-    ast: ast.HexStringLiterals,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.HexStringLiterals, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new HexStringLiteral(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new HexStringLiteral(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/Identifier.ts
+++ b/src/slang-nodes/Identifier.ts
@@ -1,4 +1,5 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 
 import type { Doc } from 'prettier';
 import type { Location, SlangNode } from '../types.d.ts';
@@ -13,14 +14,13 @@ export class Identifier implements SlangNode {
 
   value: string;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.comments = [];
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.comments = metadata.comments;
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/IdentifierPath.ts
+++ b/src/slang-nodes/IdentifierPath.ts
@@ -17,13 +17,10 @@ export class IdentifierPath implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.IdentifierPath, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.IdentifierPath) {
+    const metadata = getNodeMetadata(ast);
 
-    this.items = ast.items.map(
-      (item, index) => new Identifier(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new Identifier(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -27,18 +27,13 @@ export class IfStatement implements SlangNode {
 
   elseBranch?: ElseBranch;
 
-  constructor(
-    ast: ast.IfStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.IfStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.condition = new Expression(ast.condition, offsets[0], options);
-    this.body = new Statement(ast.body, offsets[1], options);
+    this.condition = new Expression(ast.condition, options);
+    this.body = new Statement(ast.body, options);
     if (ast.elseBranch) {
-      this.elseBranch = new ElseBranch(ast.elseBranch, offsets[2], options);
+      this.elseBranch = new ElseBranch(ast.elseBranch, options);
     }
 
     metadata = updateMetadata(metadata, [

--- a/src/slang-nodes/ImportAlias.ts
+++ b/src/slang-nodes/ImportAlias.ts
@@ -15,11 +15,10 @@ export class ImportAlias implements SlangNode {
 
   identifier: Identifier;
 
-  constructor(ast: ast.ImportAlias, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportAlias) {
+    const metadata = getNodeMetadata(ast);
 
-    this.identifier = new Identifier(ast.identifier, offsets[0]);
+    this.identifier = new Identifier(ast.identifier);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -18,33 +18,19 @@ export class ImportClause implements SlangNode {
 
   variant: PathImport | NamedImport | ImportDeconstruction;
 
-  constructor(
-    ast: ast.ImportClause,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportClause, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.PathImport:
-        this.variant = new PathImport(
-          ast.variant as ast.PathImport,
-          offsets[0],
-          options
-        );
+        this.variant = new PathImport(ast.variant as ast.PathImport, options);
         break;
       case NonterminalKind.NamedImport:
-        this.variant = new NamedImport(
-          ast.variant as ast.NamedImport,
-          offsets[0],
-          options
-        );
+        this.variant = new NamedImport(ast.variant as ast.NamedImport, options);
         break;
       case NonterminalKind.ImportDeconstruction:
         this.variant = new ImportDeconstruction(
           ast.variant as ast.ImportDeconstruction,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/ImportDeconstruction.ts
+++ b/src/slang-nodes/ImportDeconstruction.ts
@@ -19,16 +19,11 @@ export class ImportDeconstruction implements SlangNode {
 
   path: StringLiteral;
 
-  constructor(
-    ast: ast.ImportDeconstruction,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportDeconstruction, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.symbols = new ImportDeconstructionSymbols(ast.symbols, offsets[0]);
-    this.path = new StringLiteral(ast.path, offsets[1], options);
+    this.symbols = new ImportDeconstructionSymbols(ast.symbols);
+    this.path = new StringLiteral(ast.path, options);
 
     metadata = updateMetadata(metadata, [this.symbols, this.path]);
 

--- a/src/slang-nodes/ImportDeconstructionSymbol.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbol.ts
@@ -18,13 +18,12 @@ export class ImportDeconstructionSymbol implements SlangNode {
 
   alias?: ImportAlias;
 
-  constructor(ast: ast.ImportDeconstructionSymbol, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportDeconstructionSymbol) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
+    this.name = new Identifier(ast.name);
     if (ast.alias) {
-      this.alias = new ImportAlias(ast.alias, offsets[1]);
+      this.alias = new ImportAlias(ast.alias);
     }
 
     metadata = updateMetadata(metadata, [this.alias]);

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -23,13 +23,10 @@ export class ImportDeconstructionSymbols implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.ImportDeconstructionSymbols, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportDeconstructionSymbols) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ImportDeconstructionSymbol(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new ImportDeconstructionSymbol(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/ImportDirective.ts
+++ b/src/slang-nodes/ImportDirective.ts
@@ -16,15 +16,10 @@ export class ImportDirective implements SlangNode {
 
   clause: ImportClause;
 
-  constructor(
-    ast: ast.ImportDirective,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ImportDirective, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.clause = new ImportClause(ast.clause, offsets[0], options);
+    this.clause = new ImportClause(ast.clause, options);
 
     metadata = updateMetadata(metadata, [this.clause]);
 

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -16,16 +16,11 @@ export class IndexAccessEnd implements SlangNode {
 
   end?: Expression;
 
-  constructor(
-    ast: ast.IndexAccessEnd,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.IndexAccessEnd, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.end) {
-      this.end = new Expression(ast.end, offsets[0], options);
+      this.end = new Expression(ast.end, options);
     }
 
     metadata = updateMetadata(metadata, [this.end]);

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -25,22 +25,15 @@ export class IndexAccessExpression implements SlangNode {
 
   end?: IndexAccessEnd;
 
-  constructor(
-    ast: ast.IndexAccessExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.IndexAccessExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
-    let i = 1;
+    this.operand = new Expression(ast.operand, options);
     if (ast.start) {
-      this.start = new Expression(ast.start, offsets[i], options);
-      i += 1;
+      this.start = new Expression(ast.start, options);
     }
     if (ast.end) {
-      this.end = new IndexAccessEnd(ast.end, offsets[i], options);
+      this.end = new IndexAccessEnd(ast.end, options);
     }
 
     metadata = updateMetadata(metadata, [this.operand, this.start, this.end]);

--- a/src/slang-nodes/InheritanceSpecifier.ts
+++ b/src/slang-nodes/InheritanceSpecifier.ts
@@ -16,15 +16,10 @@ export class InheritanceSpecifier implements SlangNode {
 
   types: InheritanceTypes;
 
-  constructor(
-    ast: ast.InheritanceSpecifier,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.InheritanceSpecifier, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.types = new InheritanceTypes(ast.types, offsets[0], options);
+    this.types = new InheritanceTypes(ast.types, options);
 
     metadata = updateMetadata(metadata, [this.types]);
 

--- a/src/slang-nodes/InheritanceType.ts
+++ b/src/slang-nodes/InheritanceType.ts
@@ -19,21 +19,12 @@ export class InheritanceType implements SlangNode {
 
   arguments?: ArgumentsDeclaration;
 
-  constructor(
-    ast: ast.InheritanceType,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.InheritanceType, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new IdentifierPath(ast.typeName, offsets[0]);
+    this.typeName = new IdentifierPath(ast.typeName);
     if (ast.arguments) {
-      this.arguments = new ArgumentsDeclaration(
-        ast.arguments,
-        offsets[1],
-        options
-      );
+      this.arguments = new ArgumentsDeclaration(ast.arguments, options);
     }
 
     metadata = updateMetadata(metadata, [this.typeName, this.arguments]);

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -22,17 +22,10 @@ export class InheritanceTypes implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.InheritanceTypes,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.InheritanceTypes, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new InheritanceType(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new InheritanceType(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -25,25 +25,14 @@ export class InterfaceDefinition implements SlangNode {
 
   members: InterfaceMembers;
 
-  constructor(
-    ast: ast.InterfaceDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.InterfaceDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    let i = 1;
+    this.name = new Identifier(ast.name);
     if (ast.inheritance) {
-      this.inheritance = new InheritanceSpecifier(
-        ast.inheritance,
-        offsets[i],
-        options
-      );
-      i += 1;
+      this.inheritance = new InheritanceSpecifier(ast.inheritance, options);
     }
-    this.members = new InterfaceMembers(ast.members, offsets[i], options);
+    this.members = new InterfaceMembers(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.inheritance, this.members]);
 

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -21,17 +21,10 @@ export class InterfaceMembers implements SlangNode {
 
   items: ContractMember[];
 
-  constructor(
-    ast: ast.InterfaceMembers,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.InterfaceMembers, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ContractMember(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new ContractMember(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -22,16 +22,11 @@ export class LibraryDefinition implements SlangNode {
 
   members: LibraryMembers;
 
-  constructor(
-    ast: ast.LibraryDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.LibraryDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.members = new LibraryMembers(ast.members, offsets[1], options);
+    this.name = new Identifier(ast.name);
+    this.members = new LibraryMembers(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.members]);
 

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -21,17 +21,10 @@ export class LibraryMembers implements SlangNode {
 
   items: ContractMember[];
 
-  constructor(
-    ast: ast.LibraryMembers,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.LibraryMembers, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ContractMember(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new ContractMember(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -19,13 +19,12 @@ export class MappingKey implements SlangNode {
 
   name?: Identifier;
 
-  constructor(ast: ast.MappingKey, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.MappingKey) {
+    let metadata = getNodeMetadata(ast);
 
-    this.keyType = new MappingKeyType(ast.keyType, offsets[0]);
+    this.keyType = new MappingKeyType(ast.keyType);
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[1]);
+      this.name = new Identifier(ast.name);
     }
 
     metadata = updateMetadata(metadata, [this.keyType]);

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -16,22 +16,15 @@ export class MappingKeyType implements SlangNode {
 
   variant: ElementaryType | IdentifierPath;
 
-  constructor(ast: ast.MappingKeyType, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.MappingKeyType) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(
-          ast.variant as ast.ElementaryType,
-          offsets[0]
-        );
+        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
         break;
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(
-          ast.variant as ast.IdentifierPath,
-          offsets[0]
-        );
+        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
         break;
       default:
         throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/MappingType.ts
+++ b/src/slang-nodes/MappingType.ts
@@ -19,16 +19,11 @@ export class MappingType implements SlangNode {
 
   valueType: MappingValue;
 
-  constructor(
-    ast: ast.MappingType,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.MappingType, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.keyType = new MappingKey(ast.keyType, offsets[0]);
-    this.valueType = new MappingValue(ast.valueType, offsets[1], options);
+    this.keyType = new MappingKey(ast.keyType);
+    this.valueType = new MappingValue(ast.valueType, options);
 
     metadata = updateMetadata(metadata, [this.keyType, this.valueType]);
 

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -20,17 +20,12 @@ export class MappingValue implements SlangNode {
 
   name?: Identifier;
 
-  constructor(
-    ast: ast.MappingValue,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.MappingValue, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
+    this.typeName = new TypeName(ast.typeName, options);
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[1]);
+      this.name = new Identifier(ast.name);
     }
 
     metadata = updateMetadata(metadata, [this.typeName]);

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -128,14 +128,12 @@ export class MemberAccessExpression implements SlangNode {
 
   constructor(
     ast: ast.MemberAccessExpression,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
-    this.member = new Identifier(ast.member, offsets[1]);
+    this.operand = new Expression(ast.operand, options);
+    this.member = new Identifier(ast.member);
 
     metadata = updateMetadata(metadata, [this.operand]);
 

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -15,14 +15,13 @@ export class ModifierAttribute implements SlangNode {
 
   variant: OverrideSpecifier | string;
 
-  constructor(ast: ast.ModifierAttribute, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ModifierAttribute) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new OverrideSpecifier(ast.variant, offsets[0]);
+        : new OverrideSpecifier(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -19,13 +19,10 @@ export class ModifierAttributes implements SlangNode {
 
   items: ModifierAttribute[];
 
-  constructor(ast: ast.ModifierAttributes, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.ModifierAttributes) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new ModifierAttribute(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new ModifierAttribute(item));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -27,27 +27,15 @@ export class ModifierDefinition implements SlangNode {
 
   body: FunctionBody;
 
-  constructor(
-    ast: ast.ModifierDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ModifierDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    let i = 1;
+    this.name = new Identifier(ast.name);
     if (ast.parameters) {
-      this.parameters = new ParametersDeclaration(
-        ast.parameters,
-        offsets[i],
-        options
-      );
-      i += 1;
+      this.parameters = new ParametersDeclaration(ast.parameters, options);
     }
-    this.attributes = new ModifierAttributes(ast.attributes, offsets[i]);
-    i += 1;
-    this.body = new FunctionBody(ast.body, offsets[i], options);
+    this.attributes = new ModifierAttributes(ast.attributes);
+    this.body = new FunctionBody(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/ModifierInvocation.ts
+++ b/src/slang-nodes/ModifierInvocation.ts
@@ -19,21 +19,12 @@ export class ModifierInvocation implements SlangNode {
 
   arguments?: ArgumentsDeclaration;
 
-  constructor(
-    ast: ast.ModifierInvocation,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ModifierInvocation, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new IdentifierPath(ast.name, offsets[0]);
+    this.name = new IdentifierPath(ast.name);
     if (ast.arguments) {
-      this.arguments = new ArgumentsDeclaration(
-        ast.arguments,
-        offsets[1],
-        options
-      );
+      this.arguments = new ArgumentsDeclaration(ast.arguments, options);
     }
 
     metadata = updateMetadata(metadata, [this.name, this.arguments]);

--- a/src/slang-nodes/MultiLineComment.ts
+++ b/src/slang-nodes/MultiLineComment.ts
@@ -1,5 +1,6 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 import { isIndentableBlockComment } from '../slang-utils/is-indentable-block-comment.js';
 import { printIndentableBlockComment } from '../slang-printers/print-indentable-block-comment.js';
 
@@ -30,13 +31,12 @@ export class MultiLineComment implements SlangNode, BaseComment {
 
   followingNode?: StrictAstNode;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/MultiLineNatSpecComment.ts
+++ b/src/slang-nodes/MultiLineNatSpecComment.ts
@@ -1,5 +1,6 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 import { isIndentableBlockComment } from '../slang-utils/is-indentable-block-comment.js';
 import { printIndentableBlockComment } from '../slang-printers/print-indentable-block-comment.js';
 
@@ -30,13 +31,12 @@ export class MultiLineNatSpecComment implements SlangNode, BaseComment {
 
   followingNode?: StrictAstNode;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/MultiplicativeExpression.ts
+++ b/src/slang-nodes/MultiplicativeExpression.ts
@@ -28,15 +28,13 @@ export class MultiplicativeExpression implements SlangNode {
 
   constructor(
     ast: ast.MultiplicativeExpression,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -19,16 +19,11 @@ export class NamedArgument implements SlangNode {
 
   value: Expression;
 
-  constructor(
-    ast: ast.NamedArgument,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.NamedArgument, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.value = new Expression(ast.value, offsets[1], options);
+    this.name = new Identifier(ast.name);
+    this.value = new Expression(ast.value, options);
 
     metadata = updateMetadata(metadata, [this.value]);
 

--- a/src/slang-nodes/NamedArgumentGroup.ts
+++ b/src/slang-nodes/NamedArgumentGroup.ts
@@ -16,15 +16,10 @@ export class NamedArgumentGroup implements SlangNode {
 
   arguments: NamedArguments;
 
-  constructor(
-    ast: ast.NamedArgumentGroup,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.NamedArgumentGroup, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.arguments = new NamedArguments(ast.arguments, offsets[0], options);
+    this.arguments = new NamedArguments(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.arguments]);
 

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -22,17 +22,10 @@ export class NamedArguments implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.NamedArguments,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.NamedArguments, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new NamedArgument(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new NamedArgument(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/NamedArgumentsDeclaration.ts
+++ b/src/slang-nodes/NamedArgumentsDeclaration.ts
@@ -18,18 +18,12 @@ export class NamedArgumentsDeclaration implements SlangNode {
 
   constructor(
     ast: ast.NamedArgumentsDeclaration,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     if (ast.arguments) {
-      this.arguments = new NamedArgumentGroup(
-        ast.arguments,
-        offsets[0],
-        options
-      );
+      this.arguments = new NamedArgumentGroup(ast.arguments, options);
     }
 
     metadata = updateMetadata(metadata, [this.arguments]);

--- a/src/slang-nodes/NamedImport.ts
+++ b/src/slang-nodes/NamedImport.ts
@@ -19,16 +19,11 @@ export class NamedImport implements SlangNode {
 
   path: StringLiteral;
 
-  constructor(
-    ast: ast.NamedImport,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.NamedImport, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.alias = new ImportAlias(ast.alias, offsets[0]);
-    this.path = new StringLiteral(ast.path, offsets[1], options);
+    this.alias = new ImportAlias(ast.alias);
+    this.path = new StringLiteral(ast.path, options);
 
     metadata = updateMetadata(metadata, [this.alias, this.path]);
 

--- a/src/slang-nodes/NewExpression.ts
+++ b/src/slang-nodes/NewExpression.ts
@@ -16,15 +16,10 @@ export class NewExpression implements SlangNode {
 
   typeName: TypeName;
 
-  constructor(
-    ast: ast.NewExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.NewExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
+    this.typeName = new TypeName(ast.typeName, options);
 
     metadata = updateMetadata(metadata, [this.typeName]);
 

--- a/src/slang-nodes/NumberUnit.ts
+++ b/src/slang-nodes/NumberUnit.ts
@@ -14,8 +14,8 @@ export class NumberUnit implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.NumberUnit, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.NumberUnit) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -24,17 +24,12 @@ export class OrExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.OrExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.OrExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/OverridePaths.ts
+++ b/src/slang-nodes/OverridePaths.ts
@@ -18,13 +18,10 @@ export class OverridePaths implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.OverridePaths, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.OverridePaths) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new IdentifierPath(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new IdentifierPath(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/OverridePathsDeclaration.ts
+++ b/src/slang-nodes/OverridePathsDeclaration.ts
@@ -15,11 +15,10 @@ export class OverridePathsDeclaration implements SlangNode {
 
   paths: OverridePaths;
 
-  constructor(ast: ast.OverridePathsDeclaration, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.OverridePathsDeclaration) {
+    let metadata = getNodeMetadata(ast);
 
-    this.paths = new OverridePaths(ast.paths, offsets[0]);
+    this.paths = new OverridePaths(ast.paths);
 
     metadata = updateMetadata(metadata, [this.paths]);
 

--- a/src/slang-nodes/OverrideSpecifier.ts
+++ b/src/slang-nodes/OverrideSpecifier.ts
@@ -15,15 +15,11 @@ export class OverrideSpecifier implements SlangNode {
 
   overridden?: OverridePathsDeclaration;
 
-  constructor(ast: ast.OverrideSpecifier, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.OverrideSpecifier) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.overridden) {
-      this.overridden = new OverridePathsDeclaration(
-        ast.overridden,
-        offsets[0]
-      );
+      this.overridden = new OverridePathsDeclaration(ast.overridden);
     }
 
     metadata = updateMetadata(metadata, [this.overridden]);

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -26,25 +26,15 @@ export class Parameter implements SlangNode {
 
   name?: Identifier;
 
-  constructor(
-    ast: ast.Parameter,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.Parameter, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
-    let i = 1;
+    this.typeName = new TypeName(ast.typeName, options);
     if (ast.storageLocation) {
-      this.storageLocation = new StorageLocation(
-        ast.storageLocation,
-        offsets[i]
-      );
-      i += 1;
+      this.storageLocation = new StorageLocation(ast.storageLocation);
     }
     if (ast.name) {
-      this.name = new Identifier(ast.name, offsets[i]);
+      this.name = new Identifier(ast.name);
     }
 
     metadata = updateMetadata(metadata, [this.typeName, this.storageLocation]);

--- a/src/slang-nodes/Parameters.ts
+++ b/src/slang-nodes/Parameters.ts
@@ -21,17 +21,10 @@ export class Parameters implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.Parameters,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.Parameters, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new Parameter(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new Parameter(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/ParametersDeclaration.ts
+++ b/src/slang-nodes/ParametersDeclaration.ts
@@ -16,15 +16,10 @@ export class ParametersDeclaration implements SlangNode {
 
   parameters: Parameters;
 
-  constructor(
-    ast: ast.ParametersDeclaration,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ParametersDeclaration, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new Parameters(ast.parameters, offsets[0], options);
+    this.parameters = new Parameters(ast.parameters, options);
 
     metadata = updateMetadata(metadata, [this.parameters]);
 

--- a/src/slang-nodes/PathImport.ts
+++ b/src/slang-nodes/PathImport.ts
@@ -19,17 +19,12 @@ export class PathImport implements SlangNode {
 
   alias?: ImportAlias;
 
-  constructor(
-    ast: ast.PathImport,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.PathImport, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.path = new StringLiteral(ast.path, offsets[0], options);
+    this.path = new StringLiteral(ast.path, options);
     if (ast.alias) {
-      this.alias = new ImportAlias(ast.alias, offsets[1]);
+      this.alias = new ImportAlias(ast.alias);
     }
 
     metadata = updateMetadata(metadata, [this.path, this.alias]);

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -21,17 +21,10 @@ export class PositionalArguments implements SlangNode {
 
   separators;
 
-  constructor(
-    ast: ast.PositionalArguments,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.PositionalArguments, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new Expression(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new Expression(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/PositionalArgumentsDeclaration.ts
+++ b/src/slang-nodes/PositionalArgumentsDeclaration.ts
@@ -21,17 +21,11 @@ export class PositionalArgumentsDeclaration implements SlangNode {
 
   constructor(
     ast: ast.PositionalArgumentsDeclaration,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.arguments = new PositionalArguments(
-      ast.arguments,
-      offsets[0],
-      options
-    );
+    this.arguments = new PositionalArguments(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.arguments]);
 

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -18,15 +18,10 @@ export class PostfixExpression implements SlangNode {
 
   operator: string;
 
-  constructor(
-    ast: ast.PostfixExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.PostfixExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new Expression(ast.operand, offsets[0], options);
+    this.operand = new Expression(ast.operand, options);
     this.operator = ast.operator.unparse();
 
     metadata = updateMetadata(metadata, [this.operand]);

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -18,33 +18,21 @@ export class Pragma implements SlangNode {
 
   variant: AbicoderPragma | ExperimentalPragma | VersionPragma;
 
-  constructor(
-    ast: ast.Pragma,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.Pragma, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.AbicoderPragma:
-        this.variant = new AbicoderPragma(
-          ast.variant as ast.AbicoderPragma,
-          offsets[0]
-        );
+        this.variant = new AbicoderPragma(ast.variant as ast.AbicoderPragma);
         break;
       case NonterminalKind.ExperimentalPragma:
         this.variant = new ExperimentalPragma(
           ast.variant as ast.ExperimentalPragma,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.VersionPragma:
-        this.variant = new VersionPragma(
-          ast.variant as ast.VersionPragma,
-          offsets[0]
-        );
+        this.variant = new VersionPragma(ast.variant as ast.VersionPragma);
         break;
       default:
         throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/PragmaDirective.ts
+++ b/src/slang-nodes/PragmaDirective.ts
@@ -16,15 +16,10 @@ export class PragmaDirective implements SlangNode {
 
   pragma: Pragma;
 
-  constructor(
-    ast: ast.PragmaDirective,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.PragmaDirective, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.pragma = new Pragma(ast.pragma, offsets[0], options);
+    this.pragma = new Pragma(ast.pragma, options);
 
     metadata = updateMetadata(metadata, [this.pragma]);
 

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -18,16 +18,11 @@ export class PrefixExpression implements SlangNode {
 
   operand: Expression;
 
-  constructor(
-    ast: ast.PrefixExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.PrefixExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.operator = ast.operator.unparse();
-    this.operand = new Expression(ast.operand, offsets[0], options);
+    this.operand = new Expression(ast.operand, options);
 
     metadata = updateMetadata(metadata, [this.operand]);
 

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -19,11 +19,9 @@ export class ReceiveFunctionAttribute implements SlangNode {
 
   constructor(
     ast: ast.ReceiveFunctionAttribute,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
@@ -32,14 +30,12 @@ export class ReceiveFunctionAttribute implements SlangNode {
         case NonterminalKind.ModifierInvocation:
           this.variant = new ModifierInvocation(
             ast.variant as ast.ModifierInvocation,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.OverrideSpecifier:
           this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier,
-            offsets[0]
+            ast.variant as ast.OverrideSpecifier
           );
           break;
         default:

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -22,15 +22,12 @@ export class ReceiveFunctionAttributes implements SlangNode {
 
   constructor(
     ast: ast.ReceiveFunctionAttributes,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) =>
-        new ReceiveFunctionAttribute(item, offsets[index], options)
+      (item) => new ReceiveFunctionAttribute(item, options)
     );
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/ReceiveFunctionDefinition.ts
+++ b/src/slang-nodes/ReceiveFunctionDefinition.ts
@@ -25,23 +25,13 @@ export class ReceiveFunctionDefinition implements SlangNode {
 
   constructor(
     ast: ast.ReceiveFunctionDefinition,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[0],
-      options
-    );
-    this.attributes = new ReceiveFunctionAttributes(
-      ast.attributes,
-      offsets[1],
-      options
-    );
-    this.body = new FunctionBody(ast.body, offsets[2], options);
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new ReceiveFunctionAttributes(ast.attributes, options);
+    this.body = new FunctionBody(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -37,16 +37,11 @@ export class ReturnStatement implements SlangNode {
 
   expression?: Expression;
 
-  constructor(
-    ast: ast.ReturnStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ReturnStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.expression) {
-      this.expression = new Expression(ast.expression, offsets[0], options);
+      this.expression = new Expression(ast.expression, options);
     }
 
     metadata = updateMetadata(metadata, [this.expression]);

--- a/src/slang-nodes/ReturnsDeclaration.ts
+++ b/src/slang-nodes/ReturnsDeclaration.ts
@@ -19,19 +19,10 @@ export class ReturnsDeclaration implements SlangNode {
 
   variables: ParametersDeclaration;
 
-  constructor(
-    ast: ast.ReturnsDeclaration,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ReturnsDeclaration, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.variables = new ParametersDeclaration(
-      ast.variables,
-      offsets[0],
-      options
-    );
+    this.variables = new ParametersDeclaration(ast.variables, options);
 
     metadata = updateMetadata(metadata, [this.variables]);
 

--- a/src/slang-nodes/RevertStatement.ts
+++ b/src/slang-nodes/RevertStatement.ts
@@ -20,24 +20,13 @@ export class RevertStatement implements SlangNode {
 
   arguments: ArgumentsDeclaration;
 
-  constructor(
-    ast: ast.RevertStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.RevertStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.error) {
-      this.error = new IdentifierPath(ast.error, offsets[i]);
-      i += 1;
+      this.error = new IdentifierPath(ast.error);
     }
-    this.arguments = new ArgumentsDeclaration(
-      ast.arguments,
-      offsets[i],
-      options
-    );
+    this.arguments = new ArgumentsDeclaration(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.error, this.arguments]);
 

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -33,17 +33,12 @@ export class ShiftExpression implements SlangNode {
 
   rightOperand: Expression;
 
-  constructor(
-    ast: ast.ShiftExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.ShiftExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, offsets[0], options);
+    this.leftOperand = new Expression(ast.leftOperand, options);
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, offsets[1], options);
+    this.rightOperand = new Expression(ast.rightOperand, options);
 
     metadata = updateMetadata(metadata, [this.leftOperand, this.rightOperand]);
 

--- a/src/slang-nodes/SimpleVersionLiteral.ts
+++ b/src/slang-nodes/SimpleVersionLiteral.ts
@@ -16,8 +16,8 @@ export class SimpleVersionLiteral implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.SimpleVersionLiteral, offset: number) {
-    const metadata = getNodeMetadata(ast, offset, true);
+  constructor(ast: ast.SimpleVersionLiteral) {
+    const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => item.unparse());
     this.separators = ast.separators.map((separator) => separator.unparse());

--- a/src/slang-nodes/SingleLineComment.ts
+++ b/src/slang-nodes/SingleLineComment.ts
@@ -1,4 +1,5 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 
 import type { Doc } from 'prettier';
 import type { BaseComment, Location, SlangNode } from '../types.d.ts';
@@ -25,13 +26,12 @@ export class SingleLineComment implements SlangNode, BaseComment {
 
   followingNode?: StrictAstNode;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/SingleLineNatSpecComment.ts
+++ b/src/slang-nodes/SingleLineNatSpecComment.ts
@@ -1,4 +1,5 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 
 import type { Doc } from 'prettier';
 import type { BaseComment, Location, SlangNode } from '../types.d.ts';
@@ -25,13 +26,12 @@ export class SingleLineNatSpecComment implements SlangNode, BaseComment {
 
   followingNode?: StrictAstNode;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -19,15 +19,10 @@ export class SourceUnit implements SlangNode {
 
   members: SourceUnitMembers;
 
-  constructor(
-    ast: ast.SourceUnit,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.SourceUnit, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.members = new SourceUnitMembers(ast.members, offsets[0], options);
+    this.members = new SourceUnitMembers(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.members]);
 

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -41,101 +41,81 @@ export class SourceUnitMember implements SlangNode {
     | UsingDirective
     | EventDefinition;
 
-  constructor(
-    ast: ast.SourceUnitMember,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.SourceUnitMember, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.PragmaDirective:
         this.variant = new PragmaDirective(
           ast.variant as ast.PragmaDirective,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ImportDirective:
         this.variant = new ImportDirective(
           ast.variant as ast.ImportDirective,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ContractDefinition:
         this.variant = new ContractDefinition(
           ast.variant as ast.ContractDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.InterfaceDefinition:
         this.variant = new InterfaceDefinition(
           ast.variant as ast.InterfaceDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.LibraryDefinition:
         this.variant = new LibraryDefinition(
           ast.variant as ast.LibraryDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.StructDefinition:
         this.variant = new StructDefinition(
           ast.variant as ast.StructDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(
-          ast.variant as ast.EnumDefinition,
-          offsets[0]
-        );
+        this.variant = new EnumDefinition(ast.variant as ast.EnumDefinition);
         break;
       case NonterminalKind.FunctionDefinition:
         this.variant = new FunctionDefinition(
           ast.variant as ast.FunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ConstantDefinition:
         this.variant = new ConstantDefinition(
           ast.variant as ast.ConstantDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ErrorDefinition:
         this.variant = new ErrorDefinition(
           ast.variant as ast.ErrorDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.UserDefinedValueTypeDefinition:
         this.variant = new UserDefinedValueTypeDefinition(
-          ast.variant as ast.UserDefinedValueTypeDefinition,
-          offsets[0]
+          ast.variant as ast.UserDefinedValueTypeDefinition
         );
         break;
       case NonterminalKind.UsingDirective:
         this.variant = new UsingDirective(
           ast.variant as ast.UsingDirective,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.EventDefinition:
         this.variant = new EventDefinition(
           ast.variant as ast.EventDefinition,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/SourceUnitMembers.ts
+++ b/src/slang-nodes/SourceUnitMembers.ts
@@ -17,17 +17,10 @@ export class SourceUnitMembers implements SlangNode {
 
   items: SourceUnitMember[];
 
-  constructor(
-    ast: ast.SourceUnitMembers,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.SourceUnitMembers, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new SourceUnitMember(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new SourceUnitMember(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -15,14 +15,13 @@ export class StateVariableAttribute implements SlangNode {
 
   variant: OverrideSpecifier | string;
 
-  constructor(ast: ast.StateVariableAttribute, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.StateVariableAttribute) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new OverrideSpecifier(ast.variant, offsets[0]);
+        : new OverrideSpecifier(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -19,13 +19,10 @@ export class StateVariableAttributes implements SlangNode {
 
   items: StateVariableAttribute[];
 
-  constructor(ast: ast.StateVariableAttributes, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.StateVariableAttributes) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new StateVariableAttribute(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new StateVariableAttribute(item));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -30,21 +30,15 @@ export class StateVariableDefinition implements SlangNode {
 
   constructor(
     ast: ast.StateVariableDefinition,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
-    this.attributes = new StateVariableAttributes(ast.attributes, offsets[1]);
-    this.name = new Identifier(ast.name, offsets[2]);
+    this.typeName = new TypeName(ast.typeName, options);
+    this.attributes = new StateVariableAttributes(ast.attributes);
+    this.name = new Identifier(ast.name);
     if (ast.value) {
-      this.value = new StateVariableDefinitionValue(
-        ast.value,
-        offsets[3],
-        options
-      );
+      this.value = new StateVariableDefinitionValue(ast.value, options);
     }
 
     metadata = updateMetadata(metadata, [

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -21,13 +21,11 @@ export class StateVariableDefinitionValue implements SlangNode {
 
   constructor(
     ast: ast.StateVariableDefinitionValue,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.value = new Expression(ast.value, offsets[0], options);
+    this.value = new Expression(ast.value, options);
 
     metadata = updateMetadata(metadata, [this.value]);
 

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -49,124 +49,96 @@ export class Statement implements SlangNode {
     | Block
     | UncheckedBlock;
 
-  constructor(
-    ast: ast.Statement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.Statement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.ExpressionStatement:
         this.variant = new ExpressionStatement(
           ast.variant as ast.ExpressionStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.VariableDeclarationStatement:
         this.variant = new VariableDeclarationStatement(
           ast.variant as ast.VariableDeclarationStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.TupleDeconstructionStatement:
         this.variant = new TupleDeconstructionStatement(
           ast.variant as ast.TupleDeconstructionStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.IfStatement:
-        this.variant = new IfStatement(
-          ast.variant as ast.IfStatement,
-          offsets[0],
-          options
-        );
+        this.variant = new IfStatement(ast.variant as ast.IfStatement, options);
         break;
       case NonterminalKind.ForStatement:
         this.variant = new ForStatement(
           ast.variant as ast.ForStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.WhileStatement:
         this.variant = new WhileStatement(
           ast.variant as ast.WhileStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.DoWhileStatement:
         this.variant = new DoWhileStatement(
           ast.variant as ast.DoWhileStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ContinueStatement:
         this.variant = new ContinueStatement(
-          ast.variant as ast.ContinueStatement,
-          offsets[0]
+          ast.variant as ast.ContinueStatement
         );
         break;
       case NonterminalKind.BreakStatement:
-        this.variant = new BreakStatement(
-          ast.variant as ast.BreakStatement,
-          offsets[0]
-        );
+        this.variant = new BreakStatement(ast.variant as ast.BreakStatement);
         break;
       case NonterminalKind.ReturnStatement:
         this.variant = new ReturnStatement(
           ast.variant as ast.ReturnStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.ThrowStatement:
-        this.variant = new ThrowStatement(
-          ast.variant as ast.ThrowStatement,
-          offsets[0]
-        );
+        this.variant = new ThrowStatement(ast.variant as ast.ThrowStatement);
         break;
       case NonterminalKind.EmitStatement:
         this.variant = new EmitStatement(
           ast.variant as ast.EmitStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.TryStatement:
         this.variant = new TryStatement(
           ast.variant as ast.TryStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.RevertStatement:
         this.variant = new RevertStatement(
           ast.variant as ast.RevertStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.AssemblyStatement:
         this.variant = new AssemblyStatement(
           ast.variant as ast.AssemblyStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.Block:
-        this.variant = new Block(ast.variant as ast.Block, offsets[0], options);
+        this.variant = new Block(ast.variant as ast.Block, options);
         break;
       case NonterminalKind.UncheckedBlock:
         this.variant = new UncheckedBlock(
           ast.variant as ast.UncheckedBlock,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -22,17 +22,10 @@ export class Statements implements SlangNode {
 
   items: Statement[];
 
-  constructor(
-    ast: ast.Statements,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.Statements, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new Statement(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new Statement(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/StorageLocation.ts
+++ b/src/slang-nodes/StorageLocation.ts
@@ -14,8 +14,8 @@ export class StorageLocation implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.StorageLocation, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.StorageLocation) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -25,47 +25,37 @@ export class StringExpression implements SlangNode {
     | HexStringLiterals
     | UnicodeStringLiterals;
 
-  constructor(
-    ast: ast.StringExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.StringExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.StringLiteral:
         this.variant = new StringLiteral(
           ast.variant as ast.StringLiteral,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.StringLiterals:
         this.variant = new StringLiterals(
           ast.variant as ast.StringLiterals,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.HexStringLiteral:
         this.variant = new HexStringLiteral(
           ast.variant as ast.HexStringLiteral,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.HexStringLiterals:
         this.variant = new HexStringLiterals(
           ast.variant as ast.HexStringLiterals,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.UnicodeStringLiterals:
         this.variant = new UnicodeStringLiterals(
           ast.variant as ast.UnicodeStringLiterals,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/StringLiteral.ts
+++ b/src/slang-nodes/StringLiteral.ts
@@ -16,12 +16,8 @@ export class StringLiteral implements SlangNode {
 
   variant;
 
-  constructor(
-    ast: ast.StringLiteral,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.StringLiteral, options: ParserOptions<AstNode>) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/StringLiterals.ts
+++ b/src/slang-nodes/StringLiterals.ts
@@ -19,17 +19,10 @@ export class StringLiterals implements SlangNode {
 
   items: StringLiteral[];
 
-  constructor(
-    ast: ast.StringLiterals,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.StringLiterals, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new StringLiteral(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new StringLiteral(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/StructDefinition.ts
+++ b/src/slang-nodes/StructDefinition.ts
@@ -19,16 +19,11 @@ export class StructDefinition implements SlangNode {
 
   members: StructMembers;
 
-  constructor(
-    ast: ast.StructDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.StructDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.members = new StructMembers(ast.members, offsets[1], options);
+    this.name = new Identifier(ast.name);
+    this.members = new StructMembers(ast.members, options);
 
     metadata = updateMetadata(metadata, [this.members]);
 

--- a/src/slang-nodes/StructMember.ts
+++ b/src/slang-nodes/StructMember.ts
@@ -19,16 +19,11 @@ export class StructMember implements SlangNode {
 
   name: Identifier;
 
-  constructor(
-    ast: ast.StructMember,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.StructMember, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
-    this.name = new Identifier(ast.name, offsets[1]);
+    this.typeName = new TypeName(ast.typeName, options);
+    this.name = new Identifier(ast.name);
 
     metadata = updateMetadata(metadata, [this.typeName]);
 

--- a/src/slang-nodes/StructMembers.ts
+++ b/src/slang-nodes/StructMembers.ts
@@ -20,17 +20,10 @@ export class StructMembers implements SlangNode {
 
   items: StructMember[];
 
-  constructor(
-    ast: ast.StructMembers,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.StructMembers, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new StructMember(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new StructMember(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/ThrowStatement.ts
+++ b/src/slang-nodes/ThrowStatement.ts
@@ -12,8 +12,8 @@ export class ThrowStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.ThrowStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.ThrowStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -30,23 +30,15 @@ export class TryStatement implements SlangNode {
 
   catchClauses: CatchClauses;
 
-  constructor(
-    ast: ast.TryStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TryStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.expression = new Expression(ast.expression, offsets[0], options);
-    let i = 1;
+    this.expression = new Expression(ast.expression, options);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, offsets[i], options);
-      i += 1;
+      this.returns = new ReturnsDeclaration(ast.returns, options);
     }
-    this.body = new Block(ast.body, offsets[i], options);
-    i += 1;
-    this.catchClauses = new CatchClauses(ast.catchClauses, offsets[i], options);
+    this.body = new Block(ast.body, options);
+    this.catchClauses = new CatchClauses(ast.catchClauses, options);
 
     metadata = updateMetadata(metadata, [
       this.expression,

--- a/src/slang-nodes/TupleDeconstructionElement.ts
+++ b/src/slang-nodes/TupleDeconstructionElement.ts
@@ -18,14 +18,12 @@ export class TupleDeconstructionElement implements SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionElement,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     if (ast.member) {
-      this.member = new TupleMember(ast.member, offsets[0], options);
+      this.member = new TupleMember(ast.member, options);
     }
 
     metadata = updateMetadata(metadata, [this.member]);

--- a/src/slang-nodes/TupleDeconstructionElements.ts
+++ b/src/slang-nodes/TupleDeconstructionElements.ts
@@ -21,15 +21,12 @@ export class TupleDeconstructionElements implements SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionElements,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) =>
-        new TupleDeconstructionElement(item, offsets[index], options)
+      (item) => new TupleDeconstructionElement(item, options)
     );
     this.separators = ast.separators.map((separator) => separator.unparse());
 

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -26,19 +26,13 @@ export class TupleDeconstructionStatement implements SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionStatement,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     this.varKeyword = ast.varKeyword?.unparse();
-    this.elements = new TupleDeconstructionElements(
-      ast.elements,
-      offsets[0],
-      options
-    );
-    this.expression = new Expression(ast.expression, offsets[1], options);
+    this.elements = new TupleDeconstructionElements(ast.elements, options);
+    this.expression = new Expression(ast.expression, options);
 
     metadata = updateMetadata(metadata, [this.elements, this.expression]);
 

--- a/src/slang-nodes/TupleExpression.ts
+++ b/src/slang-nodes/TupleExpression.ts
@@ -16,15 +16,10 @@ export class TupleExpression implements SlangNode {
 
   items: TupleValues;
 
-  constructor(
-    ast: ast.TupleExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TupleExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.items = new TupleValues(ast.items, offsets[0], options);
+    this.items = new TupleValues(ast.items, options);
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -17,26 +17,19 @@ export class TupleMember implements SlangNode {
 
   variant: TypedTupleMember | UntypedTupleMember;
 
-  constructor(
-    ast: ast.TupleMember,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TupleMember, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.TypedTupleMember:
         this.variant = new TypedTupleMember(
           ast.variant as ast.TypedTupleMember,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.UntypedTupleMember:
         this.variant = new UntypedTupleMember(
-          ast.variant as ast.UntypedTupleMember,
-          offsets[0]
+          ast.variant as ast.UntypedTupleMember
         );
         break;
       default:

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -16,16 +16,11 @@ export class TupleValue implements SlangNode {
 
   expression?: Expression;
 
-  constructor(
-    ast: ast.TupleValue,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TupleValue, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.expression) {
-      this.expression = new Expression(ast.expression, offsets[0], options);
+      this.expression = new Expression(ast.expression, options);
     }
 
     metadata = updateMetadata(metadata, [this.expression]);

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -20,17 +20,10 @@ export class TupleValues implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.TupleValues,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.TupleValues, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new TupleValue(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new TupleValue(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/TypeExpression.ts
+++ b/src/slang-nodes/TypeExpression.ts
@@ -16,15 +16,10 @@ export class TypeExpression implements SlangNode {
 
   typeName: TypeName;
 
-  constructor(
-    ast: ast.TypeExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TypeExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
+    this.typeName = new TypeName(ast.typeName, options);
 
     metadata = updateMetadata(metadata, [this.typeName]);
 

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -25,47 +25,30 @@ export class TypeName implements SlangNode {
     | ElementaryType
     | IdentifierPath;
 
-  constructor(
-    ast: ast.TypeName,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TypeName, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.ArrayTypeName:
         this.variant = new ArrayTypeName(
           ast.variant as ast.ArrayTypeName,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.FunctionType:
         this.variant = new FunctionType(
           ast.variant as ast.FunctionType,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.MappingType:
-        this.variant = new MappingType(
-          ast.variant as ast.MappingType,
-          offsets[0],
-          options
-        );
+        this.variant = new MappingType(ast.variant as ast.MappingType, options);
         break;
       case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(
-          ast.variant as ast.ElementaryType,
-          offsets[0]
-        );
+        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
         break;
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(
-          ast.variant as ast.IdentifierPath,
-          offsets[0]
-        );
+        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
         break;
       default:
         throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -23,24 +23,14 @@ export class TypedTupleMember implements SlangNode {
 
   name: Identifier;
 
-  constructor(
-    ast: ast.TypedTupleMember,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.TypedTupleMember, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.typeName = new TypeName(ast.typeName, offsets[0], options);
-    let i = 1;
+    this.typeName = new TypeName(ast.typeName, options);
     if (ast.storageLocation) {
-      this.storageLocation = new StorageLocation(
-        ast.storageLocation,
-        offsets[i]
-      );
-      i += 1;
+      this.storageLocation = new StorageLocation(ast.storageLocation);
     }
-    this.name = new Identifier(ast.name, offsets[i]);
+    this.name = new Identifier(ast.name);
 
     metadata = updateMetadata(metadata, [this.typeName, this.storageLocation]);
 

--- a/src/slang-nodes/UncheckedBlock.ts
+++ b/src/slang-nodes/UncheckedBlock.ts
@@ -16,15 +16,10 @@ export class UncheckedBlock implements SlangNode {
 
   block: Block;
 
-  constructor(
-    ast: ast.UncheckedBlock,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UncheckedBlock, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.block = new Block(ast.block, offsets[0], options);
+    this.block = new Block(ast.block, options);
 
     metadata = updateMetadata(metadata, [this.block]);
 

--- a/src/slang-nodes/UnicodeStringLiteral.ts
+++ b/src/slang-nodes/UnicodeStringLiteral.ts
@@ -16,12 +16,8 @@ export class UnicodeStringLiteral implements SlangNode {
 
   variant: string;
 
-  constructor(
-    ast: ast.UnicodeStringLiteral,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.UnicodeStringLiteral, options: ParserOptions<AstNode>) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/UnicodeStringLiterals.ts
+++ b/src/slang-nodes/UnicodeStringLiterals.ts
@@ -19,16 +19,11 @@ export class UnicodeStringLiterals implements SlangNode {
 
   items: UnicodeStringLiteral[];
 
-  constructor(
-    ast: ast.UnicodeStringLiterals,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.UnicodeStringLiterals, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) => new UnicodeStringLiteral(item, offsets[index], options)
+      (item) => new UnicodeStringLiteral(item, options)
     );
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -18,16 +18,14 @@ export class UnnamedFunctionAttribute implements SlangNode {
 
   constructor(
     ast: ast.UnnamedFunctionAttribute,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new ModifierInvocation(ast.variant, offsets[0], options);
+        : new ModifierInvocation(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -22,15 +22,12 @@ export class UnnamedFunctionAttributes implements SlangNode {
 
   constructor(
     ast: ast.UnnamedFunctionAttributes,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map(
-      (item, index) =>
-        new UnnamedFunctionAttribute(item, offsets[index], options)
+      (item) => new UnnamedFunctionAttribute(item, options)
     );
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/UnnamedFunctionDefinition.ts
+++ b/src/slang-nodes/UnnamedFunctionDefinition.ts
@@ -25,23 +25,13 @@ export class UnnamedFunctionDefinition implements SlangNode {
 
   constructor(
     ast: ast.UnnamedFunctionDefinition,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      offsets[0],
-      options
-    );
-    this.attributes = new UnnamedFunctionAttributes(
-      ast.attributes,
-      offsets[1],
-      options
-    );
-    this.body = new FunctionBody(ast.body, offsets[2], options);
+    this.parameters = new ParametersDeclaration(ast.parameters, options);
+    this.attributes = new UnnamedFunctionAttributes(ast.attributes, options);
+    this.body = new FunctionBody(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/UntypedTupleMember.ts
+++ b/src/slang-nodes/UntypedTupleMember.ts
@@ -19,19 +19,13 @@ export class UntypedTupleMember implements SlangNode {
 
   name: Identifier;
 
-  constructor(ast: ast.UntypedTupleMember, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UntypedTupleMember) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.storageLocation) {
-      this.storageLocation = new StorageLocation(
-        ast.storageLocation,
-        offsets[i]
-      );
-      i += 1;
+      this.storageLocation = new StorageLocation(ast.storageLocation);
     }
-    this.name = new Identifier(ast.name, offsets[i]);
+    this.name = new Identifier(ast.name);
 
     metadata = updateMetadata(metadata, [this.storageLocation]);
 

--- a/src/slang-nodes/UserDefinedValueTypeDefinition.ts
+++ b/src/slang-nodes/UserDefinedValueTypeDefinition.ts
@@ -18,12 +18,11 @@ export class UserDefinedValueTypeDefinition implements SlangNode {
 
   valueType: ElementaryType;
 
-  constructor(ast: ast.UserDefinedValueTypeDefinition, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UserDefinedValueTypeDefinition) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new Identifier(ast.name, offsets[0]);
-    this.valueType = new ElementaryType(ast.valueType, offsets[1]);
+    this.name = new Identifier(ast.name);
+    this.valueType = new ElementaryType(ast.valueType);
 
     metadata = updateMetadata(metadata, [this.valueType]);
 

--- a/src/slang-nodes/UsingAlias.ts
+++ b/src/slang-nodes/UsingAlias.ts
@@ -15,11 +15,10 @@ export class UsingAlias implements SlangNode {
 
   operator: UsingOperator;
 
-  constructor(ast: ast.UsingAlias, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingAlias) {
+    let metadata = getNodeMetadata(ast);
 
-    this.operator = new UsingOperator(ast.operator, offsets[0]);
+    this.operator = new UsingOperator(ast.operator);
 
     metadata = updateMetadata(metadata, [this.operator]);
 

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -16,21 +16,16 @@ export class UsingClause implements SlangNode {
 
   variant: IdentifierPath | UsingDeconstruction;
 
-  constructor(ast: ast.UsingClause, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingClause) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(
-          ast.variant as ast.IdentifierPath,
-          offsets[0]
-        );
+        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
         break;
       case NonterminalKind.UsingDeconstruction:
         this.variant = new UsingDeconstruction(
-          ast.variant as ast.UsingDeconstruction,
-          offsets[0]
+          ast.variant as ast.UsingDeconstruction
         );
         break;
       default:

--- a/src/slang-nodes/UsingDeconstruction.ts
+++ b/src/slang-nodes/UsingDeconstruction.ts
@@ -15,11 +15,10 @@ export class UsingDeconstruction implements SlangNode {
 
   symbols: UsingDeconstructionSymbols;
 
-  constructor(ast: ast.UsingDeconstruction, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingDeconstruction) {
+    let metadata = getNodeMetadata(ast);
 
-    this.symbols = new UsingDeconstructionSymbols(ast.symbols, offsets[0]);
+    this.symbols = new UsingDeconstructionSymbols(ast.symbols);
 
     metadata = updateMetadata(metadata, [this.symbols]);
 

--- a/src/slang-nodes/UsingDeconstructionSymbol.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbol.ts
@@ -18,13 +18,12 @@ export class UsingDeconstructionSymbol implements SlangNode {
 
   alias?: UsingAlias;
 
-  constructor(ast: ast.UsingDeconstructionSymbol, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingDeconstructionSymbol) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new IdentifierPath(ast.name, offsets[0]);
+    this.name = new IdentifierPath(ast.name);
     if (ast.alias) {
-      this.alias = new UsingAlias(ast.alias, offsets[1]);
+      this.alias = new UsingAlias(ast.alias);
     }
 
     metadata = updateMetadata(metadata, [this.name, this.alias]);

--- a/src/slang-nodes/UsingDeconstructionSymbols.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbols.ts
@@ -22,13 +22,10 @@ export class UsingDeconstructionSymbols implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.UsingDeconstructionSymbols, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingDeconstructionSymbols) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new UsingDeconstructionSymbol(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new UsingDeconstructionSymbol(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/UsingDirective.ts
+++ b/src/slang-nodes/UsingDirective.ts
@@ -22,16 +22,11 @@ export class UsingDirective implements SlangNode {
 
   globalKeyword?: string;
 
-  constructor(
-    ast: ast.UsingDirective,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingDirective, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.clause = new UsingClause(ast.clause, offsets[0]);
-    this.target = new UsingTarget(ast.target, offsets[1], options);
+    this.clause = new UsingClause(ast.clause);
+    this.target = new UsingTarget(ast.target, options);
     this.globalKeyword = ast.globalKeyword?.unparse();
 
     metadata = updateMetadata(metadata, [this.clause, this.target]);

--- a/src/slang-nodes/UsingOperator.ts
+++ b/src/slang-nodes/UsingOperator.ts
@@ -14,8 +14,8 @@ export class UsingOperator implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.UsingOperator, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.UsingOperator) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -16,18 +16,13 @@ export class UsingTarget implements SlangNode {
 
   variant: TypeName | string;
 
-  constructor(
-    ast: ast.UsingTarget,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.UsingTarget, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new TypeName(ast.variant, offsets[0], options);
+        : new TypeName(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -30,29 +30,17 @@ export class VariableDeclarationStatement implements SlangNode {
 
   constructor(
     ast: ast.VariableDeclarationStatement,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.variableType = new VariableDeclarationType(
-      ast.variableType,
-      offsets[0],
-      options
-    );
-    let i = 1;
+    this.variableType = new VariableDeclarationType(ast.variableType, options);
     if (ast.storageLocation) {
-      this.storageLocation = new StorageLocation(
-        ast.storageLocation,
-        offsets[i]
-      );
-      i += 1;
+      this.storageLocation = new StorageLocation(ast.storageLocation);
     }
-    this.name = new Identifier(ast.name, offsets[i]);
-    i += 1;
+    this.name = new Identifier(ast.name);
     if (ast.value) {
-      this.value = new VariableDeclarationValue(ast.value, offsets[i], options);
+      this.value = new VariableDeclarationValue(ast.value, options);
     }
 
     metadata = updateMetadata(metadata, [

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -18,16 +18,14 @@ export class VariableDeclarationType implements SlangNode {
 
   constructor(
     ast: ast.VariableDeclarationType,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new TypeName(ast.variant, offsets[0], options);
+        : new TypeName(ast.variant, options);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -18,13 +18,11 @@ export class VariableDeclarationValue implements SlangNode {
 
   constructor(
     ast: ast.VariableDeclarationValue,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.expression = new Expression(ast.expression, offsets[0], options);
+    this.expression = new Expression(ast.expression, options);
 
     metadata = updateMetadata(metadata, [this.expression]);
 

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -16,22 +16,15 @@ export class VersionExpression implements SlangNode {
 
   variant: VersionRange | VersionTerm;
 
-  constructor(ast: ast.VersionExpression, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionExpression) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.VersionRange:
-        this.variant = new VersionRange(
-          ast.variant as ast.VersionRange,
-          offsets[0]
-        );
+        this.variant = new VersionRange(ast.variant as ast.VersionRange);
         break;
       case NonterminalKind.VersionTerm:
-        this.variant = new VersionTerm(
-          ast.variant as ast.VersionTerm,
-          offsets[0]
-        );
+        this.variant = new VersionTerm(ast.variant as ast.VersionTerm);
         break;
       default:
         throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/VersionExpressionSet.ts
+++ b/src/slang-nodes/VersionExpressionSet.ts
@@ -18,13 +18,10 @@ export class VersionExpressionSet implements SlangNode {
 
   items: VersionExpression[];
 
-  constructor(ast: ast.VersionExpressionSet, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionExpressionSet) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new VersionExpression(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new VersionExpression(item));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/VersionExpressionSets.ts
+++ b/src/slang-nodes/VersionExpressionSets.ts
@@ -17,13 +17,10 @@ export class VersionExpressionSets implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.VersionExpressionSets, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionExpressionSets) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new VersionExpressionSet(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new VersionExpressionSet(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -15,14 +15,13 @@ export class VersionLiteral implements SlangNode {
 
   variant: SimpleVersionLiteral | string;
 
-  constructor(ast: ast.VersionLiteral, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionLiteral) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new SimpleVersionLiteral(ast.variant, offsets[0]);
+        : new SimpleVersionLiteral(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/VersionOperator.ts
+++ b/src/slang-nodes/VersionOperator.ts
@@ -14,8 +14,8 @@ export class VersionOperator implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.VersionOperator, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.VersionOperator) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/VersionPragma.ts
+++ b/src/slang-nodes/VersionPragma.ts
@@ -15,11 +15,10 @@ export class VersionPragma implements SlangNode {
 
   sets: VersionExpressionSets;
 
-  constructor(ast: ast.VersionPragma, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionPragma) {
+    let metadata = getNodeMetadata(ast);
 
-    this.sets = new VersionExpressionSets(ast.sets, offsets[0]);
+    this.sets = new VersionExpressionSets(ast.sets);
 
     metadata = updateMetadata(metadata, [this.sets]);
 

--- a/src/slang-nodes/VersionRange.ts
+++ b/src/slang-nodes/VersionRange.ts
@@ -17,12 +17,11 @@ export class VersionRange implements SlangNode {
 
   end: VersionLiteral;
 
-  constructor(ast: ast.VersionRange, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionRange) {
+    let metadata = getNodeMetadata(ast);
 
-    this.start = new VersionLiteral(ast.start, offsets[0]);
-    this.end = new VersionLiteral(ast.end, offsets[1]);
+    this.start = new VersionLiteral(ast.start);
+    this.end = new VersionLiteral(ast.end);
 
     metadata = updateMetadata(metadata, [this.start, this.end]);
 

--- a/src/slang-nodes/VersionTerm.ts
+++ b/src/slang-nodes/VersionTerm.ts
@@ -18,16 +18,13 @@ export class VersionTerm implements SlangNode {
 
   literal: VersionLiteral;
 
-  constructor(ast: ast.VersionTerm, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.VersionTerm) {
+    let metadata = getNodeMetadata(ast);
 
-    let i = 0;
     if (ast.operator) {
-      this.operator = new VersionOperator(ast.operator, offsets[i]);
-      i += 1;
+      this.operator = new VersionOperator(ast.operator);
     }
-    this.literal = new VersionLiteral(ast.literal, offsets[i]);
+    this.literal = new VersionLiteral(ast.literal);
 
     metadata = updateMetadata(metadata, [this.operator, this.literal]);
 

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -23,16 +23,11 @@ export class WhileStatement implements SlangNode {
 
   body: Statement;
 
-  constructor(
-    ast: ast.WhileStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.WhileStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.condition = new Expression(ast.condition, offsets[0], options);
-    this.body = new Statement(ast.body, offsets[1], options);
+    this.condition = new Expression(ast.condition, options);
+    this.body = new Statement(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.condition, this.body]);
 

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -19,17 +19,10 @@ export class YulArguments implements SlangNode {
 
   separators: string[];
 
-  constructor(
-    ast: ast.YulArguments,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulArguments, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulExpression(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new YulExpression(item, options));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -15,14 +15,13 @@ export class YulAssignmentOperator implements SlangNode {
 
   variant: YulColonAndEqual | string;
 
-  constructor(ast: ast.YulAssignmentOperator, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulAssignmentOperator) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new YulColonAndEqual(ast.variant, offsets[0]);
+        : new YulColonAndEqual(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/YulBlock.ts
+++ b/src/slang-nodes/YulBlock.ts
@@ -16,15 +16,10 @@ export class YulBlock implements SlangNode {
 
   statements: YulStatements;
 
-  constructor(
-    ast: ast.YulBlock,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulBlock, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.statements = new YulStatements(ast.statements, offsets[0], options);
+    this.statements = new YulStatements(ast.statements, options);
 
     metadata = updateMetadata(metadata, [this.statements]);
 

--- a/src/slang-nodes/YulBreakStatement.ts
+++ b/src/slang-nodes/YulBreakStatement.ts
@@ -12,8 +12,8 @@ export class YulBreakStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.YulBreakStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulBreakStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulBuiltInFunction.ts
+++ b/src/slang-nodes/YulBuiltInFunction.ts
@@ -14,8 +14,8 @@ export class YulBuiltInFunction implements SlangNode {
 
   variant: string;
 
-  constructor(ast: ast.YulBuiltInFunction, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulBuiltInFunction) {
+    const metadata = getNodeMetadata(ast);
 
     this.variant = ast.variant.unparse();
 

--- a/src/slang-nodes/YulColonAndEqual.ts
+++ b/src/slang-nodes/YulColonAndEqual.ts
@@ -12,8 +12,8 @@ export class YulColonAndEqual implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.YulColonAndEqual, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulColonAndEqual) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulContinueStatement.ts
+++ b/src/slang-nodes/YulContinueStatement.ts
@@ -12,8 +12,8 @@ export class YulContinueStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.YulContinueStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulContinueStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulDefaultCase.ts
+++ b/src/slang-nodes/YulDefaultCase.ts
@@ -16,15 +16,10 @@ export class YulDefaultCase implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulDefaultCase,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulDefaultCase, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.body = new YulBlock(ast.body, offsets[0], options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.body]);
 

--- a/src/slang-nodes/YulEqualAndColon.ts
+++ b/src/slang-nodes/YulEqualAndColon.ts
@@ -12,8 +12,8 @@ export class YulEqualAndColon implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.YulEqualAndColon, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulEqualAndColon) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -23,37 +23,26 @@ export class YulExpression implements SlangNode {
     | YulBuiltInFunction
     | YulPath;
 
-  constructor(
-    ast: ast.YulExpression,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulExpression, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.YulFunctionCallExpression:
         this.variant = new YulFunctionCallExpression(
           ast.variant as ast.YulFunctionCallExpression,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulLiteral:
-        this.variant = new YulLiteral(
-          ast.variant as ast.YulLiteral,
-          offsets[0],
-          options
-        );
+        this.variant = new YulLiteral(ast.variant as ast.YulLiteral, options);
         break;
       case NonterminalKind.YulBuiltInFunction:
         this.variant = new YulBuiltInFunction(
-          ast.variant as ast.YulBuiltInFunction,
-          offsets[0]
+          ast.variant as ast.YulBuiltInFunction
         );
         break;
       case NonterminalKind.YulPath:
-        this.variant = new YulPath(ast.variant as ast.YulPath, offsets[0]);
+        this.variant = new YulPath(ast.variant as ast.YulPath);
         break;
       default:
         throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -26,18 +26,13 @@ export class YulForStatement implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulForStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulForStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.initialization = new YulBlock(ast.initialization, offsets[0], options);
-    this.condition = new YulExpression(ast.condition, offsets[1], options);
-    this.iterator = new YulBlock(ast.iterator, offsets[2], options);
-    this.body = new YulBlock(ast.body, offsets[3], options);
+    this.initialization = new YulBlock(ast.initialization, options);
+    this.condition = new YulExpression(ast.condition, options);
+    this.iterator = new YulBlock(ast.iterator, options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.initialization,

--- a/src/slang-nodes/YulFunctionCallExpression.ts
+++ b/src/slang-nodes/YulFunctionCallExpression.ts
@@ -21,14 +21,12 @@ export class YulFunctionCallExpression implements SlangNode {
 
   constructor(
     ast: ast.YulFunctionCallExpression,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.operand = new YulExpression(ast.operand, offsets[0], options);
-    this.arguments = new YulArguments(ast.arguments, offsets[1], options);
+    this.operand = new YulExpression(ast.operand, options);
+    this.arguments = new YulArguments(ast.arguments, options);
 
     metadata = updateMetadata(metadata, [this.operand, this.arguments]);
 

--- a/src/slang-nodes/YulFunctionDefinition.ts
+++ b/src/slang-nodes/YulFunctionDefinition.ts
@@ -25,22 +25,15 @@ export class YulFunctionDefinition implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulFunctionDefinition,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulFunctionDefinition, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.name = new YulIdentifier(ast.name, offsets[0]);
-    this.parameters = new YulParametersDeclaration(ast.parameters, offsets[1]);
-    let i = 2;
+    this.name = new YulIdentifier(ast.name);
+    this.parameters = new YulParametersDeclaration(ast.parameters);
     if (ast.returns) {
-      this.returns = new YulReturnsDeclaration(ast.returns, offsets[i]);
-      i += 1;
+      this.returns = new YulReturnsDeclaration(ast.returns);
     }
-    this.body = new YulBlock(ast.body, offsets[i], options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [
       this.parameters,

--- a/src/slang-nodes/YulIdentifier.ts
+++ b/src/slang-nodes/YulIdentifier.ts
@@ -1,4 +1,5 @@
 import { TerminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { getNodeMetadata } from '../slang-utils/metadata.js';
 
 import type { Doc } from 'prettier';
 import type { Location, SlangNode } from '../types.d.ts';
@@ -13,14 +14,13 @@ export class YulIdentifier implements SlangNode {
 
   value: string;
 
-  constructor(ast: TerminalNode, offset: number) {
+  constructor(ast: TerminalNode) {
+    const metadata = getNodeMetadata(ast);
+
     this.value = ast.unparse();
 
-    this.comments = [];
-    this.loc = {
-      start: offset,
-      end: offset + ast.textLength.utf16
-    };
+    this.comments = metadata.comments;
+    this.loc = metadata.loc;
   }
 
   print(): Doc {

--- a/src/slang-nodes/YulIfStatement.ts
+++ b/src/slang-nodes/YulIfStatement.ts
@@ -19,16 +19,11 @@ export class YulIfStatement implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulIfStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulIfStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.condition = new YulExpression(ast.condition, offsets[0], options);
-    this.body = new YulBlock(ast.body, offsets[1], options);
+    this.condition = new YulExpression(ast.condition, options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.condition, this.body]);
 

--- a/src/slang-nodes/YulLabel.ts
+++ b/src/slang-nodes/YulLabel.ts
@@ -18,11 +18,10 @@ export class YulLabel implements SlangNode {
 
   label: YulIdentifier;
 
-  constructor(ast: ast.YulLabel, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulLabel) {
+    const metadata = getNodeMetadata(ast);
 
-    this.label = new YulIdentifier(ast.label, offsets[0]);
+    this.label = new YulIdentifier(ast.label);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulLeaveStatement.ts
+++ b/src/slang-nodes/YulLeaveStatement.ts
@@ -12,8 +12,8 @@ export class YulLeaveStatement implements SlangNode {
 
   loc;
 
-  constructor(ast: ast.YulLeaveStatement, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
+  constructor(ast: ast.YulLeaveStatement) {
+    const metadata = getNodeMetadata(ast);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -17,13 +17,8 @@ export class YulLiteral implements SlangNode {
 
   variant: HexStringLiteral | StringLiteral | string;
 
-  constructor(
-    ast: ast.YulLiteral,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulLiteral, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
@@ -32,14 +27,12 @@ export class YulLiteral implements SlangNode {
         case NonterminalKind.HexStringLiteral:
           this.variant = new HexStringLiteral(
             ast.variant as ast.HexStringLiteral,
-            offsets[0],
             options
           );
           break;
         case NonterminalKind.StringLiteral:
           this.variant = new StringLiteral(
             ast.variant as ast.StringLiteral,
-            offsets[0],
             options
           );
           break;

--- a/src/slang-nodes/YulParameters.ts
+++ b/src/slang-nodes/YulParameters.ts
@@ -18,13 +18,10 @@ export class YulParameters implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.YulParameters, offset: number) {
-    const metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulParameters) {
+    const metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulIdentifier(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new YulIdentifier(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;

--- a/src/slang-nodes/YulParametersDeclaration.ts
+++ b/src/slang-nodes/YulParametersDeclaration.ts
@@ -15,11 +15,10 @@ export class YulParametersDeclaration implements SlangNode {
 
   parameters: YulParameters;
 
-  constructor(ast: ast.YulParametersDeclaration, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulParametersDeclaration) {
+    let metadata = getNodeMetadata(ast);
 
-    this.parameters = new YulParameters(ast.parameters, offsets[0]);
+    this.parameters = new YulParameters(ast.parameters);
 
     metadata = updateMetadata(metadata, [this.parameters]);
 

--- a/src/slang-nodes/YulPath.ts
+++ b/src/slang-nodes/YulPath.ts
@@ -17,13 +17,10 @@ export class YulPath implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.YulPath, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulPath) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulPathComponent(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new YulPathComponent(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/YulPathComponent.ts
+++ b/src/slang-nodes/YulPathComponent.ts
@@ -15,11 +15,10 @@ export class YulPathComponent implements SlangNode {
 
   variant: YulIdentifier;
 
-  constructor(ast: ast.YulPathComponent, offset: number) {
-    const metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulPathComponent) {
+    const metadata = getNodeMetadata(ast);
 
-    this.variant = new YulIdentifier(ast.variant, offsets[0]);
+    this.variant = new YulIdentifier(ast.variant);
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulPaths.ts
+++ b/src/slang-nodes/YulPaths.ts
@@ -17,13 +17,10 @@ export class YulPaths implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.YulPaths, offset: number) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulPaths) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulPath(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new YulPath(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);

--- a/src/slang-nodes/YulReturnsDeclaration.ts
+++ b/src/slang-nodes/YulReturnsDeclaration.ts
@@ -19,11 +19,10 @@ export class YulReturnsDeclaration implements SlangNode {
 
   variables: YulVariableNames;
 
-  constructor(ast: ast.YulReturnsDeclaration, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulReturnsDeclaration) {
+    let metadata = getNodeMetadata(ast);
 
-    this.variables = new YulVariableNames(ast.variables, offsets[0]);
+    this.variables = new YulVariableNames(ast.variables);
 
     metadata = updateMetadata(metadata, [this.variables]);
 

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -15,14 +15,13 @@ export class YulStackAssignmentOperator implements SlangNode {
 
   variant: YulEqualAndColon | string;
 
-  constructor(ast: ast.YulStackAssignmentOperator, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulStackAssignmentOperator) {
+    let metadata = getNodeMetadata(ast);
 
     this.variant =
       ast.variant instanceof TerminalNode
         ? ast.variant.unparse()
-        : new YulEqualAndColon(ast.variant, offsets[0]);
+        : new YulEqualAndColon(ast.variant);
 
     metadata = updateMetadata(
       metadata,

--- a/src/slang-nodes/YulStackAssignmentStatement.ts
+++ b/src/slang-nodes/YulStackAssignmentStatement.ts
@@ -22,15 +22,11 @@ export class YulStackAssignmentStatement implements SlangNode {
 
   variable: YulIdentifier;
 
-  constructor(ast: ast.YulStackAssignmentStatement, offset: number) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulStackAssignmentStatement) {
+    let metadata = getNodeMetadata(ast);
 
-    this.assignment = new YulStackAssignmentOperator(
-      ast.assignment,
-      offsets[0]
-    );
-    this.variable = new YulIdentifier(ast.variable, offsets[1]);
+    this.assignment = new YulStackAssignmentOperator(ast.assignment);
+    this.variable = new YulIdentifier(ast.variable);
 
     metadata = updateMetadata(metadata, [this.assignment]);
 

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -41,95 +41,75 @@ export class YulStatement implements SlangNode {
     | YulLabel
     | YulExpression;
 
-  constructor(
-    ast: ast.YulStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.YulBlock:
-        this.variant = new YulBlock(
-          ast.variant as ast.YulBlock,
-          offsets[0],
-          options
-        );
+        this.variant = new YulBlock(ast.variant as ast.YulBlock, options);
         break;
       case NonterminalKind.YulFunctionDefinition:
         this.variant = new YulFunctionDefinition(
           ast.variant as ast.YulFunctionDefinition,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulVariableDeclarationStatement:
         this.variant = new YulVariableDeclarationStatement(
           ast.variant as ast.YulVariableDeclarationStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulVariableAssignmentStatement:
         this.variant = new YulVariableAssignmentStatement(
           ast.variant as ast.YulVariableAssignmentStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulStackAssignmentStatement:
         this.variant = new YulStackAssignmentStatement(
-          ast.variant as ast.YulStackAssignmentStatement,
-          offsets[0]
+          ast.variant as ast.YulStackAssignmentStatement
         );
         break;
       case NonterminalKind.YulIfStatement:
         this.variant = new YulIfStatement(
           ast.variant as ast.YulIfStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulForStatement:
         this.variant = new YulForStatement(
           ast.variant as ast.YulForStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulSwitchStatement:
         this.variant = new YulSwitchStatement(
           ast.variant as ast.YulSwitchStatement,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulLeaveStatement:
         this.variant = new YulLeaveStatement(
-          ast.variant as ast.YulLeaveStatement,
-          offsets[0]
+          ast.variant as ast.YulLeaveStatement
         );
         break;
       case NonterminalKind.YulBreakStatement:
         this.variant = new YulBreakStatement(
-          ast.variant as ast.YulBreakStatement,
-          offsets[0]
+          ast.variant as ast.YulBreakStatement
         );
         break;
       case NonterminalKind.YulContinueStatement:
         this.variant = new YulContinueStatement(
-          ast.variant as ast.YulContinueStatement,
-          offsets[0]
+          ast.variant as ast.YulContinueStatement
         );
         break;
       case NonterminalKind.YulLabel:
-        this.variant = new YulLabel(ast.variant as ast.YulLabel, offsets[0]);
+        this.variant = new YulLabel(ast.variant as ast.YulLabel);
         break;
       case NonterminalKind.YulExpression:
         this.variant = new YulExpression(
           ast.variant as ast.YulExpression,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -22,17 +22,10 @@ export class YulStatements implements SlangNode {
 
   items: YulStatement[];
 
-  constructor(
-    ast: ast.YulStatements,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulStatements, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulStatement(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new YulStatement(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -17,26 +17,19 @@ export class YulSwitchCase implements SlangNode {
 
   variant: YulDefaultCase | YulValueCase;
 
-  constructor(
-    ast: ast.YulSwitchCase,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulSwitchCase, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
     switch (ast.variant.cst.kind) {
       case NonterminalKind.YulDefaultCase:
         this.variant = new YulDefaultCase(
           ast.variant as ast.YulDefaultCase,
-          offsets[0],
           options
         );
         break;
       case NonterminalKind.YulValueCase:
         this.variant = new YulValueCase(
           ast.variant as ast.YulValueCase,
-          offsets[0],
           options
         );
         break;

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -19,17 +19,10 @@ export class YulSwitchCases implements SlangNode {
 
   items: YulSwitchCase[];
 
-  constructor(
-    ast: ast.YulSwitchCases,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulSwitchCases, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulSwitchCase(item, offsets[index], options)
-    );
+    this.items = ast.items.map((item) => new YulSwitchCase(item, options));
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -22,16 +22,11 @@ export class YulSwitchStatement implements SlangNode {
 
   cases: YulSwitchCases;
 
-  constructor(
-    ast: ast.YulSwitchStatement,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulSwitchStatement, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.expression = new YulExpression(ast.expression, offsets[0], options);
-    this.cases = new YulSwitchCases(ast.cases, offsets[1], options);
+    this.expression = new YulExpression(ast.expression, options);
+    this.cases = new YulSwitchCases(ast.cases, options);
 
     metadata = updateMetadata(metadata, [this.expression, this.cases]);
 

--- a/src/slang-nodes/YulValueCase.ts
+++ b/src/slang-nodes/YulValueCase.ts
@@ -19,16 +19,11 @@ export class YulValueCase implements SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulValueCase,
-    offset: number,
-    options: ParserOptions<AstNode>
-  ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulValueCase, options: ParserOptions<AstNode>) {
+    let metadata = getNodeMetadata(ast);
 
-    this.value = new YulLiteral(ast.value, offsets[0], options);
-    this.body = new YulBlock(ast.body, offsets[1], options);
+    this.value = new YulLiteral(ast.value, options);
+    this.body = new YulBlock(ast.body, options);
 
     metadata = updateMetadata(metadata, [this.value, this.body]);
 

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -27,15 +27,13 @@ export class YulVariableAssignmentStatement implements SlangNode {
 
   constructor(
     ast: ast.YulVariableAssignmentStatement,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.variables = new YulPaths(ast.variables, offsets[0]);
-    this.assignment = new YulAssignmentOperator(ast.assignment, offsets[1]);
-    this.expression = new YulExpression(ast.expression, offsets[2], options);
+    this.variables = new YulPaths(ast.variables);
+    this.assignment = new YulAssignmentOperator(ast.assignment);
+    this.expression = new YulExpression(ast.expression, options);
 
     metadata = updateMetadata(metadata, [
       this.variables,

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -22,19 +22,13 @@ export class YulVariableDeclarationStatement implements SlangNode {
 
   constructor(
     ast: ast.YulVariableDeclarationStatement,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.variables = new YulVariableNames(ast.variables, offsets[0]);
+    this.variables = new YulVariableNames(ast.variables);
     if (ast.value) {
-      this.value = new YulVariableDeclarationValue(
-        ast.value,
-        offsets[1],
-        options
-      );
+      this.value = new YulVariableDeclarationValue(ast.value, options);
     }
 
     metadata = updateMetadata(metadata, [this.value]);

--- a/src/slang-nodes/YulVariableDeclarationValue.ts
+++ b/src/slang-nodes/YulVariableDeclarationValue.ts
@@ -21,14 +21,12 @@ export class YulVariableDeclarationValue implements SlangNode {
 
   constructor(
     ast: ast.YulVariableDeclarationValue,
-    offset: number,
     options: ParserOptions<AstNode>
   ) {
-    let metadata = getNodeMetadata(ast, offset);
-    const { offsets } = metadata;
+    let metadata = getNodeMetadata(ast);
 
-    this.assignment = new YulAssignmentOperator(ast.assignment, offsets[0]);
-    this.expression = new YulExpression(ast.expression, offsets[1], options);
+    this.assignment = new YulAssignmentOperator(ast.assignment);
+    this.expression = new YulExpression(ast.expression, options);
 
     metadata = updateMetadata(metadata, [this.assignment, this.expression]);
 

--- a/src/slang-nodes/YulVariableNames.ts
+++ b/src/slang-nodes/YulVariableNames.ts
@@ -21,13 +21,10 @@ export class YulVariableNames implements SlangNode {
 
   separators: string[];
 
-  constructor(ast: ast.YulVariableNames, offset: number) {
-    const metadata = getNodeMetadata(ast, offset, true);
-    const { offsets } = metadata;
+  constructor(ast: ast.YulVariableNames) {
+    const metadata = getNodeMetadata(ast, true);
 
-    this.items = ast.items.map(
-      (item, index) => new YulIdentifier(item, offsets[index])
-    );
+    this.items = ast.items.map((item) => new YulIdentifier(item));
     this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;

--- a/src/slangSolidityParser.ts
+++ b/src/slangSolidityParser.ts
@@ -3,6 +3,7 @@ import { Parser } from '@nomicfoundation/slang/parser';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SourceUnit as SlangSourceUnit } from '@nomicfoundation/slang/ast';
 import { maxSatisfying } from 'semver';
+import { clearOffsets } from './slang-utils/metadata.js';
 import { createParser } from './slang-utils/create-parser.js';
 import { printWarning } from './slang-utils/print-warning.js';
 import { SourceUnit } from './slang-nodes/SourceUnit.js';
@@ -33,11 +34,12 @@ export default function parse(
   if (parseOutput.isValid()) {
     // We update the compiler version by the inferred one.
     options.compiler = parser.version;
-    return new SourceUnit(
+    const parsed = new SourceUnit(
       new SlangSourceUnit(parseOutput.tree.asNonterminalNode()!),
-      0,
       options
     );
+    clearOffsets();
+    return parsed;
   }
   throw new Error(parseOutput.errors[0].message);
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,7 +36,6 @@ interface BaseComment {
 interface Metadata {
   comments: Comment[];
   loc: AstLocation;
-  offsets: number[];
 }
 
 interface SlangNode {


### PR DESCRIPTION
the initial approach that moved offsets between parent and child has been replaced by an approach that stores and consumes the offset based in the CST id.

This id has been available since slang 0.18.2.

the main file to review here is `slang-utils/metadata.ts` since everything else is just the removal of the passing along of the offsets.