### PR TITLE
we can import `fs/promises` since it's only used in a node environment.

### DIFF
--- a/test.config.js
+++ b/test.config.js
@@ -11,7 +11,7 @@ export default {
   optimization: { minimize: false },
   target: ['browserslist'],
 
-  externals: { 'fs/promises': 'fs/promises' },
+  externals: { 'fs/promises': 'import fs/promises' },
 
   experiments: {
     asyncWebAssembly: true,

--- a/tests/config/get-plugins.js
+++ b/tests/config/get-plugins.js
@@ -15,7 +15,6 @@ if (process.env.TEST_STANDALONE) {
           ? self
           : this || {};
   root.prettier = await getPrettier();
-  root["fs/promises"] = await import("fs/promises");
 }
 
 function getPluginsInternal() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,10 +20,9 @@ export default (webpackEnv) => {
     entry: './src/index.js',
 
     // Avoid bundling Prettier
-    externalsType: 'global',
     externals: {
-      prettier: 'prettier',
-      'fs/promises': 'fs/promises'
+      prettier: 'global prettier',
+      'fs/promises': 'import fs/promises'
     },
 
     plugins: [


### PR DESCRIPTION
With this, we don't need custom code for `node` environment and the browser never uses this module