### PR TITLE
Rename parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A [Prettier plugin](https://prettier.io/docs/en/plugins.html) for automatically 
 
 Nomic Foundation has put a lot of effort in providing a set of compiler APIs that helped us rethink our approach to parsing and rely on their flexibility, detail oriented solution and continuos support of new and old Solidity syntaxes.
 
-Since v2.0.0 this package will ship with the Slang parser and this change must be implemented in existing configurations by replacing `parser: 'solidity-parse'` with `parser: 'slang-solidity'`.
+Since v2.0.0 this package will ship with the Slang parser and this change must be implemented in existing configurations by replacing `parser: 'antlr'` with `parser: 'slang'`.
 
-The `antlr4` parser (`solidity-parse`) is still supported for the time being and will trigger a deprecation warning, since Slang gives us a much more powerful tool, is faster, allowed us to fully transition into typescript (minimizing the introduction of mismatching type bugs), and allows prettier to format the code in a much more decoupled way and position comments with a greater precision.
+The `antlr4` parser (`antlr`) is still supported for the time being and will trigger a deprecation warning, since Slang gives us a much more powerful tool, is faster, allowed us to fully transition into typescript (minimizing the introduction of mismatching type bugs), and allows prettier to format the code in a much more decoupled way and position comments with a greater precision.
 
 ## Installation and usage
 
@@ -73,7 +73,7 @@ We follow Prettier's strategy for populating their plugins in the object `pretti
 
   async function format(code) {
     return await prettier.format(code, {
-      parser: 'slang-solidity',
+      parser: 'slang',
       plugins: [solidityPlugin]
     });
   }
@@ -97,7 +97,7 @@ import solidityPlugin from 'prettier-plugin-solidity/standalone';
 
 async function format(code) {
   return await prettier.format(code, {
-    parser: "slang-solidity",
+    parser: "slang",
     plugins: [solidityPlugin],
   });
 }
@@ -118,7 +118,7 @@ The following is the default configuration internally used by this plugin.
     {
       "files": "*.sol",
       "options": {
-        "parser": "slang-solidity",
+        "parser": "slang",
         "printWidth": 80,
         "tabWidth": 4,
         "useTabs": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,10 @@ import type {
 } from 'prettier';
 import type { AstNode } from './slang-nodes/types.d.ts';
 
-const slangParserId = 'slang-solidity';
-const antlrParserId = 'solidity-parse';
+const slangParserId = 'slang';
+const antlrParserId = 'antlr';
 const slangAstId = 'slang-ast';
-const antlrAstId = 'solidity-ast';
+const antlrAstId = 'antlr-ast';
 
 // https://prettier.io/docs/en/plugins.html#languages
 // https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml

--- a/src/printer.js
+++ b/src/printer.js
@@ -18,7 +18,7 @@ function once(factory) {
 
 const warnDeprecation = once(() => {
   printWarning(
-    `'solidity-parse' has been deprecated, please use 'slang-solidity'.`
+    `The 'antlr' parser has been deprecated, please use 'slang' instead.`
   );
   return true;
 });

--- a/tests/config/run-format-test.js
+++ b/tests/config/run-format-test.js
@@ -322,7 +322,7 @@ async function runTest({
   }
 
   if (
-    formatOptions.parser === "slang-solidity" &&
+    formatOptions.parser === "slang" &&
     !isAntlrMismatch(filename, formatOptions)
   ) {
     // Compare with ANTLR's format
@@ -335,7 +335,7 @@ async function runTest({
       compiler:
         formatOptions.compiler ||
         createParser(code, formatOptions)[0].languageVersion,
-      parser: "solidity-parse",
+      parser: "antlr",
       plugins: await getPlugins(),
     });
     expect(antlrOutput).toEqual(formatResult.output);

--- a/tests/format/AddressPayable/__snapshots__/format.test.js.snap
+++ b/tests/format/AddressPayable/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AddressPayable.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/AddressPayable/format.test.js
+++ b/tests/format/AddressPayable/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/AllSolidityFeatures/__snapshots__/format.test.js.snap
+++ b/tests/format/AllSolidityFeatures/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AllSolidityFeatures.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/AllSolidityFeatures/format.test.js
+++ b/tests/format/AllSolidityFeatures/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/AllSolidityFeaturesV0.4.26/__snapshots__/format.test.js.snap
+++ b/tests/format/AllSolidityFeaturesV0.4.26/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AllSolidityFeatures.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/AllSolidityFeaturesV0.4.26/format.test.js
+++ b/tests/format/AllSolidityFeaturesV0.4.26/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Arrays/__snapshots__/format.test.js.snap
+++ b/tests/format/Arrays/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Arrays.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Arrays/format.test.js
+++ b/tests/format/Arrays/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Assembly/__snapshots__/format.test.js.snap
+++ b/tests/format/Assembly/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Assembly.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Assembly/format.test.js
+++ b/tests/format/Assembly/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/AssemblyV0.4.26/__snapshots__/format.test.js.snap
+++ b/tests/format/AssemblyV0.4.26/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Assembly.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/AssemblyV0.4.26/format.test.js
+++ b/tests/format/AssemblyV0.4.26/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/BasicIterator/__snapshots__/format.test.js.snap
+++ b/tests/format/BasicIterator/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BasicIterator.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/BasicIterator/format.test.js
+++ b/tests/format/BasicIterator/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/BinaryOperationHierarchy/__snapshots__/format.test.js.snap
+++ b/tests/format/BinaryOperationHierarchy/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Group.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1317,7 +1317,7 @@ contract Group {
 
 exports[`Indent.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/BinaryOperationHierarchy/format.test.js
+++ b/tests/format/BinaryOperationHierarchy/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/BinaryOperators/__snapshots__/format.test.js.snap
+++ b/tests/format/BinaryOperators/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BinaryOperators.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -687,7 +687,7 @@ contract LogicalOperators {
 
 exports[`Parentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/BinaryOperators/format.test.js
+++ b/tests/format/BinaryOperators/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/BreakingChangesV0.7.4/__snapshots__/format.test.js.snap
+++ b/tests/format/BreakingChangesV0.7.4/__snapshots__/format.test.js.snap
@@ -4,7 +4,7 @@ exports[`BreakingChangesV0.7.4.sol - {"compiler":"0.7.3","bracketSpacing":true} 
 ====================================options=====================================
 bracketSpacing: true
 compiler: "0.7.3"
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -35,7 +35,7 @@ import { symbol1 as alias1, symbol2 as alias2, symbol3 as alias3, symbol4 } from
 exports[`BreakingChangesV0.7.4.sol - {"compiler":"0.7.3"} format 1`] = `
 ====================================options=====================================
 compiler: "0.7.3"
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -67,7 +67,7 @@ exports[`BreakingChangesV0.7.4.sol - {"compiler":"0.7.4","bracketSpacing":true} 
 ====================================options=====================================
 bracketSpacing: true
 compiler: "0.7.4"
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -103,7 +103,7 @@ import {
 exports[`BreakingChangesV0.7.4.sol - {"compiler":"0.7.4"} format 1`] = `
 ====================================options=====================================
 compiler: "0.7.4"
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/BreakingChangesV0.7.4/format.test.js
+++ b/tests/format/BreakingChangesV0.7.4/format.test.js
@@ -1,10 +1,10 @@
-runFormatTest(import.meta, ['slang-solidity'], { compiler: '0.7.4' });
-runFormatTest(import.meta, ['slang-solidity'], {
+runFormatTest(import.meta, ['slang'], { compiler: '0.7.4' });
+runFormatTest(import.meta, ['slang'], {
   compiler: '0.7.4',
   bracketSpacing: true
 });
-runFormatTest(import.meta, ['slang-solidity'], { compiler: '0.7.3' });
-runFormatTest(import.meta, ['slang-solidity'], {
+runFormatTest(import.meta, ['slang'], { compiler: '0.7.3' });
+runFormatTest(import.meta, ['slang'], {
   compiler: '0.7.3',
   bracketSpacing: true
 });

--- a/tests/format/BreakingChangesV0.8.0/__snapshots__/format.test.js.snap
+++ b/tests/format/BreakingChangesV0.8.0/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`BreakingChangesV0.8.0.sol - {"compiler":"0.7.0"} format 1`] = `
 ====================================options=====================================
 compiler: "0.7.0"
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -91,7 +91,7 @@ contract BreakingChangesV080 {
 exports[`BreakingChangesV0.8.0.sol - {"compiler":"0.8.0"} format 1`] = `
 ====================================options=====================================
 compiler: "0.8.0"
-parsers: ["solidity-parse"]
+parsers: ["antlr"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -178,7 +178,7 @@ contract BreakingChangesV080 {
 
 exports[`BreakingChangesV0.8.0.sol format 1`] = `
 ====================================options=====================================
-parsers: ["solidity-parse"]
+parsers: ["antlr"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/BreakingChangesV0.8.0/format.test.js
+++ b/tests/format/BreakingChangesV0.8.0/format.test.js
@@ -1,3 +1,3 @@
-runFormatTest(import.meta, ['solidity-parse']);
-runFormatTest(import.meta, ['solidity-parse'], { compiler: '0.8.0' });
-runFormatTest(import.meta, ['slang-solidity'], { compiler: '0.7.0' });
+runFormatTest(import.meta, ['antlr']);
+runFormatTest(import.meta, ['antlr'], { compiler: '0.8.0' });
+runFormatTest(import.meta, ['slang'], { compiler: '0.7.0' });

--- a/tests/format/Comments/__snapshots__/format.test.js.snap
+++ b/tests/format/Comments/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Comments.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Comments/format.test.js
+++ b/tests/format/Comments/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Conditional/__snapshots__/format.test.js.snap
+++ b/tests/format/Conditional/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Conditional.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Conditional/format.test.js
+++ b/tests/format/Conditional/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Constructors/__snapshots__/format.test.js.snap
+++ b/tests/format/Constructors/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Constructors.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Constructors/format.test.js
+++ b/tests/format/Constructors/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ConstructorsV0.4.26/__snapshots__/format.test.js.snap
+++ b/tests/format/ConstructorsV0.4.26/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Constructors.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ConstructorsV0.4.26/format.test.js
+++ b/tests/format/ConstructorsV0.4.26/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContractDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ContractDefinitions/format.test.js
+++ b/tests/format/ContractDefinitions/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/CustomErrors/__snapshots__/format.test.js.snap
+++ b/tests/format/CustomErrors/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CustomErrors.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/CustomErrors/format.test.js
+++ b/tests/format/CustomErrors/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/EnumDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/EnumDefinitions/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`EnumDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/EnumDefinitions/format.test.js
+++ b/tests/format/EnumDefinitions/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Etc/__snapshots__/format.test.js.snap
+++ b/tests/format/Etc/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Etc.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Etc/format.test.js
+++ b/tests/format/Etc/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ExperimentalTernaries/__snapshots__/format.test.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true,"tabWidth":1} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 tabWidth: 1
                                                                                 | printWidth
@@ -513,7 +513,7 @@ contract Conditional {
 exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true,"useTabs":true} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 useTabs: true
                                                                                 | printWidth
@@ -1027,7 +1027,7 @@ contract Conditional {
 exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1539,7 +1539,7 @@ contract Conditional {
 
 exports[`ExperimentalTernaries.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ExperimentalTernaries/format.test.js
+++ b/tests/format/ExperimentalTernaries/format.test.js
@@ -1,10 +1,10 @@
-runFormatTest(import.meta, ['slang-solidity']);
-runFormatTest(import.meta, ['slang-solidity'], { experimentalTernaries: true });
-runFormatTest(import.meta, ['slang-solidity'], {
+runFormatTest(import.meta, ['slang']);
+runFormatTest(import.meta, ['slang'], { experimentalTernaries: true });
+runFormatTest(import.meta, ['slang'], {
   experimentalTernaries: true,
   tabWidth: 1
 });
-runFormatTest(import.meta, ['slang-solidity'], {
+runFormatTest(import.meta, ['slang'], {
   experimentalTernaries: true,
   useTabs: true
 });

--- a/tests/format/ForStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/ForStatements/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ForStatements.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ForStatements/format.test.js
+++ b/tests/format/ForStatements/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/FunctionCalls/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionCalls/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`FunctionCalls.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================
 bracketSpacing: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -155,7 +155,7 @@ contract FunctionCalls {
 
 exports[`FunctionCalls.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/FunctionCalls/format.test.js
+++ b/tests/format/FunctionCalls/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity']);
-runFormatTest(import.meta, ['slang-solidity'], { bracketSpacing: true });
+runFormatTest(import.meta, ['slang']);
+runFormatTest(import.meta, ['slang'], { bracketSpacing: true });

--- a/tests/format/FunctionDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionDefinitions/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FunctionDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/FunctionDefinitions/format.test.js
+++ b/tests/format/FunctionDefinitions/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/FunctionDefinitionsV0.5.0/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionDefinitionsV0.5.0/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FunctionDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/FunctionDefinitionsV0.5.0/format.test.js
+++ b/tests/format/FunctionDefinitionsV0.5.0/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/FunctionDefinitionsv0.5.0/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionDefinitionsv0.5.0/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FunctionDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/FunctionDefinitionsv0.5.0/format.test.js
+++ b/tests/format/FunctionDefinitionsv0.5.0/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/HexLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/HexLiteral/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`HexLiteral.sol - {"singleQuote":false} format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 singleQuote: false
                                                                                 | printWidth
@@ -29,7 +29,7 @@ contract HexLiteral {
 
 exports[`HexLiteral.sol - {"singleQuote":true} format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 singleQuote: true
                                                                                 | printWidth

--- a/tests/format/HexLiteral/format.test.js
+++ b/tests/format/HexLiteral/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity'], { singleQuote: true });
-runFormatTest(import.meta, ['slang-solidity'], { singleQuote: false });
+runFormatTest(import.meta, ['slang'], { singleQuote: true });
+runFormatTest(import.meta, ['slang'], { singleQuote: false });

--- a/tests/format/IfStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/IfStatements/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`IfStatements.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/IfStatements/format.test.js
+++ b/tests/format/IfStatements/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Immutable/__snapshots__/format.test.js.snap
+++ b/tests/format/Immutable/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Immutable.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Immutable/format.test.js
+++ b/tests/format/Immutable/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ImportDirective/__snapshots__/format.test.js.snap
+++ b/tests/format/ImportDirective/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ImportDirectives.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================
 bracketSpacing: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -30,7 +30,7 @@ import {
 
 exports[`ImportDirectives.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ImportDirective/format.test.js
+++ b/tests/format/ImportDirective/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity']);
-runFormatTest(import.meta, ['slang-solidity'], { bracketSpacing: true });
+runFormatTest(import.meta, ['slang']);
+runFormatTest(import.meta, ['slang'], { bracketSpacing: true });

--- a/tests/format/Inbox/__snapshots__/format.test.js.snap
+++ b/tests/format/Inbox/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Inbox.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Inbox/format.test.js
+++ b/tests/format/Inbox/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/IndexOf/__snapshots__/format.test.js.snap
+++ b/tests/format/IndexOf/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`IndexOf.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/IndexOf/format.test.js
+++ b/tests/format/IndexOf/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/IndexRangeAccess/__snapshots__/format.test.js.snap
+++ b/tests/format/IndexRangeAccess/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`IndexRangeAccess.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/IndexRangeAccess/format.test.js
+++ b/tests/format/IndexRangeAccess/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Issues/__snapshots__/format.test.js.snap
+++ b/tests/format/Issues/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Issue205.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -40,7 +40,7 @@ contract Example {
 
 exports[`Issue289.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -65,7 +65,7 @@ contract Issue289 {
 
 exports[`Issue355.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -101,7 +101,7 @@ contract Bug {
 
 exports[`Issue385.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -139,7 +139,7 @@ contract Issue385 {
 
 exports[`Issue564.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -172,7 +172,7 @@ contract Issue564 {
 
 exports[`Issue799.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -186,7 +186,7 @@ struct EmptyStruct {}
 
 exports[`Issue843.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Issues/format.test.js
+++ b/tests/format/Issues/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Libraries/__snapshots__/format.test.js.snap
+++ b/tests/format/Libraries/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Libraries.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================
 bracketSpacing: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -55,7 +55,7 @@ using {
 
 exports[`Libraries.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Libraries/format.test.js
+++ b/tests/format/Libraries/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity']);
-runFormatTest(import.meta, ['slang-solidity'], { bracketSpacing: true });
+runFormatTest(import.meta, ['slang']);
+runFormatTest(import.meta, ['slang'], { bracketSpacing: true });

--- a/tests/format/MemberAccess/__snapshots__/format.test.js.snap
+++ b/tests/format/MemberAccess/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`MemberAccess.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/MemberAccess/format.test.js
+++ b/tests/format/MemberAccess/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ModifierDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/ModifierDefinitions/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ModifierDefinitions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ModifierDefinitions/format.test.js
+++ b/tests/format/ModifierDefinitions/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/ModifierInvocations/__snapshots__/format.test.js.snap
+++ b/tests/format/ModifierInvocations/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ModifierInvocations.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/ModifierInvocations/format.test.js
+++ b/tests/format/ModifierInvocations/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/MultipartStrings/__snapshots__/format.test.js.snap
+++ b/tests/format/MultipartStrings/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`MultipartStrings.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/MultipartStrings/format.test.js
+++ b/tests/format/MultipartStrings/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/NameValueExpression/__snapshots__/format.test.js.snap
+++ b/tests/format/NameValueExpression/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`NameValueExpression.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================
 bracketSpacing: true
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -35,7 +35,7 @@ contract NameValueExpression {
 
 exports[`NameValueExpression.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/NameValueExpression/format.test.js
+++ b/tests/format/NameValueExpression/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity']);
-runFormatTest(import.meta, ['slang-solidity'], { bracketSpacing: true });
+runFormatTest(import.meta, ['slang']);
+runFormatTest(import.meta, ['slang'], { bracketSpacing: true });

--- a/tests/format/NumberLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/NumberLiteral/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NumberLiteral.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/NumberLiteral/format.test.js
+++ b/tests/format/NumberLiteral/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Ownable/__snapshots__/format.test.js.snap
+++ b/tests/format/Ownable/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Ownable.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Ownable/format.test.js
+++ b/tests/format/Ownable/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Parentheses/__snapshots__/format.test.js.snap
+++ b/tests/format/Parentheses/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`AddNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -198,7 +198,7 @@ contract AddNoParentheses {
 
 exports[`BitAndNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -394,7 +394,7 @@ contract BitAndNoParentheses {
 
 exports[`BitOrNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -590,7 +590,7 @@ contract BitOrNoParentheses {
 
 exports[`BitXorNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -786,7 +786,7 @@ contract BitXorNoParentheses {
 
 exports[`DivNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -982,7 +982,7 @@ contract DivNoParentheses {
 
 exports[`ExpNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1178,7 +1178,7 @@ contract ExpNoParentheses {
 
 exports[`LogicNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1230,7 +1230,7 @@ contract LogicNoParentheses {
 
 exports[`ModNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1426,7 +1426,7 @@ contract ModNoParentheses {
 
 exports[`MulNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1622,7 +1622,7 @@ contract MulNoParentheses {
 
 exports[`ShiftLNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1818,7 +1818,7 @@ contract ShiftLNoParentheses {
 
 exports[`ShiftRNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2014,7 +2014,7 @@ contract ShiftRNoParentheses {
 
 exports[`SubNoParentheses.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Parentheses/format.test.js
+++ b/tests/format/Parentheses/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Pragma/__snapshots__/format.test.js.snap
+++ b/tests/format/Pragma/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Pragma.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Pragma/format.test.js
+++ b/tests/format/Pragma/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/PrettierIgnore/__snapshots__/format.test.js.snap
+++ b/tests/format/PrettierIgnore/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PrettierIgnore.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/PrettierIgnore/format.test.js
+++ b/tests/format/PrettierIgnore/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Proxy/__snapshots__/format.test.js.snap
+++ b/tests/format/Proxy/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Proxy.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Proxy/format.test.js
+++ b/tests/format/Proxy/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/SampleCrowdsale/__snapshots__/format.test.js.snap
+++ b/tests/format/SampleCrowdsale/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SampleCrowdsale.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/SampleCrowdsale/format.test.js
+++ b/tests/format/SampleCrowdsale/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/SimpleAuction/__snapshots__/format.test.js.snap
+++ b/tests/format/SimpleAuction/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SimpleAuction.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/SimpleAuction/format.test.js
+++ b/tests/format/SimpleAuction/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/SimpleStorage/__snapshots__/format.test.js.snap
+++ b/tests/format/SimpleStorage/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SimpleStorage.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/SimpleStorage/format.test.js
+++ b/tests/format/SimpleStorage/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/SplittableCommodity/__snapshots__/format.test.js.snap
+++ b/tests/format/SplittableCommodity/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SplittableCommodity.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/SplittableCommodity/format.test.js
+++ b/tests/format/SplittableCommodity/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/StateVariableDeclarations/__snapshots__/format.test.js.snap
+++ b/tests/format/StateVariableDeclarations/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`StateVariableDeclarations.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/StateVariableDeclarations/format.test.js
+++ b/tests/format/StateVariableDeclarations/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/StringLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/StringLiteral/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`StringLiteral.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/StringLiteral/format.test.js
+++ b/tests/format/StringLiteral/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/StyleGuide/__snapshots__/format.test.js.snap
+++ b/tests/format/StyleGuide/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BlankLines.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -48,7 +48,7 @@ contract A {
 
 exports[`ControlStructures.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -169,7 +169,7 @@ contract ControlStructures {
 
 exports[`FunctionDeclaration.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -460,7 +460,7 @@ contract X is B, C, D {
 
 exports[`Mappings.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -489,7 +489,7 @@ contract Mappings {
 
 exports[`MaximumLineLength.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -644,7 +644,7 @@ contract EventDefinitionsAndEventEmitters {
 
 exports[`OtherRecommendations.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -711,7 +711,7 @@ contract OtherRecommendations {
 
 exports[`VariableDeclarations.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -734,7 +734,7 @@ contract VariableDeclarations {
 
 exports[`WhitespaceInExpressions.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/StyleGuide/format.test.js
+++ b/tests/format/StyleGuide/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/TryCatch/__snapshots__/format.test.js.snap
+++ b/tests/format/TryCatch/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TryCatch.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/TryCatch/format.test.js
+++ b/tests/format/TryCatch/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/Tuples/__snapshots__/format.test.js.snap
+++ b/tests/format/Tuples/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tuples.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/Tuples/format.test.js
+++ b/tests/format/Tuples/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/TypeDefinition/__snapshots__/format.test.js.snap
+++ b/tests/format/TypeDefinition/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TypeDefinition.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/TypeDefinition/format.test.js
+++ b/tests/format/TypeDefinition/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/WhileStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/WhileStatements/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`WhileStatements.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/WhileStatements/format.test.js
+++ b/tests/format/WhileStatements/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/format/WrongCompiler/__snapshots__/format.test.js.snap
+++ b/tests/format/WrongCompiler/__snapshots__/format.test.js.snap
@@ -3,7 +3,7 @@
 exports[`WrongCompiler.sol - {"compiler":"0.8.4"} format 1`] = `
 ====================================options=====================================
 compiler: "0.8.4"
-parsers: ["solidity-parse"]
+parsers: ["antlr"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -21,7 +21,7 @@ pragma solidity 0.7.3;
 exports[`WrongCompiler.sol - {"compiler":"v0.7.3+commit.9bfce1f6"} format 1`] = `
 ====================================options=====================================
 compiler: "v0.7.3+commit.9bfce1f6"
-parsers: ["solidity-parse"]
+parsers: ["antlr"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -39,7 +39,7 @@ pragma solidity 0.7.3;
 exports[`WrongCompiler.sol - {"compiler":"v0.7.5-nightly.2020.11.9+commit.41f50365"} format 1`] = `
 ====================================options=====================================
 compiler: "v0.7.5-nightly.2020.11.9+commit.41f50365"
-parsers: ["solidity-parse"]
+parsers: ["antlr"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/WrongCompiler/format.test.js
+++ b/tests/format/WrongCompiler/format.test.js
@@ -1,10 +1,10 @@
 // Should warn twice
-runFormatTest(import.meta, ['solidity-parse'], { compiler: '0.8.4' });
+runFormatTest(import.meta, ['antlr'], { compiler: '0.8.4' });
 // Should warn once
-runFormatTest(import.meta, ['solidity-parse'], {
+runFormatTest(import.meta, ['antlr'], {
   compiler: 'v0.7.5-nightly.2020.11.9+commit.41f50365'
 });
 // Should not warn
-runFormatTest(import.meta, ['solidity-parse'], {
+runFormatTest(import.meta, ['antlr'], {
   compiler: 'v0.7.3+commit.9bfce1f6'
 });

--- a/tests/format/quotes/__snapshots__/format.test.js.snap
+++ b/tests/format/quotes/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Quotes.sol - {"singleQuote":false} format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 singleQuote: false
                                                                                 | printWidth
@@ -61,7 +61,7 @@ contract Foo {
 
 exports[`Quotes.sol - {"singleQuote":true} format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
 singleQuote: true
                                                                                 | printWidth

--- a/tests/format/quotes/format.test.js
+++ b/tests/format/quotes/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ['slang-solidity'], { singleQuote: true });
-runFormatTest(import.meta, ['slang-solidity'], { singleQuote: false });
+runFormatTest(import.meta, ['slang'], { singleQuote: true });
+runFormatTest(import.meta, ['slang'], { singleQuote: false });

--- a/tests/format/strings/__snapshots__/format.test.js.snap
+++ b/tests/format/strings/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`strings.sol format 1`] = `
 ====================================options=====================================
-parsers: ["slang-solidity"]
+parsers: ["slang"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/strings/format.test.js
+++ b/tests/format/strings/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ['slang-solidity']);
+runFormatTest(import.meta, ['slang']);

--- a/tests/integration/test-app.js
+++ b/tests/integration/test-app.js
@@ -3,7 +3,7 @@ import '../../dist/standalone.js';
 
 export default async function format(code) {
   const formattedCode = await prettier.format(code, {
-    parser: 'slang-solidity',
+    parser: 'slang',
     plugins: prettierPlugins
   });
   return formattedCode;


### PR DESCRIPTION
Rename parser values. `solidity-parse` is now `antlr` and `slang-solidity` is `slang`.

This is a breaking change, but I think it's for the best. The names are very confusing otherwise.

I decided to go with `slang` and not `slang-solidity` because, even if we later add a `slang-yul` parser, I think the meaning is obvious and I'd rather have a shorter value for the default case.