### PR TITLE
better handling of empty array from `inferLanguage`

### DIFF
--- a/src/slang-utils/create-parser.ts
+++ b/src/slang-utils/create-parser.ts
@@ -21,6 +21,15 @@ function parserAndOutput(
   };
 }
 
+function createError(
+  { parseOutput }: { parseOutput: ParseOutput },
+  reason: string
+): Error {
+  return new Error(
+    `We encountered the following syntax error:\n\n\t${parseOutput.errors()[0].message}\n\n${reason}`
+  );
+}
+
 export function createParser(
   text: string,
   options: ParserOptions<AstNode>
@@ -30,10 +39,9 @@ export function createParser(
     const result = parserAndOutput(text, compiler);
 
     if (!result.parseOutput.isValid())
-      throw new Error(
-        `We encountered the following syntax error:\n\n\t${
-          result.parseOutput.errors()[0].message
-        }\n\nBased on the compiler option provided, we inferred your code to be using Solidity version ${
+      throw createError(
+        result,
+        `Based on the compiler option provided, we inferred your code to be using Solidity version ${
           result.parser.languageVersion
         }. If you would like to change that, specify a different version in your \`.prettierrc\` file.`
       );
@@ -51,10 +59,9 @@ export function createParser(
     );
 
     if (!result.parseOutput.isValid())
-      throw new Error(
-        `We encountered the following syntax error:\n\n\t${
-          result.parseOutput.errors()[0].message
-        }\n\nWe couldn't infer a Solidity version base on the pragma statements in your code so we defaulted to ${
+      throw createError(
+        result,
+        `We couldn't infer a Solidity version based on the pragma statements in your code so we defaulted to ${
           result.parser.languageVersion
         }. You might be attempting to use a syntax not yet supported by Slang or you might want to specify a version in your \`.prettierrc\` file.`
       );
@@ -64,10 +71,9 @@ export function createParser(
   const result = parserAndOutput(text, inferredRanges[0]);
 
   if (!result.parseOutput.isValid())
-    throw new Error(
-      `We encountered the following syntax error:\n\n\t${
-        result.parseOutput.errors()[0].message
-      }\n\nBased on the pragma statements, we inferred your code to be using Solidity version ${
+    throw createError(
+      result,
+      `Based on the pragma statements, we inferred your code to be using Solidity version ${
         result.parser.languageVersion
       }. If you would like to change that, update the pragmas in your source file, or specify a version in your \`.prettierrc\` file.`
     );

--- a/tests/unit/slang-utils/create-parser.test.js
+++ b/tests/unit/slang-utils/create-parser.test.js
@@ -110,9 +110,44 @@ describe('inferLanguage', function () {
     expect(parser.languageVersion).toEqual('0.8.0');
   });
 
-  test.skip('should throw an error if there are incompatible ranges', function () {
+  test('should throw if compiler option does not match the syntax', function () {
     expect(() =>
-      createParser(`pragma solidity ^0.8.0; pragma solidity 0.7.6;`, options)
-    ).toThrow();
+      createParser(`contract Foo {byte bar;}`, { compiler: '0.8.0' })
+    ).toThrow(
+      'Based on the compiler option provided, we inferred your code to be using Solidity version'
+    );
+  });
+
+  test('should throw if pragma is outside the supported version and the syntax does not match with the latest supported version', function () {
+    expect(() =>
+      createParser(`pragma solidity 10.0.0;contract Foo {byte bar;}`, options)
+    ).toThrow(
+      "We couldn't infer a Solidity version based on the pragma statements"
+    );
+  });
+
+  test('should throw if there is no pragma and the syntax does not match with the latest supported version', function () {
+    expect(() => createParser(`contract Foo {byte bar;}`, options)).toThrow(
+      "We couldn't infer a Solidity version based on the pragma statements"
+    );
+  });
+
+  test('should throw an error if there are incompatible ranges and the syntax does not match with the latest supported version', function () {
+    expect(() =>
+      createParser(
+        `pragma solidity ^0.8.0; pragma solidity 0.7.6;contract Foo {byte bar;}`,
+        options
+      )
+    ).toThrow(
+      "We couldn't infer a Solidity version based on the pragma statements"
+    );
+  });
+
+  test('should throw an error if the pragma statement is and the syntax do not match', function () {
+    expect(() =>
+      createParser(`pragma solidity ^0.8.0;contract Foo {byte bar;}`, options)
+    ).toThrow(
+      'Based on the pragma statements, we inferred your code to be using Solidity version'
+    );
   });
 });


### PR DESCRIPTION
There are 2 cases in which we receive an empty array from `inferLanguage`.

- the range is outside of the supported versions.
- there are ranges in the pragmas that don't intersect.

with this in mind we are defaulting to the latest supported version and return a more detailed error.

also in this PR:

I could not parse any nightly builds even when using specific versions of nightly builds of `solc`. Therefore I'm removing this test.

https://github.com/NomicFoundation/slang/issues/1346