### PR TITLE
Comments in struct definition

### DIFF
--- a/src/slang-comments/handlers/handle-struct-comments.ts
+++ b/src/slang-comments/handlers/handle-struct-comments.ts
@@ -1,0 +1,39 @@
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { util } from 'prettier';
+import { locEnd } from '../../slang-utils/loc.js';
+import addCollectionNodeFirstComment from './add-collection-node-first-comment.js';
+import addCollectionNodeLastComment from './add-collection-node-last-comment.js';
+
+import type { HandlerParams } from './types.d.ts';
+
+export default function handleStructComments({
+  text,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  comment
+}: HandlerParams): boolean {
+  if (enclosingNode?.kind !== NonterminalKind.StructDefinition) {
+    return false;
+  }
+
+  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+    text,
+    locEnd(comment)
+  );
+
+  if (
+    precedingNode?.kind === NonterminalKind.StructMembers &&
+    nextCharacter === '}'
+  ) {
+    addCollectionNodeLastComment(precedingNode, comment);
+    return true;
+  }
+
+  if (followingNode?.kind === NonterminalKind.StructMembers) {
+    addCollectionNodeFirstComment(followingNode, comment);
+    return true;
+  }
+
+  return false;
+}

--- a/src/slang-comments/handlers/index.ts
+++ b/src/slang-comments/handlers/index.ts
@@ -9,6 +9,7 @@ import handleModifierInvocationComments from './handle-modifier-invocation-comme
 import handleParametersDeclarationComments from './handle-parameters-declaration-comments.js';
 import handlePositionalArgumentsDeclarationComments from './handle-positional-arguments-declaration-comments.js';
 import handleStorageLayoutSpecifierComments from './handle-storage-layout-specifier-comments.js';
+import handleStructComments from './handle-struct-comments.js';
 import handleWhileStatementComments from './handle-while-statement-comments.js';
 import handleYulBlockComments from './handle-yul-block-comments.js';
 
@@ -24,6 +25,7 @@ export default [
   handleParametersDeclarationComments,
   handlePositionalArgumentsDeclarationComments,
   handleStorageLayoutSpecifierComments,
+  handleStructComments,
   handleWhileStatementComments,
   handleYulBlockComments
 ];

--- a/tests/format/Comments/Comments.sol
+++ b/tests/format/Comments/Comments.sol
@@ -166,3 +166,16 @@ contract Comments13 {
       {
   }
 }
+
+
+
+contract Comments14 {
+    struct AssetStore // use 0 for non-EVM chains
+    {
+        uint chainId;
+        uint assetStoreIndex;
+        string assetStoreAddress; // we assume all addresses are strings and the front-end will cast correctly
+    //string shortName; // usually an asset shortName `eth:` or `st:` for a stealth address
+    }
+
+}

--- a/tests/format/Comments/__snapshots__/format.test.js.snap
+++ b/tests/format/Comments/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Comments.sol format 1`] = `
 ====================================options=====================================
@@ -173,6 +173,19 @@ contract Comments13 {
       ) // comment 13
       {
   }
+}
+
+
+
+contract Comments14 {
+    struct AssetStore // use 0 for non-EVM chains
+    {
+        uint chainId;
+        uint assetStoreIndex;
+        string assetStoreAddress; // we assume all addresses are strings and the front-end will cast correctly
+    //string shortName; // usually an asset shortName \`eth:\` or \`st:\` for a stealth address
+    }
+
 }
 =====================================output=====================================
 contract Comments1 {
@@ -376,6 +389,15 @@ contract Comments13 {
             // comment 12
         ) // comment 13
     {}
+}
+
+contract Comments14 {
+    struct AssetStore { // use 0 for non-EVM chains
+        uint chainId;
+        uint assetStoreIndex;
+        string assetStoreAddress; // we assume all addresses are strings and the front-end will cast correctly
+    }
+    //string shortName; // usually an asset shortName \`eth:\` or \`st:\` for a stealth address
 }
 
 ================================================================================

--- a/tests/format/Comments/__snapshots__/format.test.js.snap
+++ b/tests/format/Comments/__snapshots__/format.test.js.snap
@@ -392,12 +392,13 @@ contract Comments13 {
 }
 
 contract Comments14 {
-    struct AssetStore { // use 0 for non-EVM chains
+    struct AssetStore {
+        // use 0 for non-EVM chains
         uint chainId;
         uint assetStoreIndex;
         string assetStoreAddress; // we assume all addresses are strings and the front-end will cast correctly
+        //string shortName; // usually an asset shortName \`eth:\` or \`st:\` for a stealth address
     }
-    //string shortName; // usually an asset shortName \`eth:\` or \`st:\` for a stealth address
 }
 
 ================================================================================


### PR DESCRIPTION
Fix to comments at the end of a StructDefinition being placed just outside of it.