### PR TITLE
avoid calling coerce multiple times and only do it once

### DIFF
--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -1,5 +1,5 @@
 import { doc } from 'prettier';
-import { coerce, satisfies } from 'semver';
+import { satisfies } from 'semver';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { getNodeMetadata, updateMetadata } from '../slang-utils/metadata.js';
 import { Identifier } from './Identifier.js';
@@ -44,10 +44,9 @@ export class ContractDefinition implements SlangNode {
     this.cleanModifierInvocationArguments(options);
   }
 
-  cleanModifierInvocationArguments(options: ParserOptions<AstNode>): void {
+  cleanModifierInvocationArguments({ compiler }: ParserOptions<AstNode>): void {
     // Older versions of Solidity defined a constructor as a function having
     // the same name as the contract.
-    const compiler = coerce(options.compiler);
     if (compiler && !satisfies(compiler, '>=0.5.0')) {
       for (const member of this.members.items) {
         if (

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -1,4 +1,4 @@
-import { coerce, satisfies } from 'semver';
+import { satisfies } from 'semver';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printFunction } from '../slang-printers/print-function.js';
 import { getNodeMetadata, updateMetadata } from '../slang-utils/metadata.js';
@@ -54,7 +54,7 @@ export class FunctionDefinition implements SlangNode {
 
     // Older versions of Solidity defined a constructor as a function having
     // the same name as the contract.
-    const compiler = coerce(options.compiler);
+    const compiler = options.compiler;
     if (compiler && satisfies(compiler, '>=0.5.0')) {
       this.cleanModifierInvocationArguments();
     }

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -1,5 +1,5 @@
 import { doc } from 'prettier';
-import { coerce, satisfies } from 'semver';
+import { satisfies } from 'semver';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { getNodeMetadata, updateMetadata } from '../slang-utils/metadata.js';
@@ -40,7 +40,7 @@ export class ImportDeconstructionSymbols implements SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    const compiler = coerce(options.compiler);
+    const compiler = options.compiler;
     return printSeparatedList(
       path.map(print, 'items'),
       compiler && satisfies(compiler, '>=0.7.4')

--- a/src/slang-utils/create-parser.ts
+++ b/src/slang-utils/create-parser.ts
@@ -34,19 +34,25 @@ export function createParser(
   text: string,
   options: ParserOptions<AstNode>
 ): { parser: Parser; parseOutput: ParseOutput } {
-  const compiler = minSatisfying(supportedVersions, options.compiler);
+  const compiler = options.compiler;
   if (compiler) {
-    const result = parserAndOutput(text, compiler);
+    const version = minSatisfying(
+      supportedVersions,
+      typeof compiler === 'string' ? compiler : compiler.version
+    );
+    if (version) {
+      const result = parserAndOutput(text, version);
 
-    if (!result.parseOutput.isValid())
-      throw createError(
-        result,
-        `Based on the compiler option provided, we inferred your code to be using Solidity version ${
-          result.parser.languageVersion
-        }. If you would like to change that, specify a different version in your \`.prettierrc\` file.`
-      );
+      if (!result.parseOutput.isValid())
+        throw createError(
+          result,
+          `Based on the compiler option provided, we inferred your code to be using Solidity version ${
+            result.parser.languageVersion
+          }. If you would like to change that, specify a different version in your \`.prettierrc\` file.`
+        );
 
-    return result;
+      return result;
+    }
   }
 
   const inferredRanges: string[] = LanguageFacts.inferLanguageVersions(text);

--- a/src/slangSolidityParser.ts
+++ b/src/slangSolidityParser.ts
@@ -1,5 +1,6 @@
 // https://prettier.io/docs/en/plugins.html#parsers
 import { SourceUnit as SlangSourceUnit } from '@nomicfoundation/slang/ast';
+import { coerce } from 'semver';
 import { clearOffsets } from './slang-utils/metadata.js';
 import { createParser } from './slang-utils/create-parser.js';
 import { SourceUnit } from './slang-nodes/SourceUnit.js';
@@ -14,7 +15,7 @@ export default function parse(
   const { parser, parseOutput } = createParser(text, options);
 
   // We update the compiler version by the inferred one.
-  options.compiler = parser.languageVersion;
+  options.compiler = coerce(parser.languageVersion);
   const parsed = new SourceUnit(
     new SlangSourceUnit(parseOutput.tree.asNonterminalNode()),
     options

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,12 +1,13 @@
 import type { NonterminalKind, TerminalKind } from '@nomicfoundation/slang/cst';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { SemVer } from 'semver';
 import type { AstNode, Comment, StrictAstNode } from './slang-nodes/types.d.ts';
 
 // Adding our own options to prettier's `ParserOptions` interface.
 declare module 'prettier' {
   interface ParserOptions {
-    compiler: string;
+    compiler: string | SemVer | null;
   }
 }
 


### PR DESCRIPTION
 at the beginning of the parse.
 
 Had to add an extra check in `create-parser` because the type grew in complexity.