### PR TITLE
cleaning up how we check for `TupleExpression`s with a single item

### DIFF
--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -133,13 +133,22 @@ export class ConditionalExpression implements SlangNode {
       // We can remove parentheses only because we are sure that the
       // `condition` must be a single `bool` value.
       const operandLoc = this.operand.loc;
-      while (
-        this.operand.variant.kind === NonterminalKind.TupleExpression &&
-        this.operand.variant.items.items.length === 1 &&
-        this.operand.variant.items.items[0].expression!.variant.kind !==
-          NonterminalKind.ConditionalExpression
+
+      const getOperandSingleExpression = (): Expression | undefined => {
+        const operandVariant = this.operand.variant;
+        return operandVariant.kind === NonterminalKind.TupleExpression
+          ? operandVariant.items.getSingleExpression()
+          : undefined;
+      };
+
+      for (
+        let operandSingleExpression = getOperandSingleExpression();
+        operandSingleExpression &&
+        operandSingleExpression.variant.kind !==
+          NonterminalKind.ConditionalExpression;
+        operandSingleExpression = getOperandSingleExpression()
       ) {
-        this.operand = this.operand.variant.items.items[0].expression!;
+        this.operand = operandSingleExpression;
       }
       this.operand.loc = operandLoc;
     }

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -100,6 +100,14 @@ function traditionalTernaries(
   ]);
 }
 
+function getOperandSingleExpression({
+  variant
+}: Expression): Expression | undefined {
+  return variant.kind === NonterminalKind.TupleExpression
+    ? variant.items.getSingleExpression()
+    : undefined;
+}
+
 export class ConditionalExpression implements SlangNode {
   readonly kind = NonterminalKind.ConditionalExpression;
 
@@ -133,20 +141,12 @@ export class ConditionalExpression implements SlangNode {
       // We can remove parentheses only because we are sure that the
       // `condition` must be a single `bool` value.
       const operandLoc = this.operand.loc;
-
-      const getOperandSingleExpression = (): Expression | undefined => {
-        const operandVariant = this.operand.variant;
-        return operandVariant.kind === NonterminalKind.TupleExpression
-          ? operandVariant.items.getSingleExpression()
-          : undefined;
-      };
-
       for (
-        let operandSingleExpression = getOperandSingleExpression();
+        let operandSingleExpression = getOperandSingleExpression(this.operand);
         operandSingleExpression &&
         operandSingleExpression.variant.kind !==
           NonterminalKind.ConditionalExpression;
-        operandSingleExpression = getOperandSingleExpression()
+        operandSingleExpression = getOperandSingleExpression(this.operand)
       ) {
         this.operand = operandSingleExpression;
       }

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -24,9 +24,9 @@ function isEndOfChain(
   path: AstPath<StrictAstNode>
 ): boolean {
   for (
-    let i = 2, current: StrictAstNode = node, grandparent = path.getNode(i)!;
-    isChainableExpression(grandparent);
-    i += 2, current = grandparent, grandparent = path.getNode(i)!
+    let i = 2, current: StrictAstNode = node, grandparent = path.getNode(i);
+    grandparent && isChainableExpression(grandparent);
+    i += 2, current = grandparent, grandparent = path.getNode(i)
   ) {
     switch (grandparent.kind) {
       case NonterminalKind.MemberAccessExpression:

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -34,7 +34,8 @@ export class TupleValues implements SlangNode {
   }
 
   getSingleExpression(): Expression | undefined {
-    return this.items.length === 1 ? this.items[0].expression : undefined;
+    const items = this.items;
+    return items.length === 1 ? items[0].expression : undefined;
   }
 
   print(path: AstPath<TupleValues>, print: PrintFunction): Doc {

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -39,10 +39,10 @@ export class TupleValues implements SlangNode {
   }
 
   print(path: AstPath<TupleValues>, print: PrintFunction): Doc {
-    const singleExpression = this.getSingleExpression();
-    return singleExpression &&
-      singleExpression.variant.kind !== TerminalKind.Identifier &&
-      isBinaryOperation(singleExpression.variant)
+    const singleExpressionVariant = this.getSingleExpression()?.variant;
+    return singleExpressionVariant &&
+      singleExpressionVariant.kind !== TerminalKind.Identifier &&
+      isBinaryOperation(singleExpressionVariant)
       ? path.map(print, 'items')
       : printSeparatedList(path.map(print, 'items'));
   }

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -8,6 +8,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction, SlangNode } from '../types.d.ts';
+import type { Expression } from './Expression.js';
 
 export class TupleValues implements SlangNode {
   readonly kind = NonterminalKind.TupleValues;
@@ -32,11 +33,15 @@ export class TupleValues implements SlangNode {
     this.loc = metadata.loc;
   }
 
+  getSingleExpression(): Expression | undefined {
+    return this.items.length === 1 ? this.items[0].expression : undefined;
+  }
+
   print(path: AstPath<TupleValues>, print: PrintFunction): Doc {
-    return this.items.length === 1 &&
-      this.items[0].expression &&
-      this.items[0].expression.variant.kind !== TerminalKind.Identifier &&
-      isBinaryOperation(this.items[0].expression.variant)
+    const singleExpression = this.getSingleExpression();
+    return singleExpression &&
+      singleExpression.variant.kind !== TerminalKind.Identifier &&
+      isBinaryOperation(singleExpression.variant)
       ? path.map(print, 'items')
       : printSeparatedList(path.map(print, 'items'));
   }


### PR DESCRIPTION
There is a tricky way to check if a `TupleExpression` has a single item since a `TupleValue` can have an `Expression` or be `undefined`. However by the nature of a `TupleExpression` if there is only 1 `TupleValue`, then it will always have an `Expression`.
This is very difficult to express in typescript therefor there are a few non-null assertions  we were using.

To clean this I added a single function to `src/slang-nodes/TupleValues.ts` to return the single expression contained. If it has multiple or 0 it will default to `undefined`.

This avoids multiple checks and navigation down the chain like this `this.operand.variant.items.items[0].expression!`