### PR TITLE
updating jest snapshot link

### DIFF
--- a/tests/format/AddressPayable/__snapshots__/format.test.js.snap
+++ b/tests/format/AddressPayable/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddressPayable.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/AllSolidityFeatures/__snapshots__/format.test.js.snap
+++ b/tests/format/AllSolidityFeatures/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AllSolidityFeatures.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Arrays/__snapshots__/format.test.js.snap
+++ b/tests/format/Arrays/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Arrays.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Assembly/__snapshots__/format.test.js.snap
+++ b/tests/format/Assembly/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Assembly.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/AssemblyV0.4.26/__snapshots__/format.test.js.snap
+++ b/tests/format/AssemblyV0.4.26/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Assembly.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/BinaryOperationHierarchy/__snapshots__/format.test.js.snap
+++ b/tests/format/BinaryOperationHierarchy/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Group.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/BreakingChangesV0.7.4/__snapshots__/format.test.js.snap
+++ b/tests/format/BreakingChangesV0.7.4/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BreakingChangesV0.7.4.sol - {"compiler":"0.7.3","bracketSpacing":true} format 1`] = `
 ====================================options=====================================

--- a/tests/format/BreakingChangesV0.8.0/__snapshots__/format.test.js.snap
+++ b/tests/format/BreakingChangesV0.8.0/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`BreakingChangesV0.8.0.sol - {"compiler":"0.7.0"} format 1`] = `
 ====================================options=====================================

--- a/tests/format/Conditional/__snapshots__/format.test.js.snap
+++ b/tests/format/Conditional/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Conditional.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Constructors/__snapshots__/format.test.js.snap
+++ b/tests/format/Constructors/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Constructors.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/ConstructorsV0.4.26/__snapshots__/format.test.js.snap
+++ b/tests/format/ConstructorsV0.4.26/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Constructors.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ContractDefinitions.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/CustomErrors/__snapshots__/format.test.js.snap
+++ b/tests/format/CustomErrors/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CustomErrors.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/EnumDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/EnumDefinitions/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`EnumDefinitions.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Etc/__snapshots__/format.test.js.snap
+++ b/tests/format/Etc/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Etc.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/ExperimentalTernaries/__snapshots__/format.test.js.snap
+++ b/tests/format/ExperimentalTernaries/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExperimentalTernaries.sol - {"experimentalTernaries":true,"tabWidth":1} format 1`] = `
 ====================================options=====================================

--- a/tests/format/ForStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/ForStatements/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ForStatements.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/FunctionCalls/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionCalls/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FunctionCalls.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================

--- a/tests/format/FunctionDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/FunctionDefinitions/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FunctionDefinitions.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/HexLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/HexLiteral/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HexLiteral.sol - {"singleQuote":false} format 1`] = `
 ====================================options=====================================

--- a/tests/format/IfStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/IfStatements/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`IfStatements.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Immutable/__snapshots__/format.test.js.snap
+++ b/tests/format/Immutable/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Immutable.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Inbox/__snapshots__/format.test.js.snap
+++ b/tests/format/Inbox/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Inbox.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/IndexRangeAccess/__snapshots__/format.test.js.snap
+++ b/tests/format/IndexRangeAccess/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`IndexRangeAccess.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Issues/__snapshots__/format.test.js.snap
+++ b/tests/format/Issues/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Issue205.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Libraries/__snapshots__/format.test.js.snap
+++ b/tests/format/Libraries/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Libraries.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================

--- a/tests/format/Markdown/__snapshots__/format.test.js.snap
+++ b/tests/format/Markdown/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Markdown.md format 1`] = `
 ====================================options=====================================

--- a/tests/format/ModifierDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/ModifierDefinitions/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ModifierDefinitions.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/ModifierInvocations/__snapshots__/format.test.js.snap
+++ b/tests/format/ModifierInvocations/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ModifierInvocations.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/MultipartStrings/__snapshots__/format.test.js.snap
+++ b/tests/format/MultipartStrings/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MultipartStrings.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/NameValueExpression/__snapshots__/format.test.js.snap
+++ b/tests/format/NameValueExpression/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NameValueExpression.sol - {"bracketSpacing":true} format 1`] = `
 ====================================options=====================================

--- a/tests/format/NumberLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/NumberLiteral/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NumberLiteral.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Ownable/__snapshots__/format.test.js.snap
+++ b/tests/format/Ownable/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Ownable.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Parentheses/__snapshots__/format.test.js.snap
+++ b/tests/format/Parentheses/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AddNoParentheses.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Pragma/__snapshots__/format.test.js.snap
+++ b/tests/format/Pragma/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Pragma.sol - {"compiler":"0.8.0"} format 1`] = `
 ====================================options=====================================

--- a/tests/format/PrettierIgnore/__snapshots__/format.test.js.snap
+++ b/tests/format/PrettierIgnore/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PrettierIgnore.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Proxy/__snapshots__/format.test.js.snap
+++ b/tests/format/Proxy/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Proxy.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/RespectDefaultOptions/__snapshots__/format.test.js.snap
+++ b/tests/format/RespectDefaultOptions/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`respect-default-options.js format 1`] = `
 ====================================options=====================================

--- a/tests/format/SampleCrowdsale/__snapshots__/format.test.js.snap
+++ b/tests/format/SampleCrowdsale/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SampleCrowdsale.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/SimpleAuction/__snapshots__/format.test.js.snap
+++ b/tests/format/SimpleAuction/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SimpleAuction.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/SplittableCommodity/__snapshots__/format.test.js.snap
+++ b/tests/format/SplittableCommodity/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SplittableCommodity.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/StateVariableDeclarations/__snapshots__/format.test.js.snap
+++ b/tests/format/StateVariableDeclarations/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`StateVariableDeclarations.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/StringLiteral/__snapshots__/format.test.js.snap
+++ b/tests/format/StringLiteral/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`StringLiteral.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/TryCatch/__snapshots__/format.test.js.snap
+++ b/tests/format/TryCatch/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TryCatch.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/Tuples/__snapshots__/format.test.js.snap
+++ b/tests/format/Tuples/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tuples.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/TypeDefinition/__snapshots__/format.test.js.snap
+++ b/tests/format/TypeDefinition/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TypeDefinition.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/WhileStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/WhileStatements/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`WhileStatements.sol format 1`] = `
 ====================================options=====================================

--- a/tests/format/WrongCompiler/__snapshots__/format.test.js.snap
+++ b/tests/format/WrongCompiler/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`WrongCompiler.sol - {"compiler":"0.8.4"} format 1`] = `
 ====================================options=====================================

--- a/tests/format/quotes/__snapshots__/format.test.js.snap
+++ b/tests/format/quotes/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Quotes.sol - {"singleQuote":false} format 1`] = `
 ====================================options=====================================


### PR DESCRIPTION
Jest has started updating the link in their snapshots but it only does it when it attempts to update or a snapshot fails to match in the tests. This tends to generate some nuisance when developing and a snapshots I'm not currently working on fails due to a bug while developing.
So I decided to update all the links in the snapshots. 