### PR TITLE
dropping all the unnecessary storing of separators

### DIFF
--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -17,13 +17,10 @@ export class ArrayValues implements SlangNode {
 
   items: Expression[];
 
-  separators: string[];
-
   constructor(ast: ast.ArrayValues, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new Expression(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/AssemblyFlags.ts
+++ b/src/slang-nodes/AssemblyFlags.ts
@@ -17,13 +17,10 @@ export class AssemblyFlags implements SlangNode {
 
   items: StringLiteral[];
 
-  separators: string[];
-
   constructor(ast: ast.AssemblyFlags, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new StringLiteral(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -20,13 +20,10 @@ export class CallOptions implements SlangNode {
 
   items: NamedArgument[];
 
-  separators: string[];
-
   constructor(ast: ast.CallOptions, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new NamedArgument(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/EnumMembers.ts
+++ b/src/slang-nodes/EnumMembers.ts
@@ -19,13 +19,10 @@ export class EnumMembers implements SlangNode {
 
   items: Identifier[];
 
-  separators: string[];
-
   constructor(ast: ast.EnumMembers) {
     const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new Identifier(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/ErrorParameters.ts
+++ b/src/slang-nodes/ErrorParameters.ts
@@ -17,13 +17,10 @@ export class ErrorParameters implements SlangNode {
 
   items: ErrorParameter[];
 
-  separators: string[];
-
   constructor(ast: ast.ErrorParameters, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new ErrorParameter(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/EventParameters.ts
+++ b/src/slang-nodes/EventParameters.ts
@@ -17,13 +17,10 @@ export class EventParameters implements SlangNode {
 
   items: EventParameter[];
 
-  separators: string[];
-
   constructor(ast: ast.EventParameters, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new EventParameter(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/IdentifierPath.ts
+++ b/src/slang-nodes/IdentifierPath.ts
@@ -1,10 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { doc } from 'prettier';
 import { getNodeMetadata } from '../slang-utils/metadata.js';
 import { Identifier } from './Identifier.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction, SlangNode } from '../types.d.ts';
+
+const { join } = doc.builders;
 
 export class IdentifierPath implements SlangNode {
   readonly kind = NonterminalKind.IdentifierPath;
@@ -15,23 +18,16 @@ export class IdentifierPath implements SlangNode {
 
   items: Identifier[];
 
-  separators: string[];
-
   constructor(ast: ast.IdentifierPath) {
     const metadata = getNodeMetadata(ast);
 
     this.items = ast.items.map((item) => new Identifier(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;
   }
 
   print(path: AstPath<IdentifierPath>, print: PrintFunction): Doc {
-    return path
-      .map(print, 'items')
-      .map((item, index) =>
-        index === 0 ? item : [this.separators[index - 1], item]
-      );
+    return join('.', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -21,13 +21,10 @@ export class ImportDeconstructionSymbols implements SlangNode {
 
   items: ImportDeconstructionSymbol[];
 
-  separators: string[];
-
   constructor(ast: ast.ImportDeconstructionSymbols) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new ImportDeconstructionSymbol(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -20,13 +20,10 @@ export class InheritanceTypes implements SlangNode {
 
   items: InheritanceType[];
 
-  separators: string[];
-
   constructor(ast: ast.InheritanceTypes, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new InheritanceType(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -68,8 +68,7 @@ export class ModifierDefinition implements SlangNode {
               kind: NonterminalKind.Parameters,
               loc: { ...parametersLoc },
               comments: [],
-              items: [],
-              separators: []
+              items: []
             }
           )
         }

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -20,13 +20,10 @@ export class NamedArguments implements SlangNode {
 
   items: NamedArgument[];
 
-  separators: string[];
-
   constructor(ast: ast.NamedArguments, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new NamedArgument(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/OverridePaths.ts
+++ b/src/slang-nodes/OverridePaths.ts
@@ -16,13 +16,10 @@ export class OverridePaths implements SlangNode {
 
   items: IdentifierPath[];
 
-  separators: string[];
-
   constructor(ast: ast.OverridePaths) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new IdentifierPath(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/Parameters.ts
+++ b/src/slang-nodes/Parameters.ts
@@ -19,13 +19,10 @@ export class Parameters implements SlangNode {
 
   items: Parameter[];
 
-  separators: string[];
-
   constructor(ast: ast.Parameters, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new Parameter(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -19,13 +19,10 @@ export class PositionalArguments implements SlangNode {
 
   items: Expression[];
 
-  separators: string[];
-
   constructor(ast: ast.PositionalArguments, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new Expression(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/SimpleVersionLiteral.ts
+++ b/src/slang-nodes/SimpleVersionLiteral.ts
@@ -14,21 +14,16 @@ export class SimpleVersionLiteral implements SlangNode {
 
   items: string[];
 
-  separators: string[];
-
   constructor(ast: ast.SimpleVersionLiteral) {
     const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => item.unparse());
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;
   }
 
   print(): Doc {
-    return this.items.map((item, index) =>
-      index === 0 ? item : [this.separators[index - 1], item]
-    );
+    return this.items.join('.');
   }
 }

--- a/src/slang-nodes/TupleDeconstructionElements.ts
+++ b/src/slang-nodes/TupleDeconstructionElements.ts
@@ -17,8 +17,6 @@ export class TupleDeconstructionElements implements SlangNode {
 
   items: TupleDeconstructionElement[];
 
-  separators: string[];
-
   constructor(
     ast: ast.TupleDeconstructionElements,
     options: ParserOptions<AstNode>
@@ -28,7 +26,6 @@ export class TupleDeconstructionElements implements SlangNode {
     this.items = ast.items.map(
       (item) => new TupleDeconstructionElement(item, options)
     );
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -18,13 +18,10 @@ export class TupleValues implements SlangNode {
 
   items: TupleValue[];
 
-  separators: string[];
-
   constructor(ast: ast.TupleValues, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new TupleValue(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/UsingDeconstructionSymbols.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbols.ts
@@ -20,13 +20,10 @@ export class UsingDeconstructionSymbols implements SlangNode {
 
   items: UsingDeconstructionSymbol[];
 
-  separators: string[];
-
   constructor(ast: ast.UsingDeconstructionSymbols) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new UsingDeconstructionSymbol(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/VersionExpressionSets.ts
+++ b/src/slang-nodes/VersionExpressionSets.ts
@@ -1,10 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { doc } from 'prettier';
 import { getNodeMetadata, updateMetadata } from '../slang-utils/metadata.js';
 import { VersionExpressionSet } from './VersionExpressionSet.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction, SlangNode } from '../types.d.ts';
+
+const { join } = doc.builders;
 
 export class VersionExpressionSets implements SlangNode {
   readonly kind = NonterminalKind.VersionExpressionSets;
@@ -15,13 +18,10 @@ export class VersionExpressionSets implements SlangNode {
 
   items: VersionExpressionSet[];
 
-  separators: string[];
-
   constructor(ast: ast.VersionExpressionSets) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new VersionExpressionSet(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 
@@ -30,10 +30,6 @@ export class VersionExpressionSets implements SlangNode {
   }
 
   print(path: AstPath<VersionExpressionSets>, print: PrintFunction): Doc {
-    return path
-      .map(print, 'items')
-      .map((item, index) =>
-        index === 0 ? item : [` ${this.separators[index - 1]} `, item]
-      );
+    return join(' || ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -17,13 +17,10 @@ export class YulArguments implements SlangNode {
 
   items: YulExpression[];
 
-  separators: string[];
-
   constructor(ast: ast.YulArguments, options: ParserOptions<AstNode>) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new YulExpression(item, options));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 

--- a/src/slang-nodes/YulParameters.ts
+++ b/src/slang-nodes/YulParameters.ts
@@ -16,13 +16,10 @@ export class YulParameters implements SlangNode {
 
   items: YulIdentifier[];
 
-  separators: string[];
-
   constructor(ast: ast.YulParameters) {
     const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new YulIdentifier(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-nodes/YulPath.ts
+++ b/src/slang-nodes/YulPath.ts
@@ -1,10 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { doc } from 'prettier';
 import { getNodeMetadata } from '../slang-utils/metadata.js';
 import { YulIdentifier } from './YulIdentifier.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction, SlangNode } from '../types.d.ts';
+
+const { join } = doc.builders;
 
 export class YulPath implements SlangNode {
   readonly kind = NonterminalKind.YulPath;
@@ -15,23 +18,16 @@ export class YulPath implements SlangNode {
 
   items: YulIdentifier[];
 
-  separators: string[];
-
   constructor(ast: ast.YulPath) {
     const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new YulIdentifier(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;
   }
 
   print(path: AstPath<YulPath>, print: PrintFunction): Doc {
-    return path
-      .map(print, 'items')
-      .map((item, index) =>
-        index === 0 ? item : [this.separators[index - 1], item]
-      );
+    return join('.', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulPaths.ts
+++ b/src/slang-nodes/YulPaths.ts
@@ -1,10 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { doc } from 'prettier';
 import { getNodeMetadata, updateMetadata } from '../slang-utils/metadata.js';
 import { YulPath } from './YulPath.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction, SlangNode } from '../types.d.ts';
+
+const { join } = doc.builders;
 
 export class YulPaths implements SlangNode {
   readonly kind = NonterminalKind.YulPaths;
@@ -15,13 +18,10 @@ export class YulPaths implements SlangNode {
 
   items: YulPath[];
 
-  separators: string[];
-
   constructor(ast: ast.YulPaths) {
     let metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new YulPath(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     metadata = updateMetadata(metadata, [this.items]);
 
@@ -30,10 +30,6 @@ export class YulPaths implements SlangNode {
   }
 
   print(path: AstPath<YulPaths>, print: PrintFunction): Doc {
-    return path
-      .map(print, 'items')
-      .map((item, index) =>
-        index === 0 ? item : [this.separators[index - 1], item]
-      );
+    return join(', ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulVariableNames.ts
+++ b/src/slang-nodes/YulVariableNames.ts
@@ -19,13 +19,10 @@ export class YulVariableNames implements SlangNode {
 
   items: YulIdentifier[];
 
-  separators: string[];
-
   constructor(ast: ast.YulVariableNames) {
     const metadata = getNodeMetadata(ast, true);
 
     this.items = ast.items.map((item) => new YulIdentifier(item));
-    this.separators = ast.separators.map((separator) => separator.unparse());
 
     this.comments = metadata.comments;
     this.loc = metadata.loc;

--- a/src/slang-utils/create-hug-function.ts
+++ b/src/slang-utils/create-hug-function.ts
@@ -43,8 +43,7 @@ export function createHugFunction(
                       expression: node
                     }
                   )
-                ],
-                separators: []
+                ]
               }
             )
           }


### PR DESCRIPTION
according to the [documentation](https://github.com/NomicFoundation/slang/blob/f3b51be7ea341be62ef8c6d8a7847765a24af9c6/crates/solidity/outputs/npm/package/src/generated/ast/generated/nodes.mts#L4826) the separator will always be the same for each node.

```TypeScript
/**
 * VersionExpressionSets       = (* item: *) VersionExpressionSet       ((* separator: *) BAR_BAR (* item: *) VersionExpressionSet)*;
 * SimpleVersionLiteral        = (* item: *) VERSION_SPECIFIER          ((* separator: *) PERIOD  (* item: *) VERSION_SPECIFIER)*;
 * ImportDeconstructionSymbols = (* item: *) ImportDeconstructionSymbol ((* separator: *) COMMA   (* item: *) ImportDeconstructionSymbol)*;
 * UsingDeconstructionSymbols  = (* item: *) UsingDeconstructionSymbol  ((* separator: *) COMMA   (* item: *) UsingDeconstructionSymbol)*;
 * InheritanceTypes            = (* item: *) InheritanceType            ((* separator: *) COMMA   (* item: *) InheritanceType)*;
 * EnumMembers                 = ((* item: *) IDENTIFIER                ((* separator: *) COMMA   (* item: *) IDENTIFIER)*)?;
 * Parameters                  = ((* item: *) Parameter                 ((* separator: *) COMMA   (* item: *) Parameter)*)?;
 * OverridePaths               = (* item: *) IdentifierPath             ((* separator: *) COMMA   (* item: *) IdentifierPath)*;
 * EventParameters             = ((* item: *) EventParameter            ((* separator: *) COMMA   (* item: *) EventParameter)*)?;
 * ErrorParameters             = ((* item: *) ErrorParameter            ((* separator: *) COMMA   (* item: *) ErrorParameter)*)?;
 * AssemblyFlags               = (* item: *) StringLiteral              ((* separator: *) COMMA   (* item: *) StringLiteral)*;
 * TupleDeconstructionElements = (* item: *) TupleDeconstructionElement ((* separator: *) COMMA   (* item: *) TupleDeconstructionElement)*;
 * PositionalArguments         = ((* item: *) Expression                ((* separator: *) COMMA   (* item: *) Expression)*)?;
 * NamedArguments              = ((* item: *) NamedArgument             ((* separator: *) COMMA   (* item: *) NamedArgument)*)?;
 * CallOptions                 = (* item: *) NamedArgument              ((* separator: *) COMMA   (* item: *) NamedArgument)*;
 * TupleValues                 = (* item: *) TupleValue                 ((* separator: *) COMMA   (* item: *) TupleValue)*;
 * ArrayValues                 = (* item: *) Expression                 ((* separator: *) COMMA   (* item: *) Expression)*;
 * IdentifierPath              = (* item: *) IDENTIFIER                 ((* separator: *) PERIOD  (* item: *) IDENTIFIER)*;
 * YulParameters               = ((* item: *) YUL_IDENTIFIER            ((* separator: *) COMMA   (* item: *) YUL_IDENTIFIER)*)?;
 * YulVariableNames            = (* item: *) YUL_IDENTIFIER             ((* separator: *) COMMA   (* item: *) YUL_IDENTIFIER)*;
 * YulArguments                = ((* item: *) YulExpression             ((* separator: *) COMMA   (* item: *) YulExpression)*)?;
 * YulPaths                    = (* item: *) YulPath                    ((* separator: *) COMMA   (* item: *) YulPath)*;
 * YulPath                     = (* item: *) YUL_IDENTIFIER             ((* separator: *) PERIOD  (* item: *) YUL_IDENTIFIER)*;
 */
 ```
 
 If in the future there is a separator added that could have different representations according to the situation, we can add logic just for that.