### PR TITLE
Cleaning up variant logic

### DIFF
--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -8,6 +8,26 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.ArgumentsDeclaration['variant'],
+  options: ParserOptions<AstNode>
+): ArgumentsDeclaration['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.PositionalArgumentsDeclaration:
+      return new PositionalArgumentsDeclaration(
+        variant as ast.PositionalArgumentsDeclaration,
+        options
+      );
+    case NonterminalKind.NamedArgumentsDeclaration:
+      return new NamedArgumentsDeclaration(
+        variant as ast.NamedArgumentsDeclaration,
+        options
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ArgumentsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.ArgumentsDeclaration;
 
@@ -16,24 +36,7 @@ export class ArgumentsDeclaration extends SlangNode {
   constructor(ast: ast.ArgumentsDeclaration, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.PositionalArgumentsDeclaration:
-        this.variant = new PositionalArgumentsDeclaration(
-          variant as ast.PositionalArgumentsDeclaration,
-          options
-        );
-        break;
-      case NonterminalKind.NamedArgumentsDeclaration:
-        this.variant = new NamedArgumentsDeclaration(
-          variant as ast.NamedArgumentsDeclaration,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -14,12 +14,12 @@ function createNonterminalVariant(
 ): ArgumentsDeclaration['variant'] {
   if (variant instanceof ast.PositionalArgumentsDeclaration) {
     return new PositionalArgumentsDeclaration(variant, options);
-  } else if (variant instanceof ast.NamedArgumentsDeclaration) {
-    return new NamedArgumentsDeclaration(variant, options);
-  } else {
-    const exhaustiveCheck: never = variant;
-    return exhaustiveCheck;
   }
+  if (variant instanceof ast.NamedArgumentsDeclaration) {
+    return new NamedArgumentsDeclaration(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ArgumentsDeclaration extends SlangNode {

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -1,9 +1,9 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { PositionalArgumentsDeclaration } from './PositionalArgumentsDeclaration.js';
 import { NamedArgumentsDeclaration } from './NamedArgumentsDeclaration.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -12,19 +12,13 @@ function createNonterminalVariant(
   variant: ast.ArgumentsDeclaration['variant'],
   options: ParserOptions<AstNode>
 ): ArgumentsDeclaration['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.PositionalArgumentsDeclaration:
-      return new PositionalArgumentsDeclaration(
-        variant as ast.PositionalArgumentsDeclaration,
-        options
-      );
-    case NonterminalKind.NamedArgumentsDeclaration:
-      return new NamedArgumentsDeclaration(
-        variant as ast.NamedArgumentsDeclaration,
-        options
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.PositionalArgumentsDeclaration) {
+    return new PositionalArgumentsDeclaration(variant, options);
+  } else if (variant instanceof ast.NamedArgumentsDeclaration) {
+    return new NamedArgumentsDeclaration(variant, options);
+  } else {
+    const exhaustiveCheck: never = variant;
+    return exhaustiveCheck;
   }
 }
 

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -16,21 +16,23 @@ export class ArgumentsDeclaration extends SlangNode {
   constructor(ast: ast.ArgumentsDeclaration, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.PositionalArgumentsDeclaration:
         this.variant = new PositionalArgumentsDeclaration(
-          ast.variant as ast.PositionalArgumentsDeclaration,
+          variant as ast.PositionalArgumentsDeclaration,
           options
         );
         break;
       case NonterminalKind.NamedArgumentsDeclaration:
         this.variant = new NamedArgumentsDeclaration(
-          ast.variant as ast.NamedArgumentsDeclaration,
+          variant as ast.NamedArgumentsDeclaration,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -16,11 +16,12 @@ export class ConstructorAttribute extends SlangNode {
   constructor(ast: ast.ConstructorAttribute, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new ModifierInvocation(ast.variant, options);
+    this.variant = new ModifierInvocation(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -15,12 +15,13 @@ export class ConstructorAttribute extends SlangNode {
   constructor(ast: ast.ConstructorAttribute, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new ModifierInvocation(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new ModifierInvocation(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ConstructorAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 
@@ -25,8 +26,6 @@ export class ConstructorAttribute extends SlangNode {
   }
 
   print(path: AstPath<ConstructorAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -19,6 +19,59 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.ContractMember['variant'],
+  options: ParserOptions<AstNode>
+): ContractMember['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.UsingDirective:
+      return new UsingDirective(variant as ast.UsingDirective, options);
+    case NonterminalKind.FunctionDefinition:
+      return new FunctionDefinition(variant as ast.FunctionDefinition, options);
+    case NonterminalKind.ConstructorDefinition:
+      return new ConstructorDefinition(
+        variant as ast.ConstructorDefinition,
+        options
+      );
+    case NonterminalKind.ReceiveFunctionDefinition:
+      return new ReceiveFunctionDefinition(
+        variant as ast.ReceiveFunctionDefinition,
+        options
+      );
+    case NonterminalKind.FallbackFunctionDefinition:
+      return new FallbackFunctionDefinition(
+        variant as ast.FallbackFunctionDefinition,
+        options
+      );
+    case NonterminalKind.UnnamedFunctionDefinition:
+      return new UnnamedFunctionDefinition(
+        variant as ast.UnnamedFunctionDefinition,
+        options
+      );
+    case NonterminalKind.ModifierDefinition:
+      return new ModifierDefinition(variant as ast.ModifierDefinition, options);
+    case NonterminalKind.StructDefinition:
+      return new StructDefinition(variant as ast.StructDefinition, options);
+    case NonterminalKind.EnumDefinition:
+      return new EnumDefinition(variant as ast.EnumDefinition);
+    case NonterminalKind.EventDefinition:
+      return new EventDefinition(variant as ast.EventDefinition, options);
+    case NonterminalKind.StateVariableDefinition:
+      return new StateVariableDefinition(
+        variant as ast.StateVariableDefinition,
+        options
+      );
+    case NonterminalKind.ErrorDefinition:
+      return new ErrorDefinition(variant as ast.ErrorDefinition, options);
+    case NonterminalKind.UserDefinedValueTypeDefinition:
+      return new UserDefinedValueTypeDefinition(
+        variant as ast.UserDefinedValueTypeDefinition
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ContractMember extends SlangNode {
   readonly kind = NonterminalKind.ContractMember;
 
@@ -40,86 +93,7 @@ export class ContractMember extends SlangNode {
   constructor(ast: ast.ContractMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.UsingDirective:
-        this.variant = new UsingDirective(
-          variant as ast.UsingDirective,
-          options
-        );
-        break;
-      case NonterminalKind.FunctionDefinition:
-        this.variant = new FunctionDefinition(
-          variant as ast.FunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ConstructorDefinition:
-        this.variant = new ConstructorDefinition(
-          variant as ast.ConstructorDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ReceiveFunctionDefinition:
-        this.variant = new ReceiveFunctionDefinition(
-          variant as ast.ReceiveFunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.FallbackFunctionDefinition:
-        this.variant = new FallbackFunctionDefinition(
-          variant as ast.FallbackFunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.UnnamedFunctionDefinition:
-        this.variant = new UnnamedFunctionDefinition(
-          variant as ast.UnnamedFunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ModifierDefinition:
-        this.variant = new ModifierDefinition(
-          variant as ast.ModifierDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.StructDefinition:
-        this.variant = new StructDefinition(
-          variant as ast.StructDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(variant as ast.EnumDefinition);
-        break;
-      case NonterminalKind.EventDefinition:
-        this.variant = new EventDefinition(
-          variant as ast.EventDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.StateVariableDefinition:
-        this.variant = new StateVariableDefinition(
-          variant as ast.StateVariableDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ErrorDefinition:
-        this.variant = new ErrorDefinition(
-          variant as ast.ErrorDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.UserDefinedValueTypeDefinition:
-        this.variant = new UserDefinedValueTypeDefinition(
-          variant as ast.UserDefinedValueTypeDefinition
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { UsingDirective } from './UsingDirective.js';
@@ -14,7 +15,6 @@ import { StateVariableDefinition } from './StateVariableDefinition.js';
 import { ErrorDefinition } from './ErrorDefinition.js';
 import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -23,53 +23,47 @@ function createNonterminalVariant(
   variant: ast.ContractMember['variant'],
   options: ParserOptions<AstNode>
 ): ContractMember['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.UsingDirective:
-      return new UsingDirective(variant as ast.UsingDirective, options);
-    case NonterminalKind.FunctionDefinition:
-      return new FunctionDefinition(variant as ast.FunctionDefinition, options);
-    case NonterminalKind.ConstructorDefinition:
-      return new ConstructorDefinition(
-        variant as ast.ConstructorDefinition,
-        options
-      );
-    case NonterminalKind.ReceiveFunctionDefinition:
-      return new ReceiveFunctionDefinition(
-        variant as ast.ReceiveFunctionDefinition,
-        options
-      );
-    case NonterminalKind.FallbackFunctionDefinition:
-      return new FallbackFunctionDefinition(
-        variant as ast.FallbackFunctionDefinition,
-        options
-      );
-    case NonterminalKind.UnnamedFunctionDefinition:
-      return new UnnamedFunctionDefinition(
-        variant as ast.UnnamedFunctionDefinition,
-        options
-      );
-    case NonterminalKind.ModifierDefinition:
-      return new ModifierDefinition(variant as ast.ModifierDefinition, options);
-    case NonterminalKind.StructDefinition:
-      return new StructDefinition(variant as ast.StructDefinition, options);
-    case NonterminalKind.EnumDefinition:
-      return new EnumDefinition(variant as ast.EnumDefinition);
-    case NonterminalKind.EventDefinition:
-      return new EventDefinition(variant as ast.EventDefinition, options);
-    case NonterminalKind.StateVariableDefinition:
-      return new StateVariableDefinition(
-        variant as ast.StateVariableDefinition,
-        options
-      );
-    case NonterminalKind.ErrorDefinition:
-      return new ErrorDefinition(variant as ast.ErrorDefinition, options);
-    case NonterminalKind.UserDefinedValueTypeDefinition:
-      return new UserDefinedValueTypeDefinition(
-        variant as ast.UserDefinedValueTypeDefinition
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.UsingDirective) {
+    return new UsingDirective(variant, options);
   }
+  if (variant instanceof ast.FunctionDefinition) {
+    return new FunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.ConstructorDefinition) {
+    return new ConstructorDefinition(variant, options);
+  }
+  if (variant instanceof ast.ReceiveFunctionDefinition) {
+    return new ReceiveFunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.FallbackFunctionDefinition) {
+    return new FallbackFunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.UnnamedFunctionDefinition) {
+    return new UnnamedFunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.ModifierDefinition) {
+    return new ModifierDefinition(variant, options);
+  }
+  if (variant instanceof ast.StructDefinition) {
+    return new StructDefinition(variant, options);
+  }
+  if (variant instanceof ast.EnumDefinition) {
+    return new EnumDefinition(variant);
+  }
+  if (variant instanceof ast.EventDefinition) {
+    return new EventDefinition(variant, options);
+  }
+  if (variant instanceof ast.StateVariableDefinition) {
+    return new StateVariableDefinition(variant, options);
+  }
+  if (variant instanceof ast.ErrorDefinition) {
+    return new ErrorDefinition(variant, options);
+  }
+  if (variant instanceof ast.UserDefinedValueTypeDefinition) {
+    return new UserDefinedValueTypeDefinition(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ContractMember extends SlangNode {

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -40,83 +40,85 @@ export class ContractMember extends SlangNode {
   constructor(ast: ast.ContractMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.UsingDirective:
         this.variant = new UsingDirective(
-          ast.variant as ast.UsingDirective,
+          variant as ast.UsingDirective,
           options
         );
         break;
       case NonterminalKind.FunctionDefinition:
         this.variant = new FunctionDefinition(
-          ast.variant as ast.FunctionDefinition,
+          variant as ast.FunctionDefinition,
           options
         );
         break;
       case NonterminalKind.ConstructorDefinition:
         this.variant = new ConstructorDefinition(
-          ast.variant as ast.ConstructorDefinition,
+          variant as ast.ConstructorDefinition,
           options
         );
         break;
       case NonterminalKind.ReceiveFunctionDefinition:
         this.variant = new ReceiveFunctionDefinition(
-          ast.variant as ast.ReceiveFunctionDefinition,
+          variant as ast.ReceiveFunctionDefinition,
           options
         );
         break;
       case NonterminalKind.FallbackFunctionDefinition:
         this.variant = new FallbackFunctionDefinition(
-          ast.variant as ast.FallbackFunctionDefinition,
+          variant as ast.FallbackFunctionDefinition,
           options
         );
         break;
       case NonterminalKind.UnnamedFunctionDefinition:
         this.variant = new UnnamedFunctionDefinition(
-          ast.variant as ast.UnnamedFunctionDefinition,
+          variant as ast.UnnamedFunctionDefinition,
           options
         );
         break;
       case NonterminalKind.ModifierDefinition:
         this.variant = new ModifierDefinition(
-          ast.variant as ast.ModifierDefinition,
+          variant as ast.ModifierDefinition,
           options
         );
         break;
       case NonterminalKind.StructDefinition:
         this.variant = new StructDefinition(
-          ast.variant as ast.StructDefinition,
+          variant as ast.StructDefinition,
           options
         );
         break;
       case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(ast.variant as ast.EnumDefinition);
+        this.variant = new EnumDefinition(variant as ast.EnumDefinition);
         break;
       case NonterminalKind.EventDefinition:
         this.variant = new EventDefinition(
-          ast.variant as ast.EventDefinition,
+          variant as ast.EventDefinition,
           options
         );
         break;
       case NonterminalKind.StateVariableDefinition:
         this.variant = new StateVariableDefinition(
-          ast.variant as ast.StateVariableDefinition,
+          variant as ast.StateVariableDefinition,
           options
         );
         break;
       case NonterminalKind.ErrorDefinition:
         this.variant = new ErrorDefinition(
-          ast.variant as ast.ErrorDefinition,
+          variant as ast.ErrorDefinition,
           options
         );
         break;
       case NonterminalKind.UserDefinedValueTypeDefinition:
         this.variant = new UserDefinedValueTypeDefinition(
-          ast.variant as ast.UserDefinedValueTypeDefinition
+          variant as ast.UserDefinedValueTypeDefinition
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -16,21 +16,23 @@ export class ContractSpecifier extends SlangNode {
   constructor(ast: ast.ContractSpecifier, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.InheritanceSpecifier:
         this.variant = new InheritanceSpecifier(
-          ast.variant as ast.InheritanceSpecifier,
+          variant as ast.InheritanceSpecifier,
           options
         );
         break;
       case NonterminalKind.StorageLayoutSpecifier:
         this.variant = new StorageLayoutSpecifier(
-          ast.variant as ast.StorageLayoutSpecifier,
+          variant as ast.StorageLayoutSpecifier,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -8,6 +8,26 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.ContractSpecifier['variant'],
+  options: ParserOptions<AstNode>
+): ContractSpecifier['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.InheritanceSpecifier:
+      return new InheritanceSpecifier(
+        variant as ast.InheritanceSpecifier,
+        options
+      );
+    case NonterminalKind.StorageLayoutSpecifier:
+      return new StorageLayoutSpecifier(
+        variant as ast.StorageLayoutSpecifier,
+        options
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ContractSpecifier extends SlangNode {
   readonly kind = NonterminalKind.ContractSpecifier;
 
@@ -16,24 +36,8 @@ export class ContractSpecifier extends SlangNode {
   constructor(ast: ast.ContractSpecifier, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.InheritanceSpecifier:
-        this.variant = new InheritanceSpecifier(
-          variant as ast.InheritanceSpecifier,
-          options
-        );
-        break;
-      case NonterminalKind.StorageLayoutSpecifier:
-        this.variant = new StorageLayoutSpecifier(
-          variant as ast.StorageLayoutSpecifier,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
+
     this.updateMetadata(this.variant);
   }
 

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -1,9 +1,9 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { StorageLayoutSpecifier } from './StorageLayoutSpecifier.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -12,20 +12,14 @@ function createNonterminalVariant(
   variant: ast.ContractSpecifier['variant'],
   options: ParserOptions<AstNode>
 ): ContractSpecifier['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.InheritanceSpecifier:
-      return new InheritanceSpecifier(
-        variant as ast.InheritanceSpecifier,
-        options
-      );
-    case NonterminalKind.StorageLayoutSpecifier:
-      return new StorageLayoutSpecifier(
-        variant as ast.StorageLayoutSpecifier,
-        options
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.InheritanceSpecifier) {
+    return new InheritanceSpecifier(variant, options);
   }
+  if (variant instanceof ast.StorageLayoutSpecifier) {
+    return new StorageLayoutSpecifier(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ContractSpecifier extends SlangNode {

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { AddressType } from './AddressType.js';
 
@@ -24,8 +25,6 @@ export class ElementaryType extends SlangNode {
   }
 
   print(path: AstPath<ElementaryType>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -15,11 +15,12 @@ export class ElementaryType extends SlangNode {
   constructor(ast: ast.ElementaryType) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new AddressType(ast.variant);
+    this.variant = new AddressType(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -14,12 +14,13 @@ export class ElementaryType extends SlangNode {
   constructor(ast: ast.ElementaryType) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new AddressType(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new AddressType(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ElementaryType>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -1,8 +1,4 @@
-import {
-  NonterminalKind,
-  TerminalKind,
-  TerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
 import { Identifier } from './Identifier.js';
@@ -20,13 +16,13 @@ export class ExperimentalFeature extends SlangNode {
   constructor(ast: ast.ExperimentalFeature, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? new Identifier(ast.variant)
-        : new StringLiteral(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = new Identifier(ast.variant);
+      return;
+    }
+    this.variant = new StringLiteral(ast.variant, options);
 
-    if (this.variant.kind !== TerminalKind.Identifier)
-      this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ExperimentalFeature>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -16,11 +16,12 @@ export class ExperimentalFeature extends SlangNode {
   constructor(ast: ast.ExperimentalFeature, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = new Identifier(ast.variant);
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = new Identifier(variant);
       return;
     }
-    this.variant = new StringLiteral(ast.variant, options);
+    this.variant = new StringLiteral(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -70,170 +70,163 @@ export class Expression extends SlangNode {
   constructor(ast: ast.Expression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = new Identifier(ast.variant);
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = new Identifier(variant);
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.AssignmentExpression:
         this.variant = new AssignmentExpression(
-          ast.variant as ast.AssignmentExpression,
+          variant as ast.AssignmentExpression,
           options
         );
         break;
       case NonterminalKind.ConditionalExpression:
         this.variant = new ConditionalExpression(
-          ast.variant as ast.ConditionalExpression,
+          variant as ast.ConditionalExpression,
           options
         );
         break;
       case NonterminalKind.OrExpression:
-        this.variant = new OrExpression(
-          ast.variant as ast.OrExpression,
-          options
-        );
+        this.variant = new OrExpression(variant as ast.OrExpression, options);
         break;
       case NonterminalKind.AndExpression:
-        this.variant = new AndExpression(
-          ast.variant as ast.AndExpression,
-          options
-        );
+        this.variant = new AndExpression(variant as ast.AndExpression, options);
         break;
       case NonterminalKind.EqualityExpression:
         this.variant = new EqualityExpression(
-          ast.variant as ast.EqualityExpression,
+          variant as ast.EqualityExpression,
           options
         );
         break;
       case NonterminalKind.InequalityExpression:
         this.variant = new InequalityExpression(
-          ast.variant as ast.InequalityExpression,
+          variant as ast.InequalityExpression,
           options
         );
         break;
       case NonterminalKind.BitwiseOrExpression:
         this.variant = new BitwiseOrExpression(
-          ast.variant as ast.BitwiseOrExpression,
+          variant as ast.BitwiseOrExpression,
           options
         );
         break;
       case NonterminalKind.BitwiseXorExpression:
         this.variant = new BitwiseXorExpression(
-          ast.variant as ast.BitwiseXorExpression,
+          variant as ast.BitwiseXorExpression,
           options
         );
         break;
       case NonterminalKind.BitwiseAndExpression:
         this.variant = new BitwiseAndExpression(
-          ast.variant as ast.BitwiseAndExpression,
+          variant as ast.BitwiseAndExpression,
           options
         );
         break;
       case NonterminalKind.ShiftExpression:
         this.variant = new ShiftExpression(
-          ast.variant as ast.ShiftExpression,
+          variant as ast.ShiftExpression,
           options
         );
         break;
       case NonterminalKind.AdditiveExpression:
         this.variant = new AdditiveExpression(
-          ast.variant as ast.AdditiveExpression,
+          variant as ast.AdditiveExpression,
           options
         );
         break;
       case NonterminalKind.MultiplicativeExpression:
         this.variant = new MultiplicativeExpression(
-          ast.variant as ast.MultiplicativeExpression,
+          variant as ast.MultiplicativeExpression,
           options
         );
         break;
       case NonterminalKind.ExponentiationExpression:
         this.variant = new ExponentiationExpression(
-          ast.variant as ast.ExponentiationExpression,
+          variant as ast.ExponentiationExpression,
           options
         );
         break;
       case NonterminalKind.PostfixExpression:
         this.variant = new PostfixExpression(
-          ast.variant as ast.PostfixExpression,
+          variant as ast.PostfixExpression,
           options
         );
         break;
       case NonterminalKind.PrefixExpression:
         this.variant = new PrefixExpression(
-          ast.variant as ast.PrefixExpression,
+          variant as ast.PrefixExpression,
           options
         );
         break;
       case NonterminalKind.FunctionCallExpression:
         this.variant = new FunctionCallExpression(
-          ast.variant as ast.FunctionCallExpression,
+          variant as ast.FunctionCallExpression,
           options
         );
         break;
       case NonterminalKind.CallOptionsExpression:
         this.variant = new CallOptionsExpression(
-          ast.variant as ast.CallOptionsExpression,
+          variant as ast.CallOptionsExpression,
           options
         );
         break;
       case NonterminalKind.MemberAccessExpression:
         this.variant = new MemberAccessExpression(
-          ast.variant as ast.MemberAccessExpression,
+          variant as ast.MemberAccessExpression,
           options
         );
         break;
       case NonterminalKind.IndexAccessExpression:
         this.variant = new IndexAccessExpression(
-          ast.variant as ast.IndexAccessExpression,
+          variant as ast.IndexAccessExpression,
           options
         );
         break;
       case NonterminalKind.NewExpression:
-        this.variant = new NewExpression(
-          ast.variant as ast.NewExpression,
-          options
-        );
+        this.variant = new NewExpression(variant as ast.NewExpression, options);
         break;
       case NonterminalKind.TupleExpression:
         this.variant = new TupleExpression(
-          ast.variant as ast.TupleExpression,
+          variant as ast.TupleExpression,
           options
         );
         break;
       case NonterminalKind.TypeExpression:
         this.variant = new TypeExpression(
-          ast.variant as ast.TypeExpression,
+          variant as ast.TypeExpression,
           options
         );
         break;
       case NonterminalKind.ArrayExpression:
         this.variant = new ArrayExpression(
-          ast.variant as ast.ArrayExpression,
+          variant as ast.ArrayExpression,
           options
         );
         break;
       case NonterminalKind.HexNumberExpression:
         this.variant = new HexNumberExpression(
-          ast.variant as ast.HexNumberExpression
+          variant as ast.HexNumberExpression
         );
         break;
       case NonterminalKind.DecimalNumberExpression:
         this.variant = new DecimalNumberExpression(
-          ast.variant as ast.DecimalNumberExpression
+          variant as ast.DecimalNumberExpression
         );
         break;
       case NonterminalKind.StringExpression:
         this.variant = new StringExpression(
-          ast.variant as ast.StringExpression,
+          variant as ast.StringExpression,
           options
         );
         break;
       case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
+        this.variant = new ElementaryType(variant as ast.ElementaryType);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -34,6 +34,108 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.Expression['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<Expression['variant'], Identifier> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.AssignmentExpression:
+      return new AssignmentExpression(
+        variant as ast.AssignmentExpression,
+        options
+      );
+    case NonterminalKind.ConditionalExpression:
+      return new ConditionalExpression(
+        variant as ast.ConditionalExpression,
+        options
+      );
+    case NonterminalKind.OrExpression:
+      return new OrExpression(variant as ast.OrExpression, options);
+    case NonterminalKind.AndExpression:
+      return new AndExpression(variant as ast.AndExpression, options);
+    case NonterminalKind.EqualityExpression:
+      return new EqualityExpression(variant as ast.EqualityExpression, options);
+    case NonterminalKind.InequalityExpression:
+      return new InequalityExpression(
+        variant as ast.InequalityExpression,
+        options
+      );
+    case NonterminalKind.BitwiseOrExpression:
+      return new BitwiseOrExpression(
+        variant as ast.BitwiseOrExpression,
+        options
+      );
+    case NonterminalKind.BitwiseXorExpression:
+      return new BitwiseXorExpression(
+        variant as ast.BitwiseXorExpression,
+        options
+      );
+    case NonterminalKind.BitwiseAndExpression:
+      return new BitwiseAndExpression(
+        variant as ast.BitwiseAndExpression,
+        options
+      );
+    case NonterminalKind.ShiftExpression:
+      return new ShiftExpression(variant as ast.ShiftExpression, options);
+    case NonterminalKind.AdditiveExpression:
+      return new AdditiveExpression(variant as ast.AdditiveExpression, options);
+    case NonterminalKind.MultiplicativeExpression:
+      return new MultiplicativeExpression(
+        variant as ast.MultiplicativeExpression,
+        options
+      );
+    case NonterminalKind.ExponentiationExpression:
+      return new ExponentiationExpression(
+        variant as ast.ExponentiationExpression,
+        options
+      );
+    case NonterminalKind.PostfixExpression:
+      return new PostfixExpression(variant as ast.PostfixExpression, options);
+    case NonterminalKind.PrefixExpression:
+      return new PrefixExpression(variant as ast.PrefixExpression, options);
+    case NonterminalKind.FunctionCallExpression:
+      return new FunctionCallExpression(
+        variant as ast.FunctionCallExpression,
+        options
+      );
+    case NonterminalKind.CallOptionsExpression:
+      return new CallOptionsExpression(
+        variant as ast.CallOptionsExpression,
+        options
+      );
+    case NonterminalKind.MemberAccessExpression:
+      return new MemberAccessExpression(
+        variant as ast.MemberAccessExpression,
+        options
+      );
+    case NonterminalKind.IndexAccessExpression:
+      return new IndexAccessExpression(
+        variant as ast.IndexAccessExpression,
+        options
+      );
+    case NonterminalKind.NewExpression:
+      return new NewExpression(variant as ast.NewExpression, options);
+    case NonterminalKind.TupleExpression:
+      return new TupleExpression(variant as ast.TupleExpression, options);
+    case NonterminalKind.TypeExpression:
+      return new TypeExpression(variant as ast.TypeExpression, options);
+    case NonterminalKind.ArrayExpression:
+      return new ArrayExpression(variant as ast.ArrayExpression, options);
+    case NonterminalKind.HexNumberExpression:
+      return new HexNumberExpression(variant as ast.HexNumberExpression);
+    case NonterminalKind.DecimalNumberExpression:
+      return new DecimalNumberExpression(
+        variant as ast.DecimalNumberExpression
+      );
+    case NonterminalKind.StringExpression:
+      return new StringExpression(variant as ast.StringExpression, options);
+    case NonterminalKind.ElementaryType:
+      return new ElementaryType(variant as ast.ElementaryType);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class Expression extends SlangNode {
   readonly kind = NonterminalKind.Expression;
 
@@ -75,159 +177,7 @@ export class Expression extends SlangNode {
       this.variant = new Identifier(variant);
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.AssignmentExpression:
-        this.variant = new AssignmentExpression(
-          variant as ast.AssignmentExpression,
-          options
-        );
-        break;
-      case NonterminalKind.ConditionalExpression:
-        this.variant = new ConditionalExpression(
-          variant as ast.ConditionalExpression,
-          options
-        );
-        break;
-      case NonterminalKind.OrExpression:
-        this.variant = new OrExpression(variant as ast.OrExpression, options);
-        break;
-      case NonterminalKind.AndExpression:
-        this.variant = new AndExpression(variant as ast.AndExpression, options);
-        break;
-      case NonterminalKind.EqualityExpression:
-        this.variant = new EqualityExpression(
-          variant as ast.EqualityExpression,
-          options
-        );
-        break;
-      case NonterminalKind.InequalityExpression:
-        this.variant = new InequalityExpression(
-          variant as ast.InequalityExpression,
-          options
-        );
-        break;
-      case NonterminalKind.BitwiseOrExpression:
-        this.variant = new BitwiseOrExpression(
-          variant as ast.BitwiseOrExpression,
-          options
-        );
-        break;
-      case NonterminalKind.BitwiseXorExpression:
-        this.variant = new BitwiseXorExpression(
-          variant as ast.BitwiseXorExpression,
-          options
-        );
-        break;
-      case NonterminalKind.BitwiseAndExpression:
-        this.variant = new BitwiseAndExpression(
-          variant as ast.BitwiseAndExpression,
-          options
-        );
-        break;
-      case NonterminalKind.ShiftExpression:
-        this.variant = new ShiftExpression(
-          variant as ast.ShiftExpression,
-          options
-        );
-        break;
-      case NonterminalKind.AdditiveExpression:
-        this.variant = new AdditiveExpression(
-          variant as ast.AdditiveExpression,
-          options
-        );
-        break;
-      case NonterminalKind.MultiplicativeExpression:
-        this.variant = new MultiplicativeExpression(
-          variant as ast.MultiplicativeExpression,
-          options
-        );
-        break;
-      case NonterminalKind.ExponentiationExpression:
-        this.variant = new ExponentiationExpression(
-          variant as ast.ExponentiationExpression,
-          options
-        );
-        break;
-      case NonterminalKind.PostfixExpression:
-        this.variant = new PostfixExpression(
-          variant as ast.PostfixExpression,
-          options
-        );
-        break;
-      case NonterminalKind.PrefixExpression:
-        this.variant = new PrefixExpression(
-          variant as ast.PrefixExpression,
-          options
-        );
-        break;
-      case NonterminalKind.FunctionCallExpression:
-        this.variant = new FunctionCallExpression(
-          variant as ast.FunctionCallExpression,
-          options
-        );
-        break;
-      case NonterminalKind.CallOptionsExpression:
-        this.variant = new CallOptionsExpression(
-          variant as ast.CallOptionsExpression,
-          options
-        );
-        break;
-      case NonterminalKind.MemberAccessExpression:
-        this.variant = new MemberAccessExpression(
-          variant as ast.MemberAccessExpression,
-          options
-        );
-        break;
-      case NonterminalKind.IndexAccessExpression:
-        this.variant = new IndexAccessExpression(
-          variant as ast.IndexAccessExpression,
-          options
-        );
-        break;
-      case NonterminalKind.NewExpression:
-        this.variant = new NewExpression(variant as ast.NewExpression, options);
-        break;
-      case NonterminalKind.TupleExpression:
-        this.variant = new TupleExpression(
-          variant as ast.TupleExpression,
-          options
-        );
-        break;
-      case NonterminalKind.TypeExpression:
-        this.variant = new TypeExpression(
-          variant as ast.TypeExpression,
-          options
-        );
-        break;
-      case NonterminalKind.ArrayExpression:
-        this.variant = new ArrayExpression(
-          variant as ast.ArrayExpression,
-          options
-        );
-        break;
-      case NonterminalKind.HexNumberExpression:
-        this.variant = new HexNumberExpression(
-          variant as ast.HexNumberExpression
-        );
-        break;
-      case NonterminalKind.DecimalNumberExpression:
-        this.variant = new DecimalNumberExpression(
-          variant as ast.DecimalNumberExpression
-        );
-        break;
-      case NonterminalKind.StringExpression:
-        this.variant = new StringExpression(
-          variant as ast.StringExpression,
-          options
-        );
-        break;
-      case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(variant as ast.ElementaryType);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { AssignmentExpression } from './AssignmentExpression.js';
@@ -29,7 +30,6 @@ import { StringExpression } from './StringExpression.js';
 import { ElementaryType } from './ElementaryType.js';
 import { Identifier } from './Identifier.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -38,102 +38,89 @@ function createNonterminalVariant(
   variant: Exclude<ast.Expression['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<Expression['variant'], Identifier> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.AssignmentExpression:
-      return new AssignmentExpression(
-        variant as ast.AssignmentExpression,
-        options
-      );
-    case NonterminalKind.ConditionalExpression:
-      return new ConditionalExpression(
-        variant as ast.ConditionalExpression,
-        options
-      );
-    case NonterminalKind.OrExpression:
-      return new OrExpression(variant as ast.OrExpression, options);
-    case NonterminalKind.AndExpression:
-      return new AndExpression(variant as ast.AndExpression, options);
-    case NonterminalKind.EqualityExpression:
-      return new EqualityExpression(variant as ast.EqualityExpression, options);
-    case NonterminalKind.InequalityExpression:
-      return new InequalityExpression(
-        variant as ast.InequalityExpression,
-        options
-      );
-    case NonterminalKind.BitwiseOrExpression:
-      return new BitwiseOrExpression(
-        variant as ast.BitwiseOrExpression,
-        options
-      );
-    case NonterminalKind.BitwiseXorExpression:
-      return new BitwiseXorExpression(
-        variant as ast.BitwiseXorExpression,
-        options
-      );
-    case NonterminalKind.BitwiseAndExpression:
-      return new BitwiseAndExpression(
-        variant as ast.BitwiseAndExpression,
-        options
-      );
-    case NonterminalKind.ShiftExpression:
-      return new ShiftExpression(variant as ast.ShiftExpression, options);
-    case NonterminalKind.AdditiveExpression:
-      return new AdditiveExpression(variant as ast.AdditiveExpression, options);
-    case NonterminalKind.MultiplicativeExpression:
-      return new MultiplicativeExpression(
-        variant as ast.MultiplicativeExpression,
-        options
-      );
-    case NonterminalKind.ExponentiationExpression:
-      return new ExponentiationExpression(
-        variant as ast.ExponentiationExpression,
-        options
-      );
-    case NonterminalKind.PostfixExpression:
-      return new PostfixExpression(variant as ast.PostfixExpression, options);
-    case NonterminalKind.PrefixExpression:
-      return new PrefixExpression(variant as ast.PrefixExpression, options);
-    case NonterminalKind.FunctionCallExpression:
-      return new FunctionCallExpression(
-        variant as ast.FunctionCallExpression,
-        options
-      );
-    case NonterminalKind.CallOptionsExpression:
-      return new CallOptionsExpression(
-        variant as ast.CallOptionsExpression,
-        options
-      );
-    case NonterminalKind.MemberAccessExpression:
-      return new MemberAccessExpression(
-        variant as ast.MemberAccessExpression,
-        options
-      );
-    case NonterminalKind.IndexAccessExpression:
-      return new IndexAccessExpression(
-        variant as ast.IndexAccessExpression,
-        options
-      );
-    case NonterminalKind.NewExpression:
-      return new NewExpression(variant as ast.NewExpression, options);
-    case NonterminalKind.TupleExpression:
-      return new TupleExpression(variant as ast.TupleExpression, options);
-    case NonterminalKind.TypeExpression:
-      return new TypeExpression(variant as ast.TypeExpression, options);
-    case NonterminalKind.ArrayExpression:
-      return new ArrayExpression(variant as ast.ArrayExpression, options);
-    case NonterminalKind.HexNumberExpression:
-      return new HexNumberExpression(variant as ast.HexNumberExpression);
-    case NonterminalKind.DecimalNumberExpression:
-      return new DecimalNumberExpression(
-        variant as ast.DecimalNumberExpression
-      );
-    case NonterminalKind.StringExpression:
-      return new StringExpression(variant as ast.StringExpression, options);
-    case NonterminalKind.ElementaryType:
-      return new ElementaryType(variant as ast.ElementaryType);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.AssignmentExpression) {
+    return new AssignmentExpression(variant, options);
   }
+  if (variant instanceof ast.ConditionalExpression) {
+    return new ConditionalExpression(variant, options);
+  }
+  if (variant instanceof ast.OrExpression) {
+    return new OrExpression(variant, options);
+  }
+  if (variant instanceof ast.AndExpression) {
+    return new AndExpression(variant, options);
+  }
+  if (variant instanceof ast.EqualityExpression) {
+    return new EqualityExpression(variant, options);
+  }
+  if (variant instanceof ast.InequalityExpression) {
+    return new InequalityExpression(variant, options);
+  }
+  if (variant instanceof ast.BitwiseOrExpression) {
+    return new BitwiseOrExpression(variant, options);
+  }
+  if (variant instanceof ast.BitwiseXorExpression) {
+    return new BitwiseXorExpression(variant, options);
+  }
+  if (variant instanceof ast.BitwiseAndExpression) {
+    return new BitwiseAndExpression(variant, options);
+  }
+  if (variant instanceof ast.ShiftExpression) {
+    return new ShiftExpression(variant, options);
+  }
+  if (variant instanceof ast.AdditiveExpression) {
+    return new AdditiveExpression(variant, options);
+  }
+  if (variant instanceof ast.MultiplicativeExpression) {
+    return new MultiplicativeExpression(variant, options);
+  }
+  if (variant instanceof ast.ExponentiationExpression) {
+    return new ExponentiationExpression(variant, options);
+  }
+  if (variant instanceof ast.PostfixExpression) {
+    return new PostfixExpression(variant, options);
+  }
+  if (variant instanceof ast.PrefixExpression) {
+    return new PrefixExpression(variant, options);
+  }
+  if (variant instanceof ast.FunctionCallExpression) {
+    return new FunctionCallExpression(variant, options);
+  }
+  if (variant instanceof ast.CallOptionsExpression) {
+    return new CallOptionsExpression(variant, options);
+  }
+  if (variant instanceof ast.MemberAccessExpression) {
+    return new MemberAccessExpression(variant, options);
+  }
+  if (variant instanceof ast.IndexAccessExpression) {
+    return new IndexAccessExpression(variant, options);
+  }
+  if (variant instanceof ast.NewExpression) {
+    return new NewExpression(variant, options);
+  }
+  if (variant instanceof ast.TupleExpression) {
+    return new TupleExpression(variant, options);
+  }
+  if (variant instanceof ast.TypeExpression) {
+    return new TypeExpression(variant, options);
+  }
+  if (variant instanceof ast.ArrayExpression) {
+    return new ArrayExpression(variant, options);
+  }
+  if (variant instanceof ast.HexNumberExpression) {
+    return new HexNumberExpression(variant);
+  }
+  if (variant instanceof ast.DecimalNumberExpression) {
+    return new DecimalNumberExpression(variant);
+  }
+  if (variant instanceof ast.StringExpression) {
+    return new StringExpression(variant, options);
+  }
+  if (variant instanceof ast.ElementaryType) {
+    return new ElementaryType(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class Expression extends SlangNode {

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -1,8 +1,4 @@
-import {
-  NonterminalKind,
-  TerminalKind,
-  TerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { AssignmentExpression } from './AssignmentExpression.js';
 import { ConditionalExpression } from './ConditionalExpression.js';
@@ -76,172 +72,171 @@ export class Expression extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = new Identifier(ast.variant);
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.AssignmentExpression:
-          this.variant = new AssignmentExpression(
-            ast.variant as ast.AssignmentExpression,
-            options
-          );
-          break;
-        case NonterminalKind.ConditionalExpression:
-          this.variant = new ConditionalExpression(
-            ast.variant as ast.ConditionalExpression,
-            options
-          );
-          break;
-        case NonterminalKind.OrExpression:
-          this.variant = new OrExpression(
-            ast.variant as ast.OrExpression,
-            options
-          );
-          break;
-        case NonterminalKind.AndExpression:
-          this.variant = new AndExpression(
-            ast.variant as ast.AndExpression,
-            options
-          );
-          break;
-        case NonterminalKind.EqualityExpression:
-          this.variant = new EqualityExpression(
-            ast.variant as ast.EqualityExpression,
-            options
-          );
-          break;
-        case NonterminalKind.InequalityExpression:
-          this.variant = new InequalityExpression(
-            ast.variant as ast.InequalityExpression,
-            options
-          );
-          break;
-        case NonterminalKind.BitwiseOrExpression:
-          this.variant = new BitwiseOrExpression(
-            ast.variant as ast.BitwiseOrExpression,
-            options
-          );
-          break;
-        case NonterminalKind.BitwiseXorExpression:
-          this.variant = new BitwiseXorExpression(
-            ast.variant as ast.BitwiseXorExpression,
-            options
-          );
-          break;
-        case NonterminalKind.BitwiseAndExpression:
-          this.variant = new BitwiseAndExpression(
-            ast.variant as ast.BitwiseAndExpression,
-            options
-          );
-          break;
-        case NonterminalKind.ShiftExpression:
-          this.variant = new ShiftExpression(
-            ast.variant as ast.ShiftExpression,
-            options
-          );
-          break;
-        case NonterminalKind.AdditiveExpression:
-          this.variant = new AdditiveExpression(
-            ast.variant as ast.AdditiveExpression,
-            options
-          );
-          break;
-        case NonterminalKind.MultiplicativeExpression:
-          this.variant = new MultiplicativeExpression(
-            ast.variant as ast.MultiplicativeExpression,
-            options
-          );
-          break;
-        case NonterminalKind.ExponentiationExpression:
-          this.variant = new ExponentiationExpression(
-            ast.variant as ast.ExponentiationExpression,
-            options
-          );
-          break;
-        case NonterminalKind.PostfixExpression:
-          this.variant = new PostfixExpression(
-            ast.variant as ast.PostfixExpression,
-            options
-          );
-          break;
-        case NonterminalKind.PrefixExpression:
-          this.variant = new PrefixExpression(
-            ast.variant as ast.PrefixExpression,
-            options
-          );
-          break;
-        case NonterminalKind.FunctionCallExpression:
-          this.variant = new FunctionCallExpression(
-            ast.variant as ast.FunctionCallExpression,
-            options
-          );
-          break;
-        case NonterminalKind.CallOptionsExpression:
-          this.variant = new CallOptionsExpression(
-            ast.variant as ast.CallOptionsExpression,
-            options
-          );
-          break;
-        case NonterminalKind.MemberAccessExpression:
-          this.variant = new MemberAccessExpression(
-            ast.variant as ast.MemberAccessExpression,
-            options
-          );
-          break;
-        case NonterminalKind.IndexAccessExpression:
-          this.variant = new IndexAccessExpression(
-            ast.variant as ast.IndexAccessExpression,
-            options
-          );
-          break;
-        case NonterminalKind.NewExpression:
-          this.variant = new NewExpression(
-            ast.variant as ast.NewExpression,
-            options
-          );
-          break;
-        case NonterminalKind.TupleExpression:
-          this.variant = new TupleExpression(
-            ast.variant as ast.TupleExpression,
-            options
-          );
-          break;
-        case NonterminalKind.TypeExpression:
-          this.variant = new TypeExpression(
-            ast.variant as ast.TypeExpression,
-            options
-          );
-          break;
-        case NonterminalKind.ArrayExpression:
-          this.variant = new ArrayExpression(
-            ast.variant as ast.ArrayExpression,
-            options
-          );
-          break;
-        case NonterminalKind.HexNumberExpression:
-          this.variant = new HexNumberExpression(
-            ast.variant as ast.HexNumberExpression
-          );
-          break;
-        case NonterminalKind.DecimalNumberExpression:
-          this.variant = new DecimalNumberExpression(
-            ast.variant as ast.DecimalNumberExpression
-          );
-          break;
-        case NonterminalKind.StringExpression:
-          this.variant = new StringExpression(
-            ast.variant as ast.StringExpression,
-            options
-          );
-          break;
-        case NonterminalKind.ElementaryType:
-          this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.AssignmentExpression:
+        this.variant = new AssignmentExpression(
+          ast.variant as ast.AssignmentExpression,
+          options
+        );
+        break;
+      case NonterminalKind.ConditionalExpression:
+        this.variant = new ConditionalExpression(
+          ast.variant as ast.ConditionalExpression,
+          options
+        );
+        break;
+      case NonterminalKind.OrExpression:
+        this.variant = new OrExpression(
+          ast.variant as ast.OrExpression,
+          options
+        );
+        break;
+      case NonterminalKind.AndExpression:
+        this.variant = new AndExpression(
+          ast.variant as ast.AndExpression,
+          options
+        );
+        break;
+      case NonterminalKind.EqualityExpression:
+        this.variant = new EqualityExpression(
+          ast.variant as ast.EqualityExpression,
+          options
+        );
+        break;
+      case NonterminalKind.InequalityExpression:
+        this.variant = new InequalityExpression(
+          ast.variant as ast.InequalityExpression,
+          options
+        );
+        break;
+      case NonterminalKind.BitwiseOrExpression:
+        this.variant = new BitwiseOrExpression(
+          ast.variant as ast.BitwiseOrExpression,
+          options
+        );
+        break;
+      case NonterminalKind.BitwiseXorExpression:
+        this.variant = new BitwiseXorExpression(
+          ast.variant as ast.BitwiseXorExpression,
+          options
+        );
+        break;
+      case NonterminalKind.BitwiseAndExpression:
+        this.variant = new BitwiseAndExpression(
+          ast.variant as ast.BitwiseAndExpression,
+          options
+        );
+        break;
+      case NonterminalKind.ShiftExpression:
+        this.variant = new ShiftExpression(
+          ast.variant as ast.ShiftExpression,
+          options
+        );
+        break;
+      case NonterminalKind.AdditiveExpression:
+        this.variant = new AdditiveExpression(
+          ast.variant as ast.AdditiveExpression,
+          options
+        );
+        break;
+      case NonterminalKind.MultiplicativeExpression:
+        this.variant = new MultiplicativeExpression(
+          ast.variant as ast.MultiplicativeExpression,
+          options
+        );
+        break;
+      case NonterminalKind.ExponentiationExpression:
+        this.variant = new ExponentiationExpression(
+          ast.variant as ast.ExponentiationExpression,
+          options
+        );
+        break;
+      case NonterminalKind.PostfixExpression:
+        this.variant = new PostfixExpression(
+          ast.variant as ast.PostfixExpression,
+          options
+        );
+        break;
+      case NonterminalKind.PrefixExpression:
+        this.variant = new PrefixExpression(
+          ast.variant as ast.PrefixExpression,
+          options
+        );
+        break;
+      case NonterminalKind.FunctionCallExpression:
+        this.variant = new FunctionCallExpression(
+          ast.variant as ast.FunctionCallExpression,
+          options
+        );
+        break;
+      case NonterminalKind.CallOptionsExpression:
+        this.variant = new CallOptionsExpression(
+          ast.variant as ast.CallOptionsExpression,
+          options
+        );
+        break;
+      case NonterminalKind.MemberAccessExpression:
+        this.variant = new MemberAccessExpression(
+          ast.variant as ast.MemberAccessExpression,
+          options
+        );
+        break;
+      case NonterminalKind.IndexAccessExpression:
+        this.variant = new IndexAccessExpression(
+          ast.variant as ast.IndexAccessExpression,
+          options
+        );
+        break;
+      case NonterminalKind.NewExpression:
+        this.variant = new NewExpression(
+          ast.variant as ast.NewExpression,
+          options
+        );
+        break;
+      case NonterminalKind.TupleExpression:
+        this.variant = new TupleExpression(
+          ast.variant as ast.TupleExpression,
+          options
+        );
+        break;
+      case NonterminalKind.TypeExpression:
+        this.variant = new TypeExpression(
+          ast.variant as ast.TypeExpression,
+          options
+        );
+        break;
+      case NonterminalKind.ArrayExpression:
+        this.variant = new ArrayExpression(
+          ast.variant as ast.ArrayExpression,
+          options
+        );
+        break;
+      case NonterminalKind.HexNumberExpression:
+        this.variant = new HexNumberExpression(
+          ast.variant as ast.HexNumberExpression
+        );
+        break;
+      case NonterminalKind.DecimalNumberExpression:
+        this.variant = new DecimalNumberExpression(
+          ast.variant as ast.DecimalNumberExpression
+        );
+        break;
+      case NonterminalKind.StringExpression:
+        this.variant = new StringExpression(
+          ast.variant as ast.StringExpression,
+          options
+        );
+        break;
+      case NonterminalKind.ElementaryType:
+        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (this.variant.kind !== TerminalKind.Identifier)
-      this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<Expression>, print: PrintFunction): Doc {

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -20,24 +20,24 @@ export class FallbackFunctionAttribute extends SlangNode {
   ) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ModifierInvocation:
         this.variant = new ModifierInvocation(
-          ast.variant as ast.ModifierInvocation,
+          variant as ast.ModifierInvocation,
           options
         );
         break;
       case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(
-          ast.variant as ast.OverrideSpecifier
-        );
+        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -21,25 +21,25 @@ export class FallbackFunctionAttribute extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.ModifierInvocation:
-          this.variant = new ModifierInvocation(
-            ast.variant as ast.ModifierInvocation,
-            options
-          );
-          break;
-        case NonterminalKind.OverrideSpecifier:
-          this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier
-          );
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.ModifierInvocation:
+        this.variant = new ModifierInvocation(
+          ast.variant as ast.ModifierInvocation,
+          options
+        );
+        break;
+      case NonterminalKind.OverrideSpecifier:
+        this.variant = new OverrideSpecifier(
+          ast.variant as ast.OverrideSpecifier
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<FallbackFunctionAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
@@ -43,8 +44,6 @@ export class FallbackFunctionAttribute extends SlangNode {
   }
 
   print(path: AstPath<FallbackFunctionAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -9,6 +9,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.FallbackFunctionAttribute['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<FallbackFunctionAttribute['variant'], string> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ModifierInvocation:
+      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
+    case NonterminalKind.OverrideSpecifier:
+      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class FallbackFunctionAttribute extends SlangNode {
   readonly kind = NonterminalKind.FallbackFunctionAttribute;
 
@@ -25,20 +39,7 @@ export class FallbackFunctionAttribute extends SlangNode {
       this.variant = variant.unparse();
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ModifierInvocation:
-        this.variant = new ModifierInvocation(
-          variant as ast.ModifierInvocation,
-          options
-        );
-        break;
-      case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,14 +13,14 @@ function createNonterminalVariant(
   variant: Exclude<ast.FallbackFunctionAttribute['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<FallbackFunctionAttribute['variant'], string> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ModifierInvocation:
-      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
-    case NonterminalKind.OverrideSpecifier:
-      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ModifierInvocation) {
+    return new ModifierInvocation(variant, options);
   }
+  if (variant instanceof ast.OverrideSpecifier) {
+    return new OverrideSpecifier(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class FallbackFunctionAttribute extends SlangNode {

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -16,11 +16,12 @@ export class ForStatementCondition extends SlangNode {
   constructor(ast: ast.ForStatementCondition, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new ExpressionStatement(ast.variant, options);
+    this.variant = new ExpressionStatement(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 
@@ -25,8 +26,6 @@ export class ForStatementCondition extends SlangNode {
   }
 
   print(path: AstPath<ForStatementCondition>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -15,12 +15,13 @@ export class ForStatementCondition extends SlangNode {
   constructor(ast: ast.ForStatementCondition, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new ExpressionStatement(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new ExpressionStatement(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ForStatementCondition>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -25,31 +25,33 @@ export class ForStatementInitialization extends SlangNode {
   ) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ExpressionStatement:
         this.variant = new ExpressionStatement(
-          ast.variant as ast.ExpressionStatement,
+          variant as ast.ExpressionStatement,
           options
         );
         break;
       case NonterminalKind.VariableDeclarationStatement:
         this.variant = new VariableDeclarationStatement(
-          ast.variant as ast.VariableDeclarationStatement,
+          variant as ast.VariableDeclarationStatement,
           options
         );
         break;
       case NonterminalKind.TupleDeconstructionStatement:
         this.variant = new TupleDeconstructionStatement(
-          ast.variant as ast.TupleDeconstructionStatement,
+          variant as ast.TupleDeconstructionStatement,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -5,7 +6,6 @@ import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -14,25 +14,17 @@ function createNonterminalVariant(
   variant: Exclude<ast.ForStatementInitialization['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<ForStatementInitialization['variant'], string> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ExpressionStatement:
-      return new ExpressionStatement(
-        variant as ast.ExpressionStatement,
-        options
-      );
-    case NonterminalKind.VariableDeclarationStatement:
-      return new VariableDeclarationStatement(
-        variant as ast.VariableDeclarationStatement,
-        options
-      );
-    case NonterminalKind.TupleDeconstructionStatement:
-      return new TupleDeconstructionStatement(
-        variant as ast.TupleDeconstructionStatement,
-        options
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ExpressionStatement) {
+    return new ExpressionStatement(variant, options);
   }
+  if (variant instanceof ast.VariableDeclarationStatement) {
+    return new VariableDeclarationStatement(variant, options);
+  }
+  if (variant instanceof ast.TupleDeconstructionStatement) {
+    return new TupleDeconstructionStatement(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ForStatementInitialization extends SlangNode {

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -10,6 +10,31 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.ForStatementInitialization['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<ForStatementInitialization['variant'], string> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ExpressionStatement:
+      return new ExpressionStatement(
+        variant as ast.ExpressionStatement,
+        options
+      );
+    case NonterminalKind.VariableDeclarationStatement:
+      return new VariableDeclarationStatement(
+        variant as ast.VariableDeclarationStatement,
+        options
+      );
+    case NonterminalKind.TupleDeconstructionStatement:
+      return new TupleDeconstructionStatement(
+        variant as ast.TupleDeconstructionStatement,
+        options
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ForStatementInitialization extends SlangNode {
   readonly kind = NonterminalKind.ForStatementInitialization;
 
@@ -30,29 +55,7 @@ export class ForStatementInitialization extends SlangNode {
       this.variant = variant.unparse();
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ExpressionStatement:
-        this.variant = new ExpressionStatement(
-          variant as ast.ExpressionStatement,
-          options
-        );
-        break;
-      case NonterminalKind.VariableDeclarationStatement:
-        this.variant = new VariableDeclarationStatement(
-          variant as ast.VariableDeclarationStatement,
-          options
-        );
-        break;
-      case NonterminalKind.TupleDeconstructionStatement:
-        this.variant = new TupleDeconstructionStatement(
-          variant as ast.TupleDeconstructionStatement,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -26,32 +26,32 @@ export class ForStatementInitialization extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.ExpressionStatement:
-          this.variant = new ExpressionStatement(
-            ast.variant as ast.ExpressionStatement,
-            options
-          );
-          break;
-        case NonterminalKind.VariableDeclarationStatement:
-          this.variant = new VariableDeclarationStatement(
-            ast.variant as ast.VariableDeclarationStatement,
-            options
-          );
-          break;
-        case NonterminalKind.TupleDeconstructionStatement:
-          this.variant = new TupleDeconstructionStatement(
-            ast.variant as ast.TupleDeconstructionStatement,
-            options
-          );
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.ExpressionStatement:
+        this.variant = new ExpressionStatement(
+          ast.variant as ast.ExpressionStatement,
+          options
+        );
+        break;
+      case NonterminalKind.VariableDeclarationStatement:
+        this.variant = new VariableDeclarationStatement(
+          ast.variant as ast.VariableDeclarationStatement,
+          options
+        );
+        break;
+      case NonterminalKind.TupleDeconstructionStatement:
+        this.variant = new TupleDeconstructionStatement(
+          ast.variant as ast.TupleDeconstructionStatement,
+          options
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ForStatementInitialization>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
@@ -55,8 +56,6 @@ export class ForStatementInitialization extends SlangNode {
   }
 
   print(path: AstPath<ForStatementInitialization>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -9,6 +9,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.FunctionAttribute['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<FunctionAttribute['variant'], string> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ModifierInvocation:
+      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
+    case NonterminalKind.OverrideSpecifier:
+      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class FunctionAttribute extends SlangNode {
   readonly kind = NonterminalKind.FunctionAttribute;
 
@@ -22,20 +36,7 @@ export class FunctionAttribute extends SlangNode {
       this.variant = variant.unparse();
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ModifierInvocation:
-        this.variant = new ModifierInvocation(
-          variant as ast.ModifierInvocation,
-          options
-        );
-        break;
-      case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -18,25 +18,25 @@ export class FunctionAttribute extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.ModifierInvocation:
-          this.variant = new ModifierInvocation(
-            ast.variant as ast.ModifierInvocation,
-            options
-          );
-          break;
-        case NonterminalKind.OverrideSpecifier:
-          this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier
-          );
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.ModifierInvocation:
+        this.variant = new ModifierInvocation(
+          ast.variant as ast.ModifierInvocation,
+          options
+        );
+        break;
+      case NonterminalKind.OverrideSpecifier:
+        this.variant = new OverrideSpecifier(
+          ast.variant as ast.OverrideSpecifier
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<FunctionAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,14 +13,14 @@ function createNonterminalVariant(
   variant: Exclude<ast.FunctionAttribute['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<FunctionAttribute['variant'], string> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ModifierInvocation:
-      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
-    case NonterminalKind.OverrideSpecifier:
-      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ModifierInvocation) {
+    return new ModifierInvocation(variant, options);
   }
+  if (variant instanceof ast.OverrideSpecifier) {
+    return new OverrideSpecifier(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class FunctionAttribute extends SlangNode {

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
@@ -40,8 +41,6 @@ export class FunctionAttribute extends SlangNode {
   }
 
   print(path: AstPath<FunctionAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -17,24 +17,24 @@ export class FunctionAttribute extends SlangNode {
   constructor(ast: ast.FunctionAttribute, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ModifierInvocation:
         this.variant = new ModifierInvocation(
-          ast.variant as ast.ModifierInvocation,
+          variant as ast.ModifierInvocation,
           options
         );
         break;
       case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(
-          ast.variant as ast.OverrideSpecifier
-        );
+        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -16,11 +16,12 @@ export class FunctionBody extends SlangNode {
   constructor(ast: ast.FunctionBody, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new Block(ast.variant, options);
+    this.variant = new Block(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Block } from './Block.js';
 
@@ -25,8 +26,6 @@ export class FunctionBody extends SlangNode {
   }
 
   print(path: AstPath<FunctionBody>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -15,12 +15,13 @@ export class FunctionBody extends SlangNode {
   constructor(ast: ast.FunctionBody, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new Block(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new Block(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<FunctionBody>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -17,21 +17,23 @@ export class ImportClause extends SlangNode {
   constructor(ast: ast.ImportClause, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.PathImport:
-        this.variant = new PathImport(ast.variant as ast.PathImport, options);
+        this.variant = new PathImport(variant as ast.PathImport, options);
         break;
       case NonterminalKind.NamedImport:
-        this.variant = new NamedImport(ast.variant as ast.NamedImport, options);
+        this.variant = new NamedImport(variant as ast.NamedImport, options);
         break;
       case NonterminalKind.ImportDeconstruction:
         this.variant = new ImportDeconstruction(
-          ast.variant as ast.ImportDeconstruction,
+          variant as ast.ImportDeconstruction,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { PathImport } from './PathImport.js';
 import { NamedImport } from './NamedImport.js';
 import { ImportDeconstruction } from './ImportDeconstruction.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,19 +13,17 @@ function createNonterminalVariant(
   variant: ast.ImportClause['variant'],
   options: ParserOptions<AstNode>
 ): ImportClause['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.PathImport:
-      return new PathImport(variant as ast.PathImport, options);
-    case NonterminalKind.NamedImport:
-      return new NamedImport(variant as ast.NamedImport, options);
-    case NonterminalKind.ImportDeconstruction:
-      return new ImportDeconstruction(
-        variant as ast.ImportDeconstruction,
-        options
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.PathImport) {
+    return new PathImport(variant, options);
   }
+  if (variant instanceof ast.NamedImport) {
+    return new NamedImport(variant, options);
+  }
+  if (variant instanceof ast.ImportDeconstruction) {
+    return new ImportDeconstruction(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ImportClause extends SlangNode {

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -9,6 +9,25 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.ImportClause['variant'],
+  options: ParserOptions<AstNode>
+): ImportClause['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.PathImport:
+      return new PathImport(variant as ast.PathImport, options);
+    case NonterminalKind.NamedImport:
+      return new NamedImport(variant as ast.NamedImport, options);
+    case NonterminalKind.ImportDeconstruction:
+      return new ImportDeconstruction(
+        variant as ast.ImportDeconstruction,
+        options
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ImportClause extends SlangNode {
   readonly kind = NonterminalKind.ImportClause;
 
@@ -17,24 +36,7 @@ export class ImportClause extends SlangNode {
   constructor(ast: ast.ImportClause, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.PathImport:
-        this.variant = new PathImport(variant as ast.PathImport, options);
-        break;
-      case NonterminalKind.NamedImport:
-        this.variant = new NamedImport(variant as ast.NamedImport, options);
-        break;
-      case NonterminalKind.ImportDeconstruction:
-        this.variant = new ImportDeconstruction(
-          variant as ast.ImportDeconstruction,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -7,6 +7,19 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.MappingKeyType['variant']
+): MappingKeyType['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ElementaryType:
+      return new ElementaryType(variant as ast.ElementaryType);
+    case NonterminalKind.IdentifierPath:
+      return new IdentifierPath(variant as ast.IdentifierPath);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class MappingKeyType extends SlangNode {
   readonly kind = NonterminalKind.MappingKeyType;
 
@@ -15,18 +28,7 @@ export class MappingKeyType extends SlangNode {
   constructor(ast: ast.MappingKeyType) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(variant as ast.ElementaryType);
-        break;
-      case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -15,15 +15,17 @@ export class MappingKeyType extends SlangNode {
   constructor(ast: ast.MappingKeyType) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
+        this.variant = new ElementaryType(variant as ast.ElementaryType);
         break;
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
+        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -1,23 +1,23 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.MappingKeyType['variant']
 ): MappingKeyType['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ElementaryType:
-      return new ElementaryType(variant as ast.ElementaryType);
-    case NonterminalKind.IdentifierPath:
-      return new IdentifierPath(variant as ast.IdentifierPath);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ElementaryType) {
+    return new ElementaryType(variant);
   }
+  if (variant instanceof ast.IdentifierPath) {
+    return new IdentifierPath(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class MappingKeyType extends SlangNode {

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 
@@ -24,8 +25,6 @@ export class ModifierAttribute extends SlangNode {
   }
 
   print(path: AstPath<ModifierAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -14,12 +14,13 @@ export class ModifierAttribute extends SlangNode {
   constructor(ast: ast.ModifierAttribute) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new OverrideSpecifier(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new OverrideSpecifier(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ModifierAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -15,11 +15,12 @@ export class ModifierAttribute extends SlangNode {
   constructor(ast: ast.ModifierAttribute) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new OverrideSpecifier(ast.variant);
+    this.variant = new OverrideSpecifier(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -9,6 +9,22 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.Pragma['variant'],
+  options: ParserOptions<AstNode>
+): Pragma['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.AbicoderPragma:
+      return new AbicoderPragma(variant as ast.AbicoderPragma);
+    case NonterminalKind.ExperimentalPragma:
+      return new ExperimentalPragma(variant as ast.ExperimentalPragma, options);
+    case NonterminalKind.VersionPragma:
+      return new VersionPragma(variant as ast.VersionPragma);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class Pragma extends SlangNode {
   readonly kind = NonterminalKind.Pragma;
 
@@ -17,24 +33,7 @@ export class Pragma extends SlangNode {
   constructor(ast: ast.Pragma, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.AbicoderPragma:
-        this.variant = new AbicoderPragma(variant as ast.AbicoderPragma);
-        break;
-      case NonterminalKind.ExperimentalPragma:
-        this.variant = new ExperimentalPragma(
-          variant as ast.ExperimentalPragma,
-          options
-        );
-        break;
-      case NonterminalKind.VersionPragma:
-        this.variant = new VersionPragma(variant as ast.VersionPragma);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { AbicoderPragma } from './AbicoderPragma.js';
 import { ExperimentalPragma } from './ExperimentalPragma.js';
 import { VersionPragma } from './VersionPragma.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,16 +13,17 @@ function createNonterminalVariant(
   variant: ast.Pragma['variant'],
   options: ParserOptions<AstNode>
 ): Pragma['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.AbicoderPragma:
-      return new AbicoderPragma(variant as ast.AbicoderPragma);
-    case NonterminalKind.ExperimentalPragma:
-      return new ExperimentalPragma(variant as ast.ExperimentalPragma, options);
-    case NonterminalKind.VersionPragma:
-      return new VersionPragma(variant as ast.VersionPragma);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.AbicoderPragma) {
+    return new AbicoderPragma(variant);
   }
+  if (variant instanceof ast.ExperimentalPragma) {
+    return new ExperimentalPragma(variant, options);
+  }
+  if (variant instanceof ast.VersionPragma) {
+    return new VersionPragma(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class Pragma extends SlangNode {

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -17,21 +17,23 @@ export class Pragma extends SlangNode {
   constructor(ast: ast.Pragma, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.AbicoderPragma:
-        this.variant = new AbicoderPragma(ast.variant as ast.AbicoderPragma);
+        this.variant = new AbicoderPragma(variant as ast.AbicoderPragma);
         break;
       case NonterminalKind.ExperimentalPragma:
         this.variant = new ExperimentalPragma(
-          ast.variant as ast.ExperimentalPragma,
+          variant as ast.ExperimentalPragma,
           options
         );
         break;
       case NonterminalKind.VersionPragma:
-        this.variant = new VersionPragma(ast.variant as ast.VersionPragma);
+        this.variant = new VersionPragma(variant as ast.VersionPragma);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,14 +13,14 @@ function createNonterminalVariant(
   variant: Exclude<ast.ReceiveFunctionAttribute['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<ReceiveFunctionAttribute['variant'], string> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ModifierInvocation:
-      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
-    case NonterminalKind.OverrideSpecifier:
-      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ModifierInvocation) {
+    return new ModifierInvocation(variant, options);
   }
+  if (variant instanceof ast.OverrideSpecifier) {
+    return new OverrideSpecifier(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class ReceiveFunctionAttribute extends SlangNode {

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -21,25 +21,25 @@ export class ReceiveFunctionAttribute extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.ModifierInvocation:
-          this.variant = new ModifierInvocation(
-            ast.variant as ast.ModifierInvocation,
-            options
-          );
-          break;
-        case NonterminalKind.OverrideSpecifier:
-          this.variant = new OverrideSpecifier(
-            ast.variant as ast.OverrideSpecifier
-          );
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.ModifierInvocation:
+        this.variant = new ModifierInvocation(
+          ast.variant as ast.ModifierInvocation,
+          options
+        );
+        break;
+      case NonterminalKind.OverrideSpecifier:
+        this.variant = new OverrideSpecifier(
+          ast.variant as ast.OverrideSpecifier
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<ReceiveFunctionAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -9,6 +9,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.ReceiveFunctionAttribute['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<ReceiveFunctionAttribute['variant'], string> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ModifierInvocation:
+      return new ModifierInvocation(variant as ast.ModifierInvocation, options);
+    case NonterminalKind.OverrideSpecifier:
+      return new OverrideSpecifier(variant as ast.OverrideSpecifier);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class ReceiveFunctionAttribute extends SlangNode {
   readonly kind = NonterminalKind.ReceiveFunctionAttribute;
 
@@ -25,20 +39,7 @@ export class ReceiveFunctionAttribute extends SlangNode {
       this.variant = variant.unparse();
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ModifierInvocation:
-        this.variant = new ModifierInvocation(
-          variant as ast.ModifierInvocation,
-          options
-        );
-        break;
-      case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -20,24 +20,24 @@ export class ReceiveFunctionAttribute extends SlangNode {
   ) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ModifierInvocation:
         this.variant = new ModifierInvocation(
-          ast.variant as ast.ModifierInvocation,
+          variant as ast.ModifierInvocation,
           options
         );
         break;
       case NonterminalKind.OverrideSpecifier:
-        this.variant = new OverrideSpecifier(
-          ast.variant as ast.OverrideSpecifier
-        );
+        this.variant = new OverrideSpecifier(variant as ast.OverrideSpecifier);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
@@ -43,8 +44,6 @@ export class ReceiveFunctionAttribute extends SlangNode {
   }
 
   print(path: AstPath<ReceiveFunctionAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -40,83 +40,85 @@ export class SourceUnitMember extends SlangNode {
   constructor(ast: ast.SourceUnitMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.PragmaDirective:
         this.variant = new PragmaDirective(
-          ast.variant as ast.PragmaDirective,
+          variant as ast.PragmaDirective,
           options
         );
         break;
       case NonterminalKind.ImportDirective:
         this.variant = new ImportDirective(
-          ast.variant as ast.ImportDirective,
+          variant as ast.ImportDirective,
           options
         );
         break;
       case NonterminalKind.ContractDefinition:
         this.variant = new ContractDefinition(
-          ast.variant as ast.ContractDefinition,
+          variant as ast.ContractDefinition,
           options
         );
         break;
       case NonterminalKind.InterfaceDefinition:
         this.variant = new InterfaceDefinition(
-          ast.variant as ast.InterfaceDefinition,
+          variant as ast.InterfaceDefinition,
           options
         );
         break;
       case NonterminalKind.LibraryDefinition:
         this.variant = new LibraryDefinition(
-          ast.variant as ast.LibraryDefinition,
+          variant as ast.LibraryDefinition,
           options
         );
         break;
       case NonterminalKind.StructDefinition:
         this.variant = new StructDefinition(
-          ast.variant as ast.StructDefinition,
+          variant as ast.StructDefinition,
           options
         );
         break;
       case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(ast.variant as ast.EnumDefinition);
+        this.variant = new EnumDefinition(variant as ast.EnumDefinition);
         break;
       case NonterminalKind.FunctionDefinition:
         this.variant = new FunctionDefinition(
-          ast.variant as ast.FunctionDefinition,
+          variant as ast.FunctionDefinition,
           options
         );
         break;
       case NonterminalKind.ConstantDefinition:
         this.variant = new ConstantDefinition(
-          ast.variant as ast.ConstantDefinition,
+          variant as ast.ConstantDefinition,
           options
         );
         break;
       case NonterminalKind.ErrorDefinition:
         this.variant = new ErrorDefinition(
-          ast.variant as ast.ErrorDefinition,
+          variant as ast.ErrorDefinition,
           options
         );
         break;
       case NonterminalKind.UserDefinedValueTypeDefinition:
         this.variant = new UserDefinedValueTypeDefinition(
-          ast.variant as ast.UserDefinedValueTypeDefinition
+          variant as ast.UserDefinedValueTypeDefinition
         );
         break;
       case NonterminalKind.UsingDirective:
         this.variant = new UsingDirective(
-          ast.variant as ast.UsingDirective,
+          variant as ast.UsingDirective,
           options
         );
         break;
       case NonterminalKind.EventDefinition:
         this.variant = new EventDefinition(
-          ast.variant as ast.EventDefinition,
+          variant as ast.EventDefinition,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { PragmaDirective } from './PragmaDirective.js';
@@ -14,7 +15,6 @@ import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition
 import { UsingDirective } from './UsingDirective.js';
 import { EventDefinition } from './EventDefinition.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -23,41 +23,47 @@ function createNonterminalVariant(
   variant: ast.SourceUnitMember['variant'],
   options: ParserOptions<AstNode>
 ): SourceUnitMember['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.PragmaDirective:
-      return new PragmaDirective(variant as ast.PragmaDirective, options);
-    case NonterminalKind.ImportDirective:
-      return new ImportDirective(variant as ast.ImportDirective, options);
-    case NonterminalKind.ContractDefinition:
-      return new ContractDefinition(variant as ast.ContractDefinition, options);
-    case NonterminalKind.InterfaceDefinition:
-      return new InterfaceDefinition(
-        variant as ast.InterfaceDefinition,
-        options
-      );
-    case NonterminalKind.LibraryDefinition:
-      return new LibraryDefinition(variant as ast.LibraryDefinition, options);
-    case NonterminalKind.StructDefinition:
-      return new StructDefinition(variant as ast.StructDefinition, options);
-    case NonterminalKind.EnumDefinition:
-      return new EnumDefinition(variant as ast.EnumDefinition);
-    case NonterminalKind.FunctionDefinition:
-      return new FunctionDefinition(variant as ast.FunctionDefinition, options);
-    case NonterminalKind.ConstantDefinition:
-      return new ConstantDefinition(variant as ast.ConstantDefinition, options);
-    case NonterminalKind.ErrorDefinition:
-      return new ErrorDefinition(variant as ast.ErrorDefinition, options);
-    case NonterminalKind.UserDefinedValueTypeDefinition:
-      return new UserDefinedValueTypeDefinition(
-        variant as ast.UserDefinedValueTypeDefinition
-      );
-    case NonterminalKind.UsingDirective:
-      return new UsingDirective(variant as ast.UsingDirective, options);
-    case NonterminalKind.EventDefinition:
-      return new EventDefinition(variant as ast.EventDefinition, options);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.PragmaDirective) {
+    return new PragmaDirective(variant, options);
   }
+  if (variant instanceof ast.ImportDirective) {
+    return new ImportDirective(variant, options);
+  }
+  if (variant instanceof ast.ContractDefinition) {
+    return new ContractDefinition(variant, options);
+  }
+  if (variant instanceof ast.InterfaceDefinition) {
+    return new InterfaceDefinition(variant, options);
+  }
+  if (variant instanceof ast.LibraryDefinition) {
+    return new LibraryDefinition(variant, options);
+  }
+  if (variant instanceof ast.StructDefinition) {
+    return new StructDefinition(variant, options);
+  }
+  if (variant instanceof ast.EnumDefinition) {
+    return new EnumDefinition(variant);
+  }
+  if (variant instanceof ast.FunctionDefinition) {
+    return new FunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.ConstantDefinition) {
+    return new ConstantDefinition(variant, options);
+  }
+  if (variant instanceof ast.ErrorDefinition) {
+    return new ErrorDefinition(variant, options);
+  }
+  if (variant instanceof ast.UserDefinedValueTypeDefinition) {
+    return new UserDefinedValueTypeDefinition(variant);
+  }
+  if (variant instanceof ast.UsingDirective) {
+    return new UsingDirective(variant, options);
+  }
+  if (variant instanceof ast.EventDefinition) {
+    return new EventDefinition(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class SourceUnitMember extends SlangNode {

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -19,6 +19,47 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.SourceUnitMember['variant'],
+  options: ParserOptions<AstNode>
+): SourceUnitMember['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.PragmaDirective:
+      return new PragmaDirective(variant as ast.PragmaDirective, options);
+    case NonterminalKind.ImportDirective:
+      return new ImportDirective(variant as ast.ImportDirective, options);
+    case NonterminalKind.ContractDefinition:
+      return new ContractDefinition(variant as ast.ContractDefinition, options);
+    case NonterminalKind.InterfaceDefinition:
+      return new InterfaceDefinition(
+        variant as ast.InterfaceDefinition,
+        options
+      );
+    case NonterminalKind.LibraryDefinition:
+      return new LibraryDefinition(variant as ast.LibraryDefinition, options);
+    case NonterminalKind.StructDefinition:
+      return new StructDefinition(variant as ast.StructDefinition, options);
+    case NonterminalKind.EnumDefinition:
+      return new EnumDefinition(variant as ast.EnumDefinition);
+    case NonterminalKind.FunctionDefinition:
+      return new FunctionDefinition(variant as ast.FunctionDefinition, options);
+    case NonterminalKind.ConstantDefinition:
+      return new ConstantDefinition(variant as ast.ConstantDefinition, options);
+    case NonterminalKind.ErrorDefinition:
+      return new ErrorDefinition(variant as ast.ErrorDefinition, options);
+    case NonterminalKind.UserDefinedValueTypeDefinition:
+      return new UserDefinedValueTypeDefinition(
+        variant as ast.UserDefinedValueTypeDefinition
+      );
+    case NonterminalKind.UsingDirective:
+      return new UsingDirective(variant as ast.UsingDirective, options);
+    case NonterminalKind.EventDefinition:
+      return new EventDefinition(variant as ast.EventDefinition, options);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class SourceUnitMember extends SlangNode {
   readonly kind = NonterminalKind.SourceUnitMember;
 
@@ -40,86 +81,7 @@ export class SourceUnitMember extends SlangNode {
   constructor(ast: ast.SourceUnitMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.PragmaDirective:
-        this.variant = new PragmaDirective(
-          variant as ast.PragmaDirective,
-          options
-        );
-        break;
-      case NonterminalKind.ImportDirective:
-        this.variant = new ImportDirective(
-          variant as ast.ImportDirective,
-          options
-        );
-        break;
-      case NonterminalKind.ContractDefinition:
-        this.variant = new ContractDefinition(
-          variant as ast.ContractDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.InterfaceDefinition:
-        this.variant = new InterfaceDefinition(
-          variant as ast.InterfaceDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.LibraryDefinition:
-        this.variant = new LibraryDefinition(
-          variant as ast.LibraryDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.StructDefinition:
-        this.variant = new StructDefinition(
-          variant as ast.StructDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.EnumDefinition:
-        this.variant = new EnumDefinition(variant as ast.EnumDefinition);
-        break;
-      case NonterminalKind.FunctionDefinition:
-        this.variant = new FunctionDefinition(
-          variant as ast.FunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ConstantDefinition:
-        this.variant = new ConstantDefinition(
-          variant as ast.ConstantDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.ErrorDefinition:
-        this.variant = new ErrorDefinition(
-          variant as ast.ErrorDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.UserDefinedValueTypeDefinition:
-        this.variant = new UserDefinedValueTypeDefinition(
-          variant as ast.UserDefinedValueTypeDefinition
-        );
-        break;
-      case NonterminalKind.UsingDirective:
-        this.variant = new UsingDirective(
-          variant as ast.UsingDirective,
-          options
-        );
-        break;
-      case NonterminalKind.EventDefinition:
-        this.variant = new EventDefinition(
-          variant as ast.EventDefinition,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -15,11 +15,12 @@ export class StateVariableAttribute extends SlangNode {
   constructor(ast: ast.StateVariableAttribute) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new OverrideSpecifier(ast.variant);
+    this.variant = new OverrideSpecifier(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 
@@ -24,8 +25,6 @@ export class StateVariableAttribute extends SlangNode {
   }
 
   print(path: AstPath<StateVariableAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -14,12 +14,13 @@ export class StateVariableAttribute extends SlangNode {
   constructor(ast: ast.StateVariableAttribute) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new OverrideSpecifier(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new OverrideSpecifier(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<StateVariableAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
@@ -18,7 +19,6 @@ import { AssemblyStatement } from './AssemblyStatement.js';
 import { Block } from './Block.js';
 import { UncheckedBlock } from './UncheckedBlock.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -27,53 +27,59 @@ function createNonterminalVariant(
   variant: ast.Statement['variant'],
   options: ParserOptions<AstNode>
 ): Statement['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ExpressionStatement:
-      return new ExpressionStatement(
-        variant as ast.ExpressionStatement,
-        options
-      );
-    case NonterminalKind.VariableDeclarationStatement:
-      return new VariableDeclarationStatement(
-        variant as ast.VariableDeclarationStatement,
-        options
-      );
-    case NonterminalKind.TupleDeconstructionStatement:
-      return new TupleDeconstructionStatement(
-        variant as ast.TupleDeconstructionStatement,
-        options
-      );
-    case NonterminalKind.IfStatement:
-      return new IfStatement(variant as ast.IfStatement, options);
-    case NonterminalKind.ForStatement:
-      return new ForStatement(variant as ast.ForStatement, options);
-    case NonterminalKind.WhileStatement:
-      return new WhileStatement(variant as ast.WhileStatement, options);
-    case NonterminalKind.DoWhileStatement:
-      return new DoWhileStatement(variant as ast.DoWhileStatement, options);
-    case NonterminalKind.ContinueStatement:
-      return new ContinueStatement(variant as ast.ContinueStatement);
-    case NonterminalKind.BreakStatement:
-      return new BreakStatement(variant as ast.BreakStatement);
-    case NonterminalKind.ReturnStatement:
-      return new ReturnStatement(variant as ast.ReturnStatement, options);
-    case NonterminalKind.ThrowStatement:
-      return new ThrowStatement(variant as ast.ThrowStatement);
-    case NonterminalKind.EmitStatement:
-      return new EmitStatement(variant as ast.EmitStatement, options);
-    case NonterminalKind.TryStatement:
-      return new TryStatement(variant as ast.TryStatement, options);
-    case NonterminalKind.RevertStatement:
-      return new RevertStatement(variant as ast.RevertStatement, options);
-    case NonterminalKind.AssemblyStatement:
-      return new AssemblyStatement(variant as ast.AssemblyStatement, options);
-    case NonterminalKind.Block:
-      return new Block(variant as ast.Block, options);
-    case NonterminalKind.UncheckedBlock:
-      return new UncheckedBlock(variant as ast.UncheckedBlock, options);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ExpressionStatement) {
+    return new ExpressionStatement(variant, options);
   }
+  if (variant instanceof ast.VariableDeclarationStatement) {
+    return new VariableDeclarationStatement(variant, options);
+  }
+  if (variant instanceof ast.TupleDeconstructionStatement) {
+    return new TupleDeconstructionStatement(variant, options);
+  }
+  if (variant instanceof ast.IfStatement) {
+    return new IfStatement(variant, options);
+  }
+  if (variant instanceof ast.ForStatement) {
+    return new ForStatement(variant, options);
+  }
+  if (variant instanceof ast.WhileStatement) {
+    return new WhileStatement(variant, options);
+  }
+  if (variant instanceof ast.DoWhileStatement) {
+    return new DoWhileStatement(variant, options);
+  }
+  if (variant instanceof ast.ContinueStatement) {
+    return new ContinueStatement(variant);
+  }
+  if (variant instanceof ast.BreakStatement) {
+    return new BreakStatement(variant);
+  }
+  if (variant instanceof ast.ReturnStatement) {
+    return new ReturnStatement(variant, options);
+  }
+  if (variant instanceof ast.ThrowStatement) {
+    return new ThrowStatement(variant);
+  }
+  if (variant instanceof ast.EmitStatement) {
+    return new EmitStatement(variant, options);
+  }
+  if (variant instanceof ast.TryStatement) {
+    return new TryStatement(variant, options);
+  }
+  if (variant instanceof ast.RevertStatement) {
+    return new RevertStatement(variant, options);
+  }
+  if (variant instanceof ast.AssemblyStatement) {
+    return new AssemblyStatement(variant, options);
+  }
+  if (variant instanceof ast.Block) {
+    return new Block(variant, options);
+  }
+  if (variant instanceof ast.UncheckedBlock) {
+    return new UncheckedBlock(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class Statement extends SlangNode {

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -48,98 +48,89 @@ export class Statement extends SlangNode {
   constructor(ast: ast.Statement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ExpressionStatement:
         this.variant = new ExpressionStatement(
-          ast.variant as ast.ExpressionStatement,
+          variant as ast.ExpressionStatement,
           options
         );
         break;
       case NonterminalKind.VariableDeclarationStatement:
         this.variant = new VariableDeclarationStatement(
-          ast.variant as ast.VariableDeclarationStatement,
+          variant as ast.VariableDeclarationStatement,
           options
         );
         break;
       case NonterminalKind.TupleDeconstructionStatement:
         this.variant = new TupleDeconstructionStatement(
-          ast.variant as ast.TupleDeconstructionStatement,
+          variant as ast.TupleDeconstructionStatement,
           options
         );
         break;
       case NonterminalKind.IfStatement:
-        this.variant = new IfStatement(ast.variant as ast.IfStatement, options);
+        this.variant = new IfStatement(variant as ast.IfStatement, options);
         break;
       case NonterminalKind.ForStatement:
-        this.variant = new ForStatement(
-          ast.variant as ast.ForStatement,
-          options
-        );
+        this.variant = new ForStatement(variant as ast.ForStatement, options);
         break;
       case NonterminalKind.WhileStatement:
         this.variant = new WhileStatement(
-          ast.variant as ast.WhileStatement,
+          variant as ast.WhileStatement,
           options
         );
         break;
       case NonterminalKind.DoWhileStatement:
         this.variant = new DoWhileStatement(
-          ast.variant as ast.DoWhileStatement,
+          variant as ast.DoWhileStatement,
           options
         );
         break;
       case NonterminalKind.ContinueStatement:
-        this.variant = new ContinueStatement(
-          ast.variant as ast.ContinueStatement
-        );
+        this.variant = new ContinueStatement(variant as ast.ContinueStatement);
         break;
       case NonterminalKind.BreakStatement:
-        this.variant = new BreakStatement(ast.variant as ast.BreakStatement);
+        this.variant = new BreakStatement(variant as ast.BreakStatement);
         break;
       case NonterminalKind.ReturnStatement:
         this.variant = new ReturnStatement(
-          ast.variant as ast.ReturnStatement,
+          variant as ast.ReturnStatement,
           options
         );
         break;
       case NonterminalKind.ThrowStatement:
-        this.variant = new ThrowStatement(ast.variant as ast.ThrowStatement);
+        this.variant = new ThrowStatement(variant as ast.ThrowStatement);
         break;
       case NonterminalKind.EmitStatement:
-        this.variant = new EmitStatement(
-          ast.variant as ast.EmitStatement,
-          options
-        );
+        this.variant = new EmitStatement(variant as ast.EmitStatement, options);
         break;
       case NonterminalKind.TryStatement:
-        this.variant = new TryStatement(
-          ast.variant as ast.TryStatement,
-          options
-        );
+        this.variant = new TryStatement(variant as ast.TryStatement, options);
         break;
       case NonterminalKind.RevertStatement:
         this.variant = new RevertStatement(
-          ast.variant as ast.RevertStatement,
+          variant as ast.RevertStatement,
           options
         );
         break;
       case NonterminalKind.AssemblyStatement:
         this.variant = new AssemblyStatement(
-          ast.variant as ast.AssemblyStatement,
+          variant as ast.AssemblyStatement,
           options
         );
         break;
       case NonterminalKind.Block:
-        this.variant = new Block(ast.variant as ast.Block, options);
+        this.variant = new Block(variant as ast.Block, options);
         break;
       case NonterminalKind.UncheckedBlock:
         this.variant = new UncheckedBlock(
-          ast.variant as ast.UncheckedBlock,
+          variant as ast.UncheckedBlock,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -23,6 +23,59 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.Statement['variant'],
+  options: ParserOptions<AstNode>
+): Statement['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ExpressionStatement:
+      return new ExpressionStatement(
+        variant as ast.ExpressionStatement,
+        options
+      );
+    case NonterminalKind.VariableDeclarationStatement:
+      return new VariableDeclarationStatement(
+        variant as ast.VariableDeclarationStatement,
+        options
+      );
+    case NonterminalKind.TupleDeconstructionStatement:
+      return new TupleDeconstructionStatement(
+        variant as ast.TupleDeconstructionStatement,
+        options
+      );
+    case NonterminalKind.IfStatement:
+      return new IfStatement(variant as ast.IfStatement, options);
+    case NonterminalKind.ForStatement:
+      return new ForStatement(variant as ast.ForStatement, options);
+    case NonterminalKind.WhileStatement:
+      return new WhileStatement(variant as ast.WhileStatement, options);
+    case NonterminalKind.DoWhileStatement:
+      return new DoWhileStatement(variant as ast.DoWhileStatement, options);
+    case NonterminalKind.ContinueStatement:
+      return new ContinueStatement(variant as ast.ContinueStatement);
+    case NonterminalKind.BreakStatement:
+      return new BreakStatement(variant as ast.BreakStatement);
+    case NonterminalKind.ReturnStatement:
+      return new ReturnStatement(variant as ast.ReturnStatement, options);
+    case NonterminalKind.ThrowStatement:
+      return new ThrowStatement(variant as ast.ThrowStatement);
+    case NonterminalKind.EmitStatement:
+      return new EmitStatement(variant as ast.EmitStatement, options);
+    case NonterminalKind.TryStatement:
+      return new TryStatement(variant as ast.TryStatement, options);
+    case NonterminalKind.RevertStatement:
+      return new RevertStatement(variant as ast.RevertStatement, options);
+    case NonterminalKind.AssemblyStatement:
+      return new AssemblyStatement(variant as ast.AssemblyStatement, options);
+    case NonterminalKind.Block:
+      return new Block(variant as ast.Block, options);
+    case NonterminalKind.UncheckedBlock:
+      return new UncheckedBlock(variant as ast.UncheckedBlock, options);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class Statement extends SlangNode {
   readonly kind = NonterminalKind.Statement;
 
@@ -48,90 +101,7 @@ export class Statement extends SlangNode {
   constructor(ast: ast.Statement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ExpressionStatement:
-        this.variant = new ExpressionStatement(
-          variant as ast.ExpressionStatement,
-          options
-        );
-        break;
-      case NonterminalKind.VariableDeclarationStatement:
-        this.variant = new VariableDeclarationStatement(
-          variant as ast.VariableDeclarationStatement,
-          options
-        );
-        break;
-      case NonterminalKind.TupleDeconstructionStatement:
-        this.variant = new TupleDeconstructionStatement(
-          variant as ast.TupleDeconstructionStatement,
-          options
-        );
-        break;
-      case NonterminalKind.IfStatement:
-        this.variant = new IfStatement(variant as ast.IfStatement, options);
-        break;
-      case NonterminalKind.ForStatement:
-        this.variant = new ForStatement(variant as ast.ForStatement, options);
-        break;
-      case NonterminalKind.WhileStatement:
-        this.variant = new WhileStatement(
-          variant as ast.WhileStatement,
-          options
-        );
-        break;
-      case NonterminalKind.DoWhileStatement:
-        this.variant = new DoWhileStatement(
-          variant as ast.DoWhileStatement,
-          options
-        );
-        break;
-      case NonterminalKind.ContinueStatement:
-        this.variant = new ContinueStatement(variant as ast.ContinueStatement);
-        break;
-      case NonterminalKind.BreakStatement:
-        this.variant = new BreakStatement(variant as ast.BreakStatement);
-        break;
-      case NonterminalKind.ReturnStatement:
-        this.variant = new ReturnStatement(
-          variant as ast.ReturnStatement,
-          options
-        );
-        break;
-      case NonterminalKind.ThrowStatement:
-        this.variant = new ThrowStatement(variant as ast.ThrowStatement);
-        break;
-      case NonterminalKind.EmitStatement:
-        this.variant = new EmitStatement(variant as ast.EmitStatement, options);
-        break;
-      case NonterminalKind.TryStatement:
-        this.variant = new TryStatement(variant as ast.TryStatement, options);
-        break;
-      case NonterminalKind.RevertStatement:
-        this.variant = new RevertStatement(
-          variant as ast.RevertStatement,
-          options
-        );
-        break;
-      case NonterminalKind.AssemblyStatement:
-        this.variant = new AssemblyStatement(
-          variant as ast.AssemblyStatement,
-          options
-        );
-        break;
-      case NonterminalKind.Block:
-        this.variant = new Block(variant as ast.Block, options);
-        break;
-      case NonterminalKind.UncheckedBlock:
-        this.variant = new UncheckedBlock(
-          variant as ast.UncheckedBlock,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -11,6 +11,29 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.StringExpression['variant'],
+  options: ParserOptions<AstNode>
+): StringExpression['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.StringLiteral:
+      return new StringLiteral(variant as ast.StringLiteral, options);
+    case NonterminalKind.StringLiterals:
+      return new StringLiterals(variant as ast.StringLiterals, options);
+    case NonterminalKind.HexStringLiteral:
+      return new HexStringLiteral(variant as ast.HexStringLiteral, options);
+    case NonterminalKind.HexStringLiterals:
+      return new HexStringLiterals(variant as ast.HexStringLiterals, options);
+    case NonterminalKind.UnicodeStringLiterals:
+      return new UnicodeStringLiterals(
+        variant as ast.UnicodeStringLiterals,
+        options
+      );
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class StringExpression extends SlangNode {
   readonly kind = NonterminalKind.StringExpression;
 
@@ -24,39 +47,7 @@ export class StringExpression extends SlangNode {
   constructor(ast: ast.StringExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.StringLiteral:
-        this.variant = new StringLiteral(variant as ast.StringLiteral, options);
-        break;
-      case NonterminalKind.StringLiterals:
-        this.variant = new StringLiterals(
-          variant as ast.StringLiterals,
-          options
-        );
-        break;
-      case NonterminalKind.HexStringLiteral:
-        this.variant = new HexStringLiteral(
-          variant as ast.HexStringLiteral,
-          options
-        );
-        break;
-      case NonterminalKind.HexStringLiterals:
-        this.variant = new HexStringLiterals(
-          variant as ast.HexStringLiterals,
-          options
-        );
-        break;
-      case NonterminalKind.UnicodeStringLiterals:
-        this.variant = new UnicodeStringLiterals(
-          variant as ast.UnicodeStringLiterals,
-          options
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -24,39 +24,38 @@ export class StringExpression extends SlangNode {
   constructor(ast: ast.StringExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.StringLiteral:
-        this.variant = new StringLiteral(
-          ast.variant as ast.StringLiteral,
-          options
-        );
+        this.variant = new StringLiteral(variant as ast.StringLiteral, options);
         break;
       case NonterminalKind.StringLiterals:
         this.variant = new StringLiterals(
-          ast.variant as ast.StringLiterals,
+          variant as ast.StringLiterals,
           options
         );
         break;
       case NonterminalKind.HexStringLiteral:
         this.variant = new HexStringLiteral(
-          ast.variant as ast.HexStringLiteral,
+          variant as ast.HexStringLiteral,
           options
         );
         break;
       case NonterminalKind.HexStringLiterals:
         this.variant = new HexStringLiterals(
-          ast.variant as ast.HexStringLiterals,
+          variant as ast.HexStringLiterals,
           options
         );
         break;
       case NonterminalKind.UnicodeStringLiterals:
         this.variant = new UnicodeStringLiterals(
-          ast.variant as ast.UnicodeStringLiterals,
+          variant as ast.UnicodeStringLiterals,
           options
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
@@ -6,7 +7,6 @@ import { HexStringLiteral } from './HexStringLiteral.js';
 import { HexStringLiterals } from './HexStringLiterals.js';
 import { UnicodeStringLiterals } from './UnicodeStringLiterals.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -15,23 +15,23 @@ function createNonterminalVariant(
   variant: ast.StringExpression['variant'],
   options: ParserOptions<AstNode>
 ): StringExpression['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.StringLiteral:
-      return new StringLiteral(variant as ast.StringLiteral, options);
-    case NonterminalKind.StringLiterals:
-      return new StringLiterals(variant as ast.StringLiterals, options);
-    case NonterminalKind.HexStringLiteral:
-      return new HexStringLiteral(variant as ast.HexStringLiteral, options);
-    case NonterminalKind.HexStringLiterals:
-      return new HexStringLiterals(variant as ast.HexStringLiterals, options);
-    case NonterminalKind.UnicodeStringLiterals:
-      return new UnicodeStringLiterals(
-        variant as ast.UnicodeStringLiterals,
-        options
-      );
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.StringLiteral) {
+    return new StringLiteral(variant, options);
   }
+  if (variant instanceof ast.StringLiterals) {
+    return new StringLiterals(variant, options);
+  }
+  if (variant instanceof ast.HexStringLiteral) {
+    return new HexStringLiteral(variant, options);
+  }
+  if (variant instanceof ast.HexStringLiterals) {
+    return new HexStringLiterals(variant, options);
+  }
+  if (variant instanceof ast.UnicodeStringLiterals) {
+    return new UnicodeStringLiterals(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class StringExpression extends SlangNode {

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -16,20 +16,22 @@ export class TupleMember extends SlangNode {
   constructor(ast: ast.TupleMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.TypedTupleMember:
         this.variant = new TypedTupleMember(
-          ast.variant as ast.TypedTupleMember,
+          variant as ast.TypedTupleMember,
           options
         );
         break;
       case NonterminalKind.UntypedTupleMember:
         this.variant = new UntypedTupleMember(
-          ast.variant as ast.UntypedTupleMember
+          variant as ast.UntypedTupleMember
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -1,9 +1,9 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { TypedTupleMember } from './TypedTupleMember.js';
 import { UntypedTupleMember } from './UntypedTupleMember.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -12,14 +12,14 @@ function createNonterminalVariant(
   variant: ast.TupleMember['variant'],
   options: ParserOptions<AstNode>
 ): TupleMember['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.TypedTupleMember:
-      return new TypedTupleMember(variant as ast.TypedTupleMember, options);
-    case NonterminalKind.UntypedTupleMember:
-      return new UntypedTupleMember(variant as ast.UntypedTupleMember);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.TypedTupleMember) {
+    return new TypedTupleMember(variant, options);
   }
+  if (variant instanceof ast.UntypedTupleMember) {
+    return new UntypedTupleMember(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class TupleMember extends SlangNode {

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -8,6 +8,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.TupleMember['variant'],
+  options: ParserOptions<AstNode>
+): TupleMember['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.TypedTupleMember:
+      return new TypedTupleMember(variant as ast.TypedTupleMember, options);
+    case NonterminalKind.UntypedTupleMember:
+      return new UntypedTupleMember(variant as ast.UntypedTupleMember);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class TupleMember extends SlangNode {
   readonly kind = NonterminalKind.TupleMember;
 
@@ -16,23 +30,7 @@ export class TupleMember extends SlangNode {
   constructor(ast: ast.TupleMember, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.TypedTupleMember:
-        this.variant = new TypedTupleMember(
-          variant as ast.TypedTupleMember,
-          options
-        );
-        break;
-      case NonterminalKind.UntypedTupleMember:
-        this.variant = new UntypedTupleMember(
-          variant as ast.UntypedTupleMember
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -11,6 +11,26 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.TypeName['variant'],
+  options: ParserOptions<AstNode>
+): TypeName['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.ArrayTypeName:
+      return new ArrayTypeName(variant as ast.ArrayTypeName, options);
+    case NonterminalKind.FunctionType:
+      return new FunctionType(variant as ast.FunctionType, options);
+    case NonterminalKind.MappingType:
+      return new MappingType(variant as ast.MappingType, options);
+    case NonterminalKind.ElementaryType:
+      return new ElementaryType(variant as ast.ElementaryType);
+    case NonterminalKind.IdentifierPath:
+      return new IdentifierPath(variant as ast.IdentifierPath);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class TypeName extends SlangNode {
   readonly kind = NonterminalKind.TypeName;
 
@@ -24,27 +44,7 @@ export class TypeName extends SlangNode {
   constructor(ast: ast.TypeName, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.ArrayTypeName:
-        this.variant = new ArrayTypeName(variant as ast.ArrayTypeName, options);
-        break;
-      case NonterminalKind.FunctionType:
-        this.variant = new FunctionType(variant as ast.FunctionType, options);
-        break;
-      case NonterminalKind.MappingType:
-        this.variant = new MappingType(variant as ast.MappingType, options);
-        break;
-      case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(variant as ast.ElementaryType);
-        break;
-      case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -24,30 +24,26 @@ export class TypeName extends SlangNode {
   constructor(ast: ast.TypeName, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.ArrayTypeName:
-        this.variant = new ArrayTypeName(
-          ast.variant as ast.ArrayTypeName,
-          options
-        );
+        this.variant = new ArrayTypeName(variant as ast.ArrayTypeName, options);
         break;
       case NonterminalKind.FunctionType:
-        this.variant = new FunctionType(
-          ast.variant as ast.FunctionType,
-          options
-        );
+        this.variant = new FunctionType(variant as ast.FunctionType, options);
         break;
       case NonterminalKind.MappingType:
-        this.variant = new MappingType(ast.variant as ast.MappingType, options);
+        this.variant = new MappingType(variant as ast.MappingType, options);
         break;
       case NonterminalKind.ElementaryType:
-        this.variant = new ElementaryType(ast.variant as ast.ElementaryType);
+        this.variant = new ElementaryType(variant as ast.ElementaryType);
         break;
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
+        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { ArrayTypeName } from './ArrayTypeName.js';
@@ -6,7 +7,6 @@ import { MappingType } from './MappingType.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -15,20 +15,23 @@ function createNonterminalVariant(
   variant: ast.TypeName['variant'],
   options: ParserOptions<AstNode>
 ): TypeName['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.ArrayTypeName:
-      return new ArrayTypeName(variant as ast.ArrayTypeName, options);
-    case NonterminalKind.FunctionType:
-      return new FunctionType(variant as ast.FunctionType, options);
-    case NonterminalKind.MappingType:
-      return new MappingType(variant as ast.MappingType, options);
-    case NonterminalKind.ElementaryType:
-      return new ElementaryType(variant as ast.ElementaryType);
-    case NonterminalKind.IdentifierPath:
-      return new IdentifierPath(variant as ast.IdentifierPath);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.ArrayTypeName) {
+    return new ArrayTypeName(variant, options);
   }
+  if (variant instanceof ast.FunctionType) {
+    return new FunctionType(variant, options);
+  }
+  if (variant instanceof ast.MappingType) {
+    return new MappingType(variant, options);
+  }
+  if (variant instanceof ast.ElementaryType) {
+    return new ElementaryType(variant);
+  }
+  if (variant instanceof ast.IdentifierPath) {
+    return new IdentifierPath(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class TypeName extends SlangNode {

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -19,11 +19,12 @@ export class UnnamedFunctionAttribute extends SlangNode {
   ) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new ModifierInvocation(ast.variant, options);
+    this.variant = new ModifierInvocation(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -18,12 +18,13 @@ export class UnnamedFunctionAttribute extends SlangNode {
   ) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new ModifierInvocation(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new ModifierInvocation(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<UnnamedFunctionAttribute>, print: PrintFunction): Doc {

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 
@@ -28,8 +29,6 @@ export class UnnamedFunctionAttribute extends SlangNode {
   }
 
   print(path: AstPath<UnnamedFunctionAttribute>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -1,23 +1,23 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { UsingDeconstruction } from './UsingDeconstruction.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.UsingClause['variant']
 ): UsingClause['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.IdentifierPath:
-      return new IdentifierPath(variant as ast.IdentifierPath);
-    case NonterminalKind.UsingDeconstruction:
-      return new UsingDeconstruction(variant as ast.UsingDeconstruction);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.IdentifierPath) {
+    return new IdentifierPath(variant);
   }
+  if (variant instanceof ast.UsingDeconstruction) {
+    return new UsingDeconstruction(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class UsingClause extends SlangNode {

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -15,17 +15,19 @@ export class UsingClause extends SlangNode {
   constructor(ast: ast.UsingClause) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(ast.variant as ast.IdentifierPath);
+        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
         break;
       case NonterminalKind.UsingDeconstruction:
         this.variant = new UsingDeconstruction(
-          ast.variant as ast.UsingDeconstruction
+          variant as ast.UsingDeconstruction
         );
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -7,6 +7,19 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.UsingClause['variant']
+): UsingClause['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.IdentifierPath:
+      return new IdentifierPath(variant as ast.IdentifierPath);
+    case NonterminalKind.UsingDeconstruction:
+      return new UsingDeconstruction(variant as ast.UsingDeconstruction);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class UsingClause extends SlangNode {
   readonly kind = NonterminalKind.UsingClause;
 
@@ -15,20 +28,7 @@ export class UsingClause extends SlangNode {
   constructor(ast: ast.UsingClause) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.IdentifierPath:
-        this.variant = new IdentifierPath(variant as ast.IdentifierPath);
-        break;
-      case NonterminalKind.UsingDeconstruction:
-        this.variant = new UsingDeconstruction(
-          variant as ast.UsingDeconstruction
-        );
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
@@ -25,8 +26,6 @@ export class UsingTarget extends SlangNode {
   }
 
   print(path: AstPath<UsingTarget>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -15,12 +15,13 @@ export class UsingTarget extends SlangNode {
   constructor(ast: ast.UsingTarget, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new TypeName(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new TypeName(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<UsingTarget>, print: PrintFunction): Doc {

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -16,11 +16,12 @@ export class UsingTarget extends SlangNode {
   constructor(ast: ast.UsingTarget, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new TypeName(ast.variant, options);
+    this.variant = new TypeName(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -18,12 +18,13 @@ export class VariableDeclarationType extends SlangNode {
   ) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new TypeName(ast.variant, options);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new TypeName(ast.variant, options);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<VariableDeclarationType>, print: PrintFunction): Doc {

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
@@ -28,8 +29,6 @@ export class VariableDeclarationType extends SlangNode {
   }
 
   print(path: AstPath<VariableDeclarationType>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -19,11 +19,12 @@ export class VariableDeclarationType extends SlangNode {
   ) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new TypeName(ast.variant, options);
+    this.variant = new TypeName(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -7,6 +7,19 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.VersionExpression['variant']
+): VersionExpression['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.VersionRange:
+      return new VersionRange(variant as ast.VersionRange);
+    case NonterminalKind.VersionTerm:
+      return new VersionTerm(variant as ast.VersionTerm);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class VersionExpression extends SlangNode {
   readonly kind = NonterminalKind.VersionExpression;
 
@@ -15,18 +28,7 @@ export class VersionExpression extends SlangNode {
   constructor(ast: ast.VersionExpression) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.VersionRange:
-        this.variant = new VersionRange(variant as ast.VersionRange);
-        break;
-      case NonterminalKind.VersionTerm:
-        this.variant = new VersionTerm(variant as ast.VersionTerm);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -1,23 +1,23 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { VersionRange } from './VersionRange.js';
 import { VersionTerm } from './VersionTerm.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.VersionExpression['variant']
 ): VersionExpression['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.VersionRange:
-      return new VersionRange(variant as ast.VersionRange);
-    case NonterminalKind.VersionTerm:
-      return new VersionTerm(variant as ast.VersionTerm);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.VersionRange) {
+    return new VersionRange(variant);
   }
+  if (variant instanceof ast.VersionTerm) {
+    return new VersionTerm(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class VersionExpression extends SlangNode {

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -15,15 +15,17 @@ export class VersionExpression extends SlangNode {
   constructor(ast: ast.VersionExpression) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.VersionRange:
-        this.variant = new VersionRange(ast.variant as ast.VersionRange);
+        this.variant = new VersionRange(variant as ast.VersionRange);
         break;
       case NonterminalKind.VersionTerm:
-        this.variant = new VersionTerm(ast.variant as ast.VersionTerm);
+        this.variant = new VersionTerm(variant as ast.VersionTerm);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { SimpleVersionLiteral } from './SimpleVersionLiteral.js';
 
@@ -24,8 +25,6 @@ export class VersionLiteral extends SlangNode {
   }
 
   print(path: AstPath<VersionLiteral>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -15,11 +15,12 @@ export class VersionLiteral extends SlangNode {
   constructor(ast: ast.VersionLiteral) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new SimpleVersionLiteral(ast.variant);
+    this.variant = new SimpleVersionLiteral(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -14,12 +14,13 @@ export class VersionLiteral extends SlangNode {
   constructor(ast: ast.VersionLiteral) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new SimpleVersionLiteral(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new SimpleVersionLiteral(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<VersionLiteral>, print: PrintFunction): Doc {

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -15,11 +15,12 @@ export class YulAssignmentOperator extends SlangNode {
   constructor(ast: ast.YulAssignmentOperator) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new YulColonAndEqual(ast.variant);
+    this.variant = new YulColonAndEqual(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulColonAndEqual } from './YulColonAndEqual.js';
 
@@ -24,8 +25,6 @@ export class YulAssignmentOperator extends SlangNode {
   }
 
   print(path: AstPath<YulAssignmentOperator>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -14,12 +14,13 @@ export class YulAssignmentOperator extends SlangNode {
   constructor(ast: ast.YulAssignmentOperator) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new YulColonAndEqual(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new YulColonAndEqual(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<YulAssignmentOperator>, print: PrintFunction): Doc {

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -9,6 +9,25 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.YulExpression['variant'],
+  options: ParserOptions<AstNode>
+): YulExpression['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.YulFunctionCallExpression:
+      return new YulFunctionCallExpression(
+        variant as ast.YulFunctionCallExpression,
+        options
+      );
+    case NonterminalKind.YulLiteral:
+      return new YulLiteral(variant as ast.YulLiteral, options);
+    case NonterminalKind.YulPath:
+      return new YulPath(variant as ast.YulPath);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class YulExpression extends SlangNode {
   readonly kind = NonterminalKind.YulExpression;
 
@@ -17,24 +36,7 @@ export class YulExpression extends SlangNode {
   constructor(ast: ast.YulExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.YulFunctionCallExpression:
-        this.variant = new YulFunctionCallExpression(
-          variant as ast.YulFunctionCallExpression,
-          options
-        );
-        break;
-      case NonterminalKind.YulLiteral:
-        this.variant = new YulLiteral(variant as ast.YulLiteral, options);
-        break;
-      case NonterminalKind.YulPath:
-        this.variant = new YulPath(variant as ast.YulPath);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { YulFunctionCallExpression } from './YulFunctionCallExpression.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulPath } from './YulPath.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,19 +13,17 @@ function createNonterminalVariant(
   variant: ast.YulExpression['variant'],
   options: ParserOptions<AstNode>
 ): YulExpression['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.YulFunctionCallExpression:
-      return new YulFunctionCallExpression(
-        variant as ast.YulFunctionCallExpression,
-        options
-      );
-    case NonterminalKind.YulLiteral:
-      return new YulLiteral(variant as ast.YulLiteral, options);
-    case NonterminalKind.YulPath:
-      return new YulPath(variant as ast.YulPath);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.YulFunctionCallExpression) {
+    return new YulFunctionCallExpression(variant, options);
   }
+  if (variant instanceof ast.YulLiteral) {
+    return new YulLiteral(variant, options);
+  }
+  if (variant instanceof ast.YulPath) {
+    return new YulPath(variant);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class YulExpression extends SlangNode {

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -17,21 +17,23 @@ export class YulExpression extends SlangNode {
   constructor(ast: ast.YulExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.YulFunctionCallExpression:
         this.variant = new YulFunctionCallExpression(
-          ast.variant as ast.YulFunctionCallExpression,
+          variant as ast.YulFunctionCallExpression,
           options
         );
         break;
       case NonterminalKind.YulLiteral:
-        this.variant = new YulLiteral(ast.variant as ast.YulLiteral, options);
+        this.variant = new YulLiteral(variant as ast.YulLiteral, options);
         break;
       case NonterminalKind.YulPath:
-        this.variant = new YulPath(ast.variant as ast.YulPath);
+        this.variant = new YulPath(variant as ast.YulPath);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
@@ -41,8 +42,6 @@ export class YulLiteral extends SlangNode {
   }
 
   print(path: AstPath<YulLiteral>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -1,10 +1,10 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -13,14 +13,14 @@ function createNonterminalVariant(
   variant: Exclude<ast.YulLiteral['variant'], TerminalNode>,
   options: ParserOptions<AstNode>
 ): Exclude<YulLiteral['variant'], string> {
-  switch (variant.cst.kind) {
-    case NonterminalKind.HexStringLiteral:
-      return new HexStringLiteral(variant as ast.HexStringLiteral, options);
-    case NonterminalKind.StringLiteral:
-      return new StringLiteral(variant as ast.StringLiteral, options);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.HexStringLiteral) {
+    return new HexStringLiteral(variant, options);
   }
+  if (variant instanceof ast.StringLiteral) {
+    return new StringLiteral(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class YulLiteral extends SlangNode {

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -17,25 +17,24 @@ export class YulLiteral extends SlangNode {
   constructor(ast: ast.YulLiteral, options: ParserOptions<AstNode>) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    switch (ast.variant.cst.kind) {
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.HexStringLiteral:
         this.variant = new HexStringLiteral(
-          ast.variant as ast.HexStringLiteral,
+          variant as ast.HexStringLiteral,
           options
         );
         break;
       case NonterminalKind.StringLiteral:
-        this.variant = new StringLiteral(
-          ast.variant as ast.StringLiteral,
-          options
-        );
+        this.variant = new StringLiteral(variant as ast.StringLiteral, options);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -9,6 +9,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: Exclude<ast.YulLiteral['variant'], TerminalNode>,
+  options: ParserOptions<AstNode>
+): Exclude<YulLiteral['variant'], string> {
+  switch (variant.cst.kind) {
+    case NonterminalKind.HexStringLiteral:
+      return new HexStringLiteral(variant as ast.HexStringLiteral, options);
+    case NonterminalKind.StringLiteral:
+      return new StringLiteral(variant as ast.StringLiteral, options);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class YulLiteral extends SlangNode {
   readonly kind = NonterminalKind.YulLiteral;
 
@@ -22,20 +36,7 @@ export class YulLiteral extends SlangNode {
       this.variant = variant.unparse();
       return;
     }
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.HexStringLiteral:
-        this.variant = new HexStringLiteral(
-          variant as ast.HexStringLiteral,
-          options
-        );
-        break;
-      case NonterminalKind.StringLiteral:
-        this.variant = new StringLiteral(variant as ast.StringLiteral, options);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -18,26 +18,26 @@ export class YulLiteral extends SlangNode {
 
     if (ast.variant instanceof TerminalNode) {
       this.variant = ast.variant.unparse();
-    } else {
-      switch (ast.variant.cst.kind) {
-        case NonterminalKind.HexStringLiteral:
-          this.variant = new HexStringLiteral(
-            ast.variant as ast.HexStringLiteral,
-            options
-          );
-          break;
-        case NonterminalKind.StringLiteral:
-          this.variant = new StringLiteral(
-            ast.variant as ast.StringLiteral,
-            options
-          );
-          break;
-        default:
-          throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
-      }
+      return;
+    }
+    switch (ast.variant.cst.kind) {
+      case NonterminalKind.HexStringLiteral:
+        this.variant = new HexStringLiteral(
+          ast.variant as ast.HexStringLiteral,
+          options
+        );
+        break;
+      case NonterminalKind.StringLiteral:
+        this.variant = new StringLiteral(
+          ast.variant as ast.StringLiteral,
+          options
+        );
+        break;
+      default:
+        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
     }
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<YulLiteral>, print: PrintFunction): Doc {

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -15,11 +15,12 @@ export class YulStackAssignmentOperator extends SlangNode {
   constructor(ast: ast.YulStackAssignmentOperator) {
     super(ast);
 
-    if (ast.variant instanceof TerminalNode) {
-      this.variant = ast.variant.unparse();
+    const variant = ast.variant;
+    if (variant instanceof TerminalNode) {
+      this.variant = variant.unparse();
       return;
     }
-    this.variant = new YulEqualAndColon(ast.variant);
+    this.variant = new YulEqualAndColon(variant);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind, TerminalNode } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulEqualAndColon } from './YulEqualAndColon.js';
 
@@ -24,8 +25,6 @@ export class YulStackAssignmentOperator extends SlangNode {
   }
 
   print(path: AstPath<YulStackAssignmentOperator>, print: PrintFunction): Doc {
-    return typeof this.variant === 'string'
-      ? this.variant
-      : path.call(print, 'variant');
+    return printVariant(this, path, print);
   }
 }

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -14,12 +14,13 @@ export class YulStackAssignmentOperator extends SlangNode {
   constructor(ast: ast.YulStackAssignmentOperator) {
     super(ast);
 
-    this.variant =
-      ast.variant instanceof TerminalNode
-        ? ast.variant.unparse()
-        : new YulEqualAndColon(ast.variant);
+    if (ast.variant instanceof TerminalNode) {
+      this.variant = ast.variant.unparse();
+      return;
+    }
+    this.variant = new YulEqualAndColon(ast.variant);
 
-    if (typeof this.variant !== 'string') this.updateMetadata(this.variant);
+    this.updateMetadata(this.variant);
   }
 
   print(path: AstPath<YulStackAssignmentOperator>, print: PrintFunction): Doc {

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -40,77 +40,72 @@ export class YulStatement extends SlangNode {
   constructor(ast: ast.YulStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.YulBlock:
-        this.variant = new YulBlock(ast.variant as ast.YulBlock, options);
+        this.variant = new YulBlock(variant as ast.YulBlock, options);
         break;
       case NonterminalKind.YulFunctionDefinition:
         this.variant = new YulFunctionDefinition(
-          ast.variant as ast.YulFunctionDefinition,
+          variant as ast.YulFunctionDefinition,
           options
         );
         break;
       case NonterminalKind.YulVariableDeclarationStatement:
         this.variant = new YulVariableDeclarationStatement(
-          ast.variant as ast.YulVariableDeclarationStatement,
+          variant as ast.YulVariableDeclarationStatement,
           options
         );
         break;
       case NonterminalKind.YulVariableAssignmentStatement:
         this.variant = new YulVariableAssignmentStatement(
-          ast.variant as ast.YulVariableAssignmentStatement,
+          variant as ast.YulVariableAssignmentStatement,
           options
         );
         break;
       case NonterminalKind.YulStackAssignmentStatement:
         this.variant = new YulStackAssignmentStatement(
-          ast.variant as ast.YulStackAssignmentStatement
+          variant as ast.YulStackAssignmentStatement
         );
         break;
       case NonterminalKind.YulIfStatement:
         this.variant = new YulIfStatement(
-          ast.variant as ast.YulIfStatement,
+          variant as ast.YulIfStatement,
           options
         );
         break;
       case NonterminalKind.YulForStatement:
         this.variant = new YulForStatement(
-          ast.variant as ast.YulForStatement,
+          variant as ast.YulForStatement,
           options
         );
         break;
       case NonterminalKind.YulSwitchStatement:
         this.variant = new YulSwitchStatement(
-          ast.variant as ast.YulSwitchStatement,
+          variant as ast.YulSwitchStatement,
           options
         );
         break;
       case NonterminalKind.YulLeaveStatement:
-        this.variant = new YulLeaveStatement(
-          ast.variant as ast.YulLeaveStatement
-        );
+        this.variant = new YulLeaveStatement(variant as ast.YulLeaveStatement);
         break;
       case NonterminalKind.YulBreakStatement:
-        this.variant = new YulBreakStatement(
-          ast.variant as ast.YulBreakStatement
-        );
+        this.variant = new YulBreakStatement(variant as ast.YulBreakStatement);
         break;
       case NonterminalKind.YulContinueStatement:
         this.variant = new YulContinueStatement(
-          ast.variant as ast.YulContinueStatement
+          variant as ast.YulContinueStatement
         );
         break;
       case NonterminalKind.YulLabel:
-        this.variant = new YulLabel(ast.variant as ast.YulLabel);
+        this.variant = new YulLabel(variant as ast.YulLabel);
         break;
       case NonterminalKind.YulExpression:
-        this.variant = new YulExpression(
-          ast.variant as ast.YulExpression,
-          options
-        );
+        this.variant = new YulExpression(variant as ast.YulExpression, options);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -19,6 +19,53 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.YulStatement['variant'],
+  options: ParserOptions<AstNode>
+): YulStatement['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.YulBlock:
+      return new YulBlock(variant as ast.YulBlock, options);
+    case NonterminalKind.YulFunctionDefinition:
+      return new YulFunctionDefinition(
+        variant as ast.YulFunctionDefinition,
+        options
+      );
+    case NonterminalKind.YulVariableDeclarationStatement:
+      return new YulVariableDeclarationStatement(
+        variant as ast.YulVariableDeclarationStatement,
+        options
+      );
+    case NonterminalKind.YulVariableAssignmentStatement:
+      return new YulVariableAssignmentStatement(
+        variant as ast.YulVariableAssignmentStatement,
+        options
+      );
+    case NonterminalKind.YulStackAssignmentStatement:
+      return new YulStackAssignmentStatement(
+        variant as ast.YulStackAssignmentStatement
+      );
+    case NonterminalKind.YulIfStatement:
+      return new YulIfStatement(variant as ast.YulIfStatement, options);
+    case NonterminalKind.YulForStatement:
+      return new YulForStatement(variant as ast.YulForStatement, options);
+    case NonterminalKind.YulSwitchStatement:
+      return new YulSwitchStatement(variant as ast.YulSwitchStatement, options);
+    case NonterminalKind.YulLeaveStatement:
+      return new YulLeaveStatement(variant as ast.YulLeaveStatement);
+    case NonterminalKind.YulBreakStatement:
+      return new YulBreakStatement(variant as ast.YulBreakStatement);
+    case NonterminalKind.YulContinueStatement:
+      return new YulContinueStatement(variant as ast.YulContinueStatement);
+    case NonterminalKind.YulLabel:
+      return new YulLabel(variant as ast.YulLabel);
+    case NonterminalKind.YulExpression:
+      return new YulExpression(variant as ast.YulExpression, options);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class YulStatement extends SlangNode {
   readonly kind = NonterminalKind.YulStatement;
 
@@ -40,73 +87,7 @@ export class YulStatement extends SlangNode {
   constructor(ast: ast.YulStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.YulBlock:
-        this.variant = new YulBlock(variant as ast.YulBlock, options);
-        break;
-      case NonterminalKind.YulFunctionDefinition:
-        this.variant = new YulFunctionDefinition(
-          variant as ast.YulFunctionDefinition,
-          options
-        );
-        break;
-      case NonterminalKind.YulVariableDeclarationStatement:
-        this.variant = new YulVariableDeclarationStatement(
-          variant as ast.YulVariableDeclarationStatement,
-          options
-        );
-        break;
-      case NonterminalKind.YulVariableAssignmentStatement:
-        this.variant = new YulVariableAssignmentStatement(
-          variant as ast.YulVariableAssignmentStatement,
-          options
-        );
-        break;
-      case NonterminalKind.YulStackAssignmentStatement:
-        this.variant = new YulStackAssignmentStatement(
-          variant as ast.YulStackAssignmentStatement
-        );
-        break;
-      case NonterminalKind.YulIfStatement:
-        this.variant = new YulIfStatement(
-          variant as ast.YulIfStatement,
-          options
-        );
-        break;
-      case NonterminalKind.YulForStatement:
-        this.variant = new YulForStatement(
-          variant as ast.YulForStatement,
-          options
-        );
-        break;
-      case NonterminalKind.YulSwitchStatement:
-        this.variant = new YulSwitchStatement(
-          variant as ast.YulSwitchStatement,
-          options
-        );
-        break;
-      case NonterminalKind.YulLeaveStatement:
-        this.variant = new YulLeaveStatement(variant as ast.YulLeaveStatement);
-        break;
-      case NonterminalKind.YulBreakStatement:
-        this.variant = new YulBreakStatement(variant as ast.YulBreakStatement);
-        break;
-      case NonterminalKind.YulContinueStatement:
-        this.variant = new YulContinueStatement(
-          variant as ast.YulContinueStatement
-        );
-        break;
-      case NonterminalKind.YulLabel:
-        this.variant = new YulLabel(variant as ast.YulLabel);
-        break;
-      case NonterminalKind.YulExpression:
-        this.variant = new YulExpression(variant as ast.YulExpression, options);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -1,3 +1,4 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
@@ -14,7 +15,6 @@ import { YulContinueStatement } from './YulContinueStatement.js';
 import { YulLabel } from './YulLabel.js';
 import { YulExpression } from './YulExpression.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -23,47 +23,47 @@ function createNonterminalVariant(
   variant: ast.YulStatement['variant'],
   options: ParserOptions<AstNode>
 ): YulStatement['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.YulBlock:
-      return new YulBlock(variant as ast.YulBlock, options);
-    case NonterminalKind.YulFunctionDefinition:
-      return new YulFunctionDefinition(
-        variant as ast.YulFunctionDefinition,
-        options
-      );
-    case NonterminalKind.YulVariableDeclarationStatement:
-      return new YulVariableDeclarationStatement(
-        variant as ast.YulVariableDeclarationStatement,
-        options
-      );
-    case NonterminalKind.YulVariableAssignmentStatement:
-      return new YulVariableAssignmentStatement(
-        variant as ast.YulVariableAssignmentStatement,
-        options
-      );
-    case NonterminalKind.YulStackAssignmentStatement:
-      return new YulStackAssignmentStatement(
-        variant as ast.YulStackAssignmentStatement
-      );
-    case NonterminalKind.YulIfStatement:
-      return new YulIfStatement(variant as ast.YulIfStatement, options);
-    case NonterminalKind.YulForStatement:
-      return new YulForStatement(variant as ast.YulForStatement, options);
-    case NonterminalKind.YulSwitchStatement:
-      return new YulSwitchStatement(variant as ast.YulSwitchStatement, options);
-    case NonterminalKind.YulLeaveStatement:
-      return new YulLeaveStatement(variant as ast.YulLeaveStatement);
-    case NonterminalKind.YulBreakStatement:
-      return new YulBreakStatement(variant as ast.YulBreakStatement);
-    case NonterminalKind.YulContinueStatement:
-      return new YulContinueStatement(variant as ast.YulContinueStatement);
-    case NonterminalKind.YulLabel:
-      return new YulLabel(variant as ast.YulLabel);
-    case NonterminalKind.YulExpression:
-      return new YulExpression(variant as ast.YulExpression, options);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.YulBlock) {
+    return new YulBlock(variant, options);
   }
+  if (variant instanceof ast.YulFunctionDefinition) {
+    return new YulFunctionDefinition(variant, options);
+  }
+  if (variant instanceof ast.YulVariableDeclarationStatement) {
+    return new YulVariableDeclarationStatement(variant, options);
+  }
+  if (variant instanceof ast.YulVariableAssignmentStatement) {
+    return new YulVariableAssignmentStatement(variant, options);
+  }
+  if (variant instanceof ast.YulStackAssignmentStatement) {
+    return new YulStackAssignmentStatement(variant);
+  }
+  if (variant instanceof ast.YulIfStatement) {
+    return new YulIfStatement(variant, options);
+  }
+  if (variant instanceof ast.YulForStatement) {
+    return new YulForStatement(variant, options);
+  }
+  if (variant instanceof ast.YulSwitchStatement) {
+    return new YulSwitchStatement(variant, options);
+  }
+  if (variant instanceof ast.YulLeaveStatement) {
+    return new YulLeaveStatement(variant);
+  }
+  if (variant instanceof ast.YulBreakStatement) {
+    return new YulBreakStatement(variant);
+  }
+  if (variant instanceof ast.YulContinueStatement) {
+    return new YulContinueStatement(variant);
+  }
+  if (variant instanceof ast.YulLabel) {
+    return new YulLabel(variant);
+  }
+  if (variant instanceof ast.YulExpression) {
+    return new YulExpression(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class YulStatement extends SlangNode {

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -16,21 +16,20 @@ export class YulSwitchCase extends SlangNode {
   constructor(ast: ast.YulSwitchCase, options: ParserOptions<AstNode>) {
     super(ast);
 
-    switch (ast.variant.cst.kind) {
+    const variant = ast.variant;
+    const variantKind = variant.cst.kind;
+    switch (variantKind) {
       case NonterminalKind.YulDefaultCase:
         this.variant = new YulDefaultCase(
-          ast.variant as ast.YulDefaultCase,
+          variant as ast.YulDefaultCase,
           options
         );
         break;
       case NonterminalKind.YulValueCase:
-        this.variant = new YulValueCase(
-          ast.variant as ast.YulValueCase,
-          options
-        );
+        this.variant = new YulValueCase(variant as ast.YulValueCase, options);
         break;
       default:
-        throw new Error(`Unexpected variant: ${ast.variant.cst.kind}`);
+        throw new Error(`Unexpected variant: ${variantKind}`);
     }
 
     this.updateMetadata(this.variant);

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -1,9 +1,9 @@
+import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { YulDefaultCase } from './YulDefaultCase.js';
 import { YulValueCase } from './YulValueCase.js';
 
-import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
@@ -12,14 +12,14 @@ function createNonterminalVariant(
   variant: ast.YulSwitchCase['variant'],
   options: ParserOptions<AstNode>
 ): YulSwitchCase['variant'] {
-  switch (variant.cst.kind) {
-    case NonterminalKind.YulDefaultCase:
-      return new YulDefaultCase(variant as ast.YulDefaultCase, options);
-    case NonterminalKind.YulValueCase:
-      return new YulValueCase(variant as ast.YulValueCase, options);
-    default:
-      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  if (variant instanceof ast.YulDefaultCase) {
+    return new YulDefaultCase(variant, options);
   }
+  if (variant instanceof ast.YulValueCase) {
+    return new YulValueCase(variant, options);
+  }
+  const exhaustiveCheck: never = variant;
+  return exhaustiveCheck;
 }
 
 export class YulSwitchCase extends SlangNode {

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -8,6 +8,20 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
+function createNonterminalVariant(
+  variant: ast.YulSwitchCase['variant'],
+  options: ParserOptions<AstNode>
+): YulSwitchCase['variant'] {
+  switch (variant.cst.kind) {
+    case NonterminalKind.YulDefaultCase:
+      return new YulDefaultCase(variant as ast.YulDefaultCase, options);
+    case NonterminalKind.YulValueCase:
+      return new YulValueCase(variant as ast.YulValueCase, options);
+    default:
+      throw new Error(`Unexpected variant: ${variant.cst.kind}`);
+  }
+}
+
 export class YulSwitchCase extends SlangNode {
   readonly kind = NonterminalKind.YulSwitchCase;
 
@@ -16,21 +30,7 @@ export class YulSwitchCase extends SlangNode {
   constructor(ast: ast.YulSwitchCase, options: ParserOptions<AstNode>) {
     super(ast);
 
-    const variant = ast.variant;
-    const variantKind = variant.cst.kind;
-    switch (variantKind) {
-      case NonterminalKind.YulDefaultCase:
-        this.variant = new YulDefaultCase(
-          variant as ast.YulDefaultCase,
-          options
-        );
-        break;
-      case NonterminalKind.YulValueCase:
-        this.variant = new YulValueCase(variant as ast.YulValueCase, options);
-        break;
-      default:
-        throw new Error(`Unexpected variant: ${variantKind}`);
-    }
+    this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/types.d.ts
+++ b/src/slang-nodes/types.d.ts
@@ -460,6 +460,13 @@ export type StrictAstNode =
   | YulPaths
   | YulPath;
 
+export type PolymorphicNode = Extract<StrictAstNode, { variant: unknown }>;
+
+export type StrictPolymorphicNode = Extract<
+  StrictAstNode,
+  { variant: StrictAstNode | Identifier | YulIdentifier }
+>;
+
 export type Collection = Extract<StrictAstNode, { items: unknown[] }>;
 
 export type NodeCollection = Extract<
@@ -469,7 +476,7 @@ export type NodeCollection = Extract<
 
 export type LineCollection = Extract<
   NodeCollection,
-  { items: Extract<StrictAstNode, { variant: StrictAstNode }>[] }
+  { items: StrictPolymorphicNode[] }
 >;
 
 export type BinaryOperation = Extract<

--- a/src/slang-printers/print-variant.ts
+++ b/src/slang-printers/print-variant.ts
@@ -1,0 +1,11 @@
+import type { AstPath, Doc } from 'prettier';
+import type { PolymorphicNode } from '../slang-nodes/types.d.ts';
+import type { PrintFunction } from '../types.d.ts';
+
+export function printVariant(
+  { variant }: PolymorphicNode,
+  path: AstPath<PolymorphicNode>,
+  print: PrintFunction
+): Doc {
+  return typeof variant === 'string' ? variant : path.call(print, 'variant');
+}


### PR DESCRIPTION
Main changes:

- we return early if the variant is a Terminal node since we don't have to calculate new `loc` or `comments` and avoid having to check again at the end.
- storing `variant` and `variantKind` so we don't have to check every time.
- adding a `printVariant` helper to standardise the printing of variants