### PR TITLE
Fix extra line in ContractSpecifiers

### DIFF
--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -31,7 +31,12 @@ export class StorageLayoutSpecifier extends SlangNode {
     return [
       'layout at',
       printSeparatedItem(path.call(print, 'expression'), {
-        firstSeparator: line
+        firstSeparator: line,
+        // If this is the second ContractSpecifier we have to delegate printing
+        // the line to the ContractSpecifiers node.
+        lastSeparator: path.callParent((parentPath) => parentPath.isFirst)
+          ? line
+          : ''
       })
     ];
   }

--- a/tests/format/Comments/__snapshots__/format.test.js.snap
+++ b/tests/format/Comments/__snapshots__/format.test.js.snap
@@ -275,9 +275,7 @@ contract Comments4c
         Interface4,
         Interface5,
         Interface6 /*why we used Interface6*/
-    layout at
-        /*where should this go?*/ f(123 + 456) /*why we used this layout*/
-
+    layout at /*where should this go?*/ f(123 + 456) /*why we used this layout*/
 {
     // solhint-disable-previous-line no-empty-blocks
 }

--- a/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
+++ b/tests/format/ContractDefinitions/__snapshots__/format.test.js.snap
@@ -79,7 +79,7 @@ contract StorageLayoutSpecifier2 layout at
     )
 {}
 
-contract StorageLayoutSpecifier3 is Contract1 layout at 123  {}
+contract StorageLayoutSpecifier3 is Contract1 layout at 123 {}
 
 contract StorageLayoutSpecifier4
     is Contract1, Contract2, Contract3, Contract4, Contract5
@@ -100,7 +100,6 @@ contract StorageLayoutSpecifier6
                 12345678901234567890 -
                 12345678901234567890
         )
-
 {}
 
 contract StorageLayoutSpecifier7
@@ -143,7 +142,6 @@ contract StorageLayoutSpecifier9
                 12345678901234567890 -
                 12345678901234567890
         )
-
 {}
 
 contract InheritanceSpecifier1 is SomeOtherContract(1234, false) {}
@@ -167,7 +165,6 @@ contract InheritanceSpecifier4
                 12345678901234567890 -
                 12345678901234567890
         )
-
 {}
 
 contract LongInheritanceSpecifier1 is
@@ -212,7 +209,6 @@ contract LongInheritanceSpecifier4
                 12345678901234567890 -
                 12345678901234567890
         )
-
 {}
 
 ================================================================================


### PR DESCRIPTION
There was an extra line being printed after a StorageSpecifier when there was a InheritanceSpecifier present in the ContractSpecifiers' array