### PR TITLE
using Slang API to ignore trivia nodes

### DIFF
--- a/src/slang-nodes/SlangNode.ts
+++ b/src/slang-nodes/SlangNode.ts
@@ -37,7 +37,7 @@ function isNonTriviaNode(node: Node): boolean {
   );
 }
 
-function getOffset(children: Edge[] | Iterable<Edge>): number {
+function getOffset(children: Iterable<Edge>): number {
   let offset = 0;
   for (const { node } of children) {
     if (isNonTriviaNode(node)) {


### PR DESCRIPTION
mainly future proofing in case Slang adds a new trivia `kind` in future versions.