### PR TITLE
Polymorphic nodes

### DIFF
--- a/src/slang-comments/handlers/handle-source-unit-members-comments.ts
+++ b/src/slang-comments/handlers/handle-source-unit-members-comments.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
 
-import type { HandlerParams } from './types.js';
+import type { HandlerParams } from './types.d.ts';
 
 export default function handleSourceUnitMembersComments({
   precedingNode,

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { PositionalArgumentsDeclaration } from './PositionalArgumentsDeclaration.js';
 import { NamedArgumentsDeclaration } from './NamedArgumentsDeclaration.js';
 
@@ -21,7 +21,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ArgumentsDeclaration extends SlangNode {
+export class ArgumentsDeclaration extends PolymorphicNode {
   readonly kind = NonterminalKind.ArgumentsDeclaration;
 
   variant: PositionalArgumentsDeclaration | NamedArgumentsDeclaration;

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { PositionalArgumentsDeclaration } from './PositionalArgumentsDeclaration.js';
 import { NamedArgumentsDeclaration } from './NamedArgumentsDeclaration.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.ArgumentsDeclaration['variant'],
@@ -33,9 +32,5 @@ export class ArgumentsDeclaration extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ArgumentsDeclaration>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class ConstructorAttribute extends SlangNode {
+export class ConstructorAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.ConstructorAttribute;
 
   variant: ModifierInvocation | TerminalNode;

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -7,9 +7,8 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class ConstructorAttribute extends SlangNode {
   readonly kind = NonterminalKind.ConstructorAttribute;
@@ -27,9 +26,5 @@ export class ConstructorAttribute extends SlangNode {
     this.variant = new ModifierInvocation(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ConstructorAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -41,12 +41,12 @@ export class ContractDefinition extends SlangNode {
     // Older versions of Solidity defined a constructor as a function having
     // the same name as the contract.
     if (!satisfies(options.compiler, '>=0.5.0')) {
-      for (const { variant: member } of this.members.items) {
+      for (const { variant } of this.members.items) {
         if (
-          member.kind === NonterminalKind.FunctionDefinition &&
-          member.name.variant.value !== this.name.value
+          variant.kind === NonterminalKind.FunctionDefinition &&
+          variant.name.variant.value !== this.name.value
         ) {
-          member.cleanModifierInvocationArguments();
+          variant.cleanModifierInvocationArguments();
         }
       }
     }

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { UsingDirective } from './UsingDirective.js';
 import { FunctionDefinition } from './FunctionDefinition.js';
 import { ConstructorDefinition } from './ConstructorDefinition.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ContractMember extends SlangNode {
+export class ContractMember extends PolymorphicNode {
   readonly kind = NonterminalKind.ContractMember;
 
   variant:

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -15,9 +15,8 @@ import { StateVariableDefinition } from './StateVariableDefinition.js';
 import { ErrorDefinition } from './ErrorDefinition.js';
 import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.ContractMember['variant'],
@@ -90,9 +89,5 @@ export class ContractMember extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ContractMember>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { StorageLayoutSpecifier } from './StorageLayoutSpecifier.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.ContractSpecifier['variant'],
@@ -33,9 +32,5 @@ export class ContractSpecifier extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ContractSpecifier>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { StorageLayoutSpecifier } from './StorageLayoutSpecifier.js';
 
@@ -21,7 +21,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ContractSpecifier extends SlangNode {
+export class ContractSpecifier extends PolymorphicNode {
   readonly kind = NonterminalKind.ContractSpecifier;
 
   variant: InheritanceSpecifier | StorageLayoutSpecifier;

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { AddressType } from './AddressType.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class ElementaryType extends SlangNode {
+export class ElementaryType extends PolymorphicNode {
   readonly kind = NonterminalKind.ElementaryType;
 
   variant: AddressType | TerminalNode;

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -7,8 +7,6 @@ import { AddressType } from './AddressType.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class ElementaryType extends SlangNode {
   readonly kind = NonterminalKind.ElementaryType;
@@ -26,9 +24,5 @@ export class ElementaryType extends SlangNode {
     this.variant = new AddressType(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ElementaryType>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class ExperimentalFeature extends SlangNode {
+export class ExperimentalFeature extends PolymorphicNode {
   readonly kind = NonterminalKind.ExperimentalFeature;
 
   variant: StringLiteral | TerminalNode;

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -7,9 +7,8 @@ import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class ExperimentalFeature extends SlangNode {
   readonly kind = NonterminalKind.ExperimentalFeature;
@@ -27,9 +26,5 @@ export class ExperimentalFeature extends SlangNode {
     this.variant = new StringLiteral(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ExperimentalFeature>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { AssignmentExpression } from './AssignmentExpression.js';
 import { ConditionalExpression } from './ConditionalExpression.js';
 import { OrExpression } from './OrExpression.js';
@@ -125,7 +125,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class Expression extends SlangNode {
+export class Expression extends PolymorphicNode {
   readonly kind = NonterminalKind.Expression;
 
   variant:

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -33,9 +33,8 @@ import { StringExpression } from './StringExpression.js';
 import { ElementaryType } from './ElementaryType.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<ast.Expression['variant'], SlangTerminalNode>,
@@ -170,9 +169,5 @@ export class Expression extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<Expression>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -8,9 +8,8 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<ast.FallbackFunctionAttribute['variant'], SlangTerminalNode>,
@@ -45,9 +44,5 @@ export class FallbackFunctionAttribute extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<FallbackFunctionAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class FallbackFunctionAttribute extends SlangNode {
+export class FallbackFunctionAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.FallbackFunctionAttribute;
 
   variant: ModifierInvocation | OverrideSpecifier | TerminalNode;

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -4,12 +4,11 @@ import {
 } from '@nomicfoundation/slang/cst';
 import { SlangNode } from './SlangNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
+import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
-import { TerminalNode } from './TerminalNode.js';
 
 export class ForStatementCondition extends SlangNode {
   readonly kind = NonterminalKind.ForStatementCondition;
@@ -27,9 +26,5 @@ export class ForStatementCondition extends SlangNode {
     this.variant = new ExpressionStatement(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ForStatementCondition>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class ForStatementCondition extends SlangNode {
+export class ForStatementCondition extends PolymorphicNode {
   readonly kind = NonterminalKind.ForStatementCondition;
 
   variant: ExpressionStatement | TerminalNode;

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
@@ -32,7 +32,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ForStatementInitialization extends SlangNode {
+export class ForStatementInitialization extends PolymorphicNode {
   readonly kind = NonterminalKind.ForStatementInitialization;
 
   variant:

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -9,9 +9,8 @@ import { VariableDeclarationStatement } from './VariableDeclarationStatement.js'
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<
@@ -56,9 +55,5 @@ export class ForStatementInitialization extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ForStatementInitialization>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class FunctionAttribute extends SlangNode {
+export class FunctionAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.FunctionAttribute;
 
   variant: ModifierInvocation | OverrideSpecifier | TerminalNode;

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -8,9 +8,8 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<ast.FunctionAttribute['variant'], SlangTerminalNode>,
@@ -42,9 +41,5 @@ export class FunctionAttribute extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<FunctionAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -7,9 +7,8 @@ import { Block } from './Block.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class FunctionBody extends SlangNode {
   readonly kind = NonterminalKind.FunctionBody;
@@ -27,9 +26,5 @@ export class FunctionBody extends SlangNode {
     this.variant = new Block(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<FunctionBody>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { Block } from './Block.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class FunctionBody extends SlangNode {
+export class FunctionBody extends PolymorphicNode {
   readonly kind = NonterminalKind.FunctionBody;
 
   variant: Block | TerminalNode;

--- a/src/slang-nodes/FunctionName.ts
+++ b/src/slang-nodes/FunctionName.ts
@@ -1,10 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class FunctionName extends SlangNode {
+export class FunctionName extends PolymorphicNode {
   readonly kind = NonterminalKind.FunctionName;
 
   variant: TerminalNode;

--- a/src/slang-nodes/FunctionName.ts
+++ b/src/slang-nodes/FunctionName.ts
@@ -3,8 +3,6 @@ import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class FunctionName extends SlangNode {
   readonly kind = NonterminalKind.FunctionName;
@@ -15,9 +13,5 @@ export class FunctionName extends SlangNode {
     super(ast);
 
     this.variant = new TerminalNode(ast.variant);
-  }
-
-  print(path: AstPath<FunctionName>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/FunctionTypeAttribute.ts
+++ b/src/slang-nodes/FunctionTypeAttribute.ts
@@ -1,10 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class FunctionTypeAttribute extends SlangNode {
+export class FunctionTypeAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.FunctionTypeAttribute;
 
   variant: TerminalNode;

--- a/src/slang-nodes/FunctionTypeAttribute.ts
+++ b/src/slang-nodes/FunctionTypeAttribute.ts
@@ -3,8 +3,6 @@ import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class FunctionTypeAttribute extends SlangNode {
   readonly kind = NonterminalKind.FunctionTypeAttribute;
@@ -15,9 +13,5 @@ export class FunctionTypeAttribute extends SlangNode {
     super(ast);
 
     this.variant = new TerminalNode(ast.variant);
-  }
-
-  print(path: AstPath<FunctionTypeAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { PathImport } from './PathImport.js';
 import { NamedImport } from './NamedImport.js';
 import { ImportDeconstruction } from './ImportDeconstruction.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ImportClause extends SlangNode {
+export class ImportClause extends PolymorphicNode {
   readonly kind = NonterminalKind.ImportClause;
 
   variant: PathImport | NamedImport | ImportDeconstruction;

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -5,9 +5,8 @@ import { PathImport } from './PathImport.js';
 import { NamedImport } from './NamedImport.js';
 import { ImportDeconstruction } from './ImportDeconstruction.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.ImportClause['variant'],
@@ -37,9 +36,5 @@ export class ImportClause extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ImportClause>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -4,9 +4,6 @@ import { SlangNode } from './SlangNode.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
-
 function createNonterminalVariant(
   variant: ast.MappingKeyType['variant']
 ): MappingKeyType['variant'] {
@@ -31,9 +28,5 @@ export class MappingKeyType extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<MappingKeyType>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
@@ -17,7 +17,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class MappingKeyType extends SlangNode {
+export class MappingKeyType extends PolymorphicNode {
   readonly kind = NonterminalKind.MappingKeyType;
 
   variant: ElementaryType | IdentifierPath;

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -7,8 +7,6 @@ import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class ModifierAttribute extends SlangNode {
   readonly kind = NonterminalKind.ModifierAttribute;
@@ -26,9 +24,5 @@ export class ModifierAttribute extends SlangNode {
     this.variant = new OverrideSpecifier(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ModifierAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class ModifierAttribute extends SlangNode {
+export class ModifierAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.ModifierAttribute;
 
   variant: OverrideSpecifier | TerminalNode;

--- a/src/slang-nodes/PolymorphicNode.ts
+++ b/src/slang-nodes/PolymorphicNode.ts
@@ -1,9 +1,17 @@
 import { SlangNode } from './SlangNode.js';
 
-import type { SlangAstNode } from '../types.d.ts';
+import type { AstPath, Doc } from 'prettier';
+import type { PrintFunction, SlangAstNode } from '../types.d.ts';
+import type { StrictPolymorphicNode } from './types.js';
 
-export class PolymorphicNode extends SlangNode {
+export abstract class PolymorphicNode extends SlangNode {
+  abstract variant: StrictPolymorphicNode['variant'];
+
   constructor(ast: SlangAstNode) {
     super(ast);
+  }
+
+  print(path: AstPath<PolymorphicNode>, print: PrintFunction): Doc {
+    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/PolymorphicNode.ts
+++ b/src/slang-nodes/PolymorphicNode.ts
@@ -2,7 +2,7 @@ import { SlangNode } from './SlangNode.js';
 
 import type { AstPath, Doc } from 'prettier';
 import type { PrintFunction, SlangAstNode } from '../types.d.ts';
-import type { StrictPolymorphicNode } from './types.js';
+import type { StrictPolymorphicNode } from './types.d.ts';
 
 export abstract class PolymorphicNode extends SlangNode {
   abstract variant: StrictPolymorphicNode['variant'];

--- a/src/slang-nodes/PolymorphicNode.ts
+++ b/src/slang-nodes/PolymorphicNode.ts
@@ -1,0 +1,9 @@
+import { SlangNode } from './SlangNode.js';
+
+import type { SlangAstNode } from '../types.d.ts';
+
+export class PolymorphicNode extends SlangNode {
+  constructor(ast: SlangAstNode) {
+    super(ast);
+  }
+}

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { AbicoderPragma } from './AbicoderPragma.js';
 import { ExperimentalPragma } from './ExperimentalPragma.js';
 import { VersionPragma } from './VersionPragma.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class Pragma extends SlangNode {
+export class Pragma extends PolymorphicNode {
   readonly kind = NonterminalKind.Pragma;
 
   variant: AbicoderPragma | ExperimentalPragma | VersionPragma;

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -5,9 +5,8 @@ import { AbicoderPragma } from './AbicoderPragma.js';
 import { ExperimentalPragma } from './ExperimentalPragma.js';
 import { VersionPragma } from './VersionPragma.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.Pragma['variant'],
@@ -37,9 +36,5 @@ export class Pragma extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<Pragma>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ReceiveFunctionAttribute extends SlangNode {
+export class ReceiveFunctionAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.ReceiveFunctionAttribute;
 
   variant: ModifierInvocation | OverrideSpecifier | TerminalNode;

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -8,9 +8,8 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<ast.ReceiveFunctionAttribute['variant'], SlangTerminalNode>,
@@ -45,9 +44,5 @@ export class ReceiveFunctionAttribute extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<ReceiveFunctionAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { PragmaDirective } from './PragmaDirective.js';
 import { ImportDirective } from './ImportDirective.js';
 import { ContractDefinition } from './ContractDefinition.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class SourceUnitMember extends SlangNode {
+export class SourceUnitMember extends PolymorphicNode {
   readonly kind = NonterminalKind.SourceUnitMember;
 
   variant:

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -15,9 +15,8 @@ import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition
 import { UsingDirective } from './UsingDirective.js';
 import { EventDefinition } from './EventDefinition.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.SourceUnitMember['variant'],
@@ -90,9 +89,5 @@ export class SourceUnitMember extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<SourceUnitMember>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class StateVariableAttribute extends SlangNode {
+export class StateVariableAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.StateVariableAttribute;
 
   variant: OverrideSpecifier | TerminalNode;

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -7,8 +7,6 @@ import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class StateVariableAttribute extends SlangNode {
   readonly kind = NonterminalKind.StateVariableAttribute;
@@ -26,9 +24,5 @@ export class StateVariableAttribute extends SlangNode {
     this.variant = new OverrideSpecifier(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<StateVariableAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
@@ -81,7 +81,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class Statement extends SlangNode {
+export class Statement extends PolymorphicNode {
   readonly kind = NonterminalKind.Statement;
 
   variant:

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -19,9 +19,8 @@ import { AssemblyStatement } from './AssemblyStatement.js';
 import { Block } from './Block.js';
 import { UncheckedBlock } from './UncheckedBlock.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.Statement['variant'],
@@ -110,9 +109,5 @@ export class Statement extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<Statement>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -7,9 +7,8 @@ import { HexStringLiteral } from './HexStringLiteral.js';
 import { HexStringLiterals } from './HexStringLiterals.js';
 import { UnicodeStringLiterals } from './UnicodeStringLiterals.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.StringExpression['variant'],
@@ -50,9 +49,5 @@ export class StringExpression extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<StringExpression>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { StringLiteral } from './StringLiteral.js';
 import { StringLiterals } from './StringLiterals.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
@@ -33,7 +33,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class StringExpression extends SlangNode {
+export class StringExpression extends PolymorphicNode {
   readonly kind = NonterminalKind.StringExpression;
 
   variant:

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypedTupleMember } from './TypedTupleMember.js';
 import { UntypedTupleMember } from './UntypedTupleMember.js';
 
@@ -21,7 +21,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class TupleMember extends SlangNode {
+export class TupleMember extends PolymorphicNode {
   readonly kind = NonterminalKind.TupleMember;
 
   variant: TypedTupleMember | UntypedTupleMember;

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { TypedTupleMember } from './TypedTupleMember.js';
 import { UntypedTupleMember } from './UntypedTupleMember.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.TupleMember['variant'],
@@ -33,9 +32,5 @@ export class TupleMember extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<TupleMember>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -9,7 +9,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-import type { Expression } from './Expression.js';
+import type { Expression } from './Expression.ts';
 
 export class TupleValues extends SlangNode {
   readonly kind = NonterminalKind.TupleValues;

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ArrayTypeName } from './ArrayTypeName.js';
 import { FunctionType } from './FunctionType.js';
 import { MappingType } from './MappingType.js';
@@ -33,7 +33,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class TypeName extends SlangNode {
+export class TypeName extends PolymorphicNode {
   readonly kind = NonterminalKind.TypeName;
 
   variant:

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -7,9 +7,8 @@ import { MappingType } from './MappingType.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.TypeName['variant'],
@@ -50,9 +49,5 @@ export class TypeName extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<TypeName>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -7,9 +7,8 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class UnnamedFunctionAttribute extends SlangNode {
   readonly kind = NonterminalKind.UnnamedFunctionAttribute;
@@ -30,9 +29,5 @@ export class UnnamedFunctionAttribute extends SlangNode {
     this.variant = new ModifierInvocation(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<UnnamedFunctionAttribute>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class UnnamedFunctionAttribute extends SlangNode {
+export class UnnamedFunctionAttribute extends PolymorphicNode {
   readonly kind = NonterminalKind.UnnamedFunctionAttribute;
 
   variant: ModifierInvocation | TerminalNode;

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { UsingDeconstruction } from './UsingDeconstruction.js';
 
@@ -17,7 +17,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class UsingClause extends SlangNode {
+export class UsingClause extends PolymorphicNode {
   readonly kind = NonterminalKind.UsingClause;
 
   variant: IdentifierPath | UsingDeconstruction;

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -4,9 +4,6 @@ import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { UsingDeconstruction } from './UsingDeconstruction.js';
 
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
-
 function createNonterminalVariant(
   variant: ast.UsingClause['variant']
 ): UsingClause['variant'] {
@@ -31,9 +28,5 @@ export class UsingClause extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<UsingClause>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -7,9 +7,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class UsingTarget extends SlangNode {
   readonly kind = NonterminalKind.UsingTarget;
@@ -27,9 +26,5 @@ export class UsingTarget extends SlangNode {
     this.variant = new TypeName(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<UsingTarget>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class UsingTarget extends SlangNode {
+export class UsingTarget extends PolymorphicNode {
   readonly kind = NonterminalKind.UsingTarget;
 
   variant: TypeName | TerminalNode;

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -7,9 +7,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 export class VariableDeclarationType extends SlangNode {
   readonly kind = NonterminalKind.VariableDeclarationType;
@@ -30,9 +29,5 @@ export class VariableDeclarationType extends SlangNode {
     this.variant = new TypeName(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<VariableDeclarationType>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -2,7 +2,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
@@ -10,7 +10,7 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
 
-export class VariableDeclarationType extends SlangNode {
+export class VariableDeclarationType extends PolymorphicNode {
   readonly kind = NonterminalKind.VariableDeclarationType;
 
   variant: TypeName | TerminalNode;

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { VersionRange } from './VersionRange.js';
 import { VersionTerm } from './VersionTerm.js';
 
@@ -17,7 +17,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class VersionExpression extends SlangNode {
+export class VersionExpression extends PolymorphicNode {
   readonly kind = NonterminalKind.VersionExpression;
 
   variant: VersionRange | VersionTerm;

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -4,9 +4,6 @@ import { SlangNode } from './SlangNode.js';
 import { VersionRange } from './VersionRange.js';
 import { VersionTerm } from './VersionTerm.js';
 
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
-
 function createNonterminalVariant(
   variant: ast.VersionExpression['variant']
 ): VersionExpression['variant'] {
@@ -31,9 +28,5 @@ export class VersionExpression extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<VersionExpression>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -7,8 +7,6 @@ import { SimpleVersionLiteral } from './SimpleVersionLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class VersionLiteral extends SlangNode {
   readonly kind = NonterminalKind.VersionLiteral;
@@ -26,9 +24,5 @@ export class VersionLiteral extends SlangNode {
     this.variant = new SimpleVersionLiteral(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<VersionLiteral>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { SimpleVersionLiteral } from './SimpleVersionLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class VersionLiteral extends SlangNode {
+export class VersionLiteral extends PolymorphicNode {
   readonly kind = NonterminalKind.VersionLiteral;
 
   variant: SimpleVersionLiteral | TerminalNode;

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulColonAndEqual } from './YulColonAndEqual.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class YulAssignmentOperator extends SlangNode {
+export class YulAssignmentOperator extends PolymorphicNode {
   readonly kind = NonterminalKind.YulAssignmentOperator;
 
   variant: YulColonAndEqual | TerminalNode;

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -7,8 +7,6 @@ import { YulColonAndEqual } from './YulColonAndEqual.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class YulAssignmentOperator extends SlangNode {
   readonly kind = NonterminalKind.YulAssignmentOperator;
@@ -26,9 +24,5 @@ export class YulAssignmentOperator extends SlangNode {
     this.variant = new YulColonAndEqual(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulAssignmentOperator>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -5,9 +5,8 @@ import { YulFunctionCallExpression } from './YulFunctionCallExpression.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulPath } from './YulPath.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.YulExpression['variant'],
@@ -37,9 +36,5 @@ export class YulExpression extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulExpression>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulFunctionCallExpression } from './YulFunctionCallExpression.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulPath } from './YulPath.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class YulExpression extends SlangNode {
+export class YulExpression extends PolymorphicNode {
   readonly kind = NonterminalKind.YulExpression;
 
   variant: YulFunctionCallExpression | YulLiteral | YulPath;

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -8,9 +8,8 @@ import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: Exclude<ast.YulLiteral['variant'], SlangTerminalNode>,
@@ -42,9 +41,5 @@ export class YulLiteral extends SlangNode {
     this.variant = createNonterminalVariant(variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulLiteral>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -3,7 +3,7 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -25,7 +25,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class YulLiteral extends SlangNode {
+export class YulLiteral extends PolymorphicNode {
   readonly kind = NonterminalKind.YulLiteral;
 
   variant: HexStringLiteral | StringLiteral | TerminalNode;

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -7,8 +7,6 @@ import { YulEqualAndColon } from './YulEqualAndColon.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
-import type { PrintFunction } from '../types.d.ts';
 
 export class YulStackAssignmentOperator extends SlangNode {
   readonly kind = NonterminalKind.YulStackAssignmentOperator;
@@ -26,9 +24,5 @@ export class YulStackAssignmentOperator extends SlangNode {
     this.variant = new YulEqualAndColon(variant);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulStackAssignmentOperator>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -2,13 +2,13 @@ import {
   NonterminalKind,
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulEqualAndColon } from './YulEqualAndColon.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 
-export class YulStackAssignmentOperator extends SlangNode {
+export class YulStackAssignmentOperator extends PolymorphicNode {
   readonly kind = NonterminalKind.YulStackAssignmentOperator;
 
   variant: YulEqualAndColon | TerminalNode;

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulBlock } from './YulBlock.js';
 import { YulFunctionDefinition } from './YulFunctionDefinition.js';
 import { YulVariableDeclarationStatement } from './YulVariableDeclarationStatement.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class YulStatement extends SlangNode {
+export class YulStatement extends PolymorphicNode {
   readonly kind = NonterminalKind.YulStatement;
 
   variant:

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -15,9 +15,8 @@ import { YulContinueStatement } from './YulContinueStatement.js';
 import { YulLabel } from './YulLabel.js';
 import { YulExpression } from './YulExpression.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.YulStatement['variant'],
@@ -90,9 +89,5 @@ export class YulStatement extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulStatement>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { YulDefaultCase } from './YulDefaultCase.js';
 import { YulValueCase } from './YulValueCase.js';
 
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { ParserOptions } from 'prettier';
 import type { AstNode } from './types.d.ts';
-import type { PrintFunction } from '../types.d.ts';
 
 function createNonterminalVariant(
   variant: ast.YulSwitchCase['variant'],
@@ -33,9 +32,5 @@ export class YulSwitchCase extends SlangNode {
     this.variant = createNonterminalVariant(ast.variant, options);
 
     this.updateMetadata(this.variant);
-  }
-
-  print(path: AstPath<YulSwitchCase>, print: PrintFunction): Doc {
-    return path.call(print, 'variant');
   }
 }

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulDefaultCase } from './YulDefaultCase.js';
 import { YulValueCase } from './YulValueCase.js';
 
@@ -21,7 +21,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class YulSwitchCase extends SlangNode {
+export class YulSwitchCase extends PolymorphicNode {
   readonly kind = NonterminalKind.YulSwitchCase;
 
   variant: YulDefaultCase | YulValueCase;

--- a/src/slang-utils/is-polymorphic-node.ts
+++ b/src/slang-utils/is-polymorphic-node.ts
@@ -1,0 +1,7 @@
+import type { PolymorphicNode, StrictAstNode } from '../slang-nodes/types.d.ts';
+
+export function isPolymorphicNode(
+  node: StrictAstNode
+): node is PolymorphicNode {
+  return typeof (node as PolymorphicNode).variant !== 'undefined';
+}

--- a/src/slang-utils/is-polymorphic-node.ts
+++ b/src/slang-utils/is-polymorphic-node.ts
@@ -1,7 +1,8 @@
+import { PolymorphicNode as PolymorphicNodeBase } from '../slang-nodes/PolymorphicNode.js';
 import type { PolymorphicNode, StrictAstNode } from '../slang-nodes/types.d.ts';
 
 export function isPolymorphicNode(
   node: StrictAstNode
 ): node is PolymorphicNode {
-  return typeof (node as PolymorphicNode).variant !== 'undefined';
+  return node instanceof PolymorphicNodeBase;
 }

--- a/src/slang-utils/is-polymorphic-node.ts
+++ b/src/slang-utils/is-polymorphic-node.ts
@@ -1,8 +1,0 @@
-import { PolymorphicNode as PolymorphicNodeBase } from '../slang-nodes/PolymorphicNode.js';
-import type { PolymorphicNode, StrictAstNode } from '../slang-nodes/types.d.ts';
-
-export function isPolymorphicNode(
-  node: StrictAstNode
-): node is PolymorphicNode {
-  return node instanceof PolymorphicNodeBase;
-}

--- a/src/slang-utils/sort-contract-specifiers.ts
+++ b/src/slang-utils/sort-contract-specifiers.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 
-import type { ContractSpecifier } from '../slang-nodes/ContractSpecifier.js';
+import type { ContractSpecifier } from '../slang-nodes/ContractSpecifier.ts';
 
 export function sortContractSpecifiers(
   { variant: { kind: aKind } }: ContractSpecifier,

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -1,5 +1,6 @@
 import { isBlockComment } from './slang-utils/is-comment.js';
 import { locEnd, locStart } from './slang-utils/loc.js';
+import { isPolymorphicNode } from './slang-utils/is-polymorphic-node.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode, StrictAstNode } from './slang-nodes/types.d.ts';
@@ -28,7 +29,6 @@ function ignoreComments(path: AstPath<AstNode>): void {
       // parser. `updateMetadata` is an internal function.
       case 'kind':
       case 'loc':
-      case 'print':
       case 'updateMetadata':
         break;
       // The key `comments` will contain every comment for this node.
@@ -58,12 +58,15 @@ function genericPrint(
 ): Doc {
   const node = path.node;
 
+  if (typeof node === 'string') return node;
+
   if (hasNodeIgnoreComment(node)) {
     ignoreComments(path);
 
     return options.originalText.slice(locStart(node), locEnd(node));
   }
 
+  if (isPolymorphicNode(node)) return path.call(print, 'variant');
   // Since each node has a print function with a specific AstPath, the union of
   // all nodes into AstNode creates a print function with an AstPath of the
   // intersection of all nodes. This forces us to cast this with a never type.

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -1,6 +1,5 @@
 import { isBlockComment } from './slang-utils/is-comment.js';
 import { locEnd, locStart } from './slang-utils/loc.js';
-import { isPolymorphicNode } from './slang-utils/is-polymorphic-node.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { AstNode, StrictAstNode } from './slang-nodes/types.d.ts';
@@ -29,6 +28,7 @@ function ignoreComments(path: AstPath<AstNode>): void {
       // parser. `updateMetadata` is an internal function.
       case 'kind':
       case 'loc':
+      case 'print':
       case 'updateMetadata':
         break;
       // The key `comments` will contain every comment for this node.
@@ -64,7 +64,6 @@ function genericPrint(
     return options.originalText.slice(locStart(node), locEnd(node));
   }
 
-  if (isPolymorphicNode(node)) return path.call(print, 'variant');
   // Since each node has a print function with a specific AstPath, the union of
   // all nodes into AstNode creates a print function with an AstPath of the
   // intersection of all nodes. This forces us to cast this with a never type.

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -58,8 +58,6 @@ function genericPrint(
 ): Doc {
   const node = path.node;
 
-  if (typeof node === 'string') return node;
-
   if (hasNodeIgnoreComment(node)) {
     ignoreComments(path);
 


### PR DESCRIPTION
Since nodes with variants now all behave in the same way, delegating the printing to the variant. we can remove the print functions allover and put it in a base class.