### PR TITLE
Singleton comments

### DIFF
--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -30,7 +30,7 @@ export class ContractMembers extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    return this.items.length > 0 || this.comments.length > 0
+    return this.items.length > 0 || (this.comments?.length || 0) > 0
       ? printSeparatedItem(printPreservingEmptyLines(path, print, options), {
           firstSeparator: hardline
         })

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -51,7 +51,7 @@ export class IfStatement extends SlangNode {
       this.elseBranch
         ? [
             bodyKind !== NonterminalKind.Block || // else on a new line if body is not a block
-            bodyComments.some(
+            bodyComments?.some(
               (comment) =>
                 !isBlockComment(comment) || comment.placement === 'ownLine'
             ) // or if body has trailing single line comments or a block comment on a new line

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -30,7 +30,7 @@ export class InterfaceMembers extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    return this.items.length > 0 || this.comments.length > 0
+    return this.items.length > 0 || (this.comments?.length || 0) > 0
       ? printSeparatedItem(printPreservingEmptyLines(path, print, options), {
           firstSeparator: hardline
         })

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -30,7 +30,7 @@ export class LibraryMembers extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    return this.items.length > 0 || this.comments.length > 0
+    return this.items.length > 0 || (this.comments?.length || 0) > 0
       ? printSeparatedItem(printPreservingEmptyLines(path, print, options), {
           firstSeparator: hardline
         })

--- a/src/slang-nodes/PositionalArgumentsDeclaration.ts
+++ b/src/slang-nodes/PositionalArgumentsDeclaration.ts
@@ -27,9 +27,11 @@ export class PositionalArgumentsDeclaration extends SlangNode {
 
     // We need to check the comments at this point because they will be removed
     // from this node into the root node.
+    // Since we are collecting comments in a different array, we have to query
+    // the ast directly for possible block comments.
     this.isEmpty =
       this.arguments.items.length === 0 && // no arguments
-      !this.comments.some((comment) => isBlockComment(comment)); // no block comments
+      !ast.cst.children().some(({ node }) => isBlockComment(node)); // no block comments
   }
 
   print(

--- a/src/slang-nodes/SlangNode.ts
+++ b/src/slang-nodes/SlangNode.ts
@@ -23,8 +23,14 @@ const isCommentOrWhiteSpace = createKindCheckFunction([
 ]);
 
 const offsets = new Map<number, number>();
+const comments: Comment[] = [];
+
 export function clearOffsets(): void {
   offsets.clear();
+}
+
+export function clearComments(): Comment[] {
+  return comments.splice(0);
 }
 
 function reversedIterator<T>(children: T[]): Iterable<T> {
@@ -52,21 +58,6 @@ function getOffset(children: Edge[] | Iterable<Edge>): number {
     offset += node.textLength.utf16;
   }
   return offset;
-}
-
-function collectComments(
-  comments: Comment[],
-  node: StrictAstNode | StrictAstNode[] | undefined
-): Comment[] {
-  if (node) {
-    if (Array.isArray(node)) {
-      return node.reduce(collectComments, comments);
-    }
-    if (node.comments.length > 0) {
-      comments.push(...node.comments.splice(0));
-    }
-  }
-  return comments;
 }
 
 export class SlangNode {
@@ -109,16 +100,16 @@ export class SlangNode {
           // offset, it's hard to separate these responsibilities into different
           // functions without doing the iteration twice.
           case TerminalKind.MultiLineComment:
-            this.comments.push(new MultiLineComment(node, offset));
+            comments.push(new MultiLineComment(node, offset));
             break;
           case TerminalKind.MultiLineNatSpecComment:
-            this.comments.push(new MultiLineNatSpecComment(node, offset));
+            comments.push(new MultiLineNatSpecComment(node, offset));
             break;
           case TerminalKind.SingleLineComment:
-            this.comments.push(new SingleLineComment(node, offset));
+            comments.push(new SingleLineComment(node, offset));
             break;
           case TerminalKind.SingleLineNatSpecComment:
-            this.comments.push(new SingleLineNatSpecComment(node, offset));
+            comments.push(new SingleLineNatSpecComment(node, offset));
             break;
         }
       }
@@ -141,10 +132,7 @@ export class SlangNode {
   updateMetadata(
     ...childNodes: (StrictAstNode | StrictAstNode[] | undefined)[]
   ): void {
-    const { comments, loc } = this;
-    // Collect comments
-    this.comments = childNodes.reduce(collectComments, comments);
-
+    const { loc } = this;
     // calculate correct loc object
     if (loc.leadingOffset === 0) {
       for (const childNode of childNodes) {

--- a/src/slang-nodes/SlangNode.ts
+++ b/src/slang-nodes/SlangNode.ts
@@ -61,7 +61,7 @@ function getOffset(children: Edge[] | Iterable<Edge>): number {
 }
 
 export class SlangNode {
-  comments: Comment[] = [];
+  comments?: Comment[];
 
   loc: AstLocation;
 

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -21,10 +21,6 @@ export class SourceUnit extends SlangNode {
     this.members = new SourceUnitMembers(ast.members, options);
 
     this.updateMetadata(this.members);
-
-    // Because of comments being extracted like a russian doll, the order needs
-    // to be fixed at the end.
-    this.comments = this.comments.sort((a, b) => a.loc.start - b.loc.start);
   }
 
   print(

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -30,7 +30,7 @@ export class Statements extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    return this.items.length > 0 || this.comments.length > 0
+    return this.items.length > 0 || (this.comments?.length || 0) > 0
       ? printSeparatedItem(printPreservingEmptyLines(path, print, options), {
           firstSeparator: hardline
         })

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -30,7 +30,7 @@ export class YulStatements extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    return this.items.length > 0 || this.comments.length > 0
+    return this.items.length > 0 || (this.comments?.length || 0) > 0
       ? printSeparatedItem(printPreservingEmptyLines(path, print, options), {
           firstSeparator: hardline
         })

--- a/src/slang-printers/print-comments.ts
+++ b/src/slang-printers/print-comments.ts
@@ -3,7 +3,11 @@ import { printComment } from '../slang-comments/printer.js';
 import { joinExisting } from '../slang-utils/join-existing.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
-import type { AstNode, Comment } from '../slang-nodes/types.d.ts';
+import type {
+  AstNode,
+  Comment,
+  StrictAstNode
+} from '../slang-nodes/types.d.ts';
 import { locEnd } from '../slang-utils/loc.js';
 
 const { hardline, line } = doc.builders;
@@ -13,9 +17,10 @@ function isPrintable(comment: Comment): boolean {
 }
 
 export function printComments(
-  path: AstPath<AstNode>,
+  path: AstPath<StrictAstNode>,
   options: ParserOptions<AstNode>
 ): Doc[] {
+  if (typeof path.node.comments === 'undefined') return [];
   return joinExisting(
     line,
     path.map((commentPath, index, comments: Comment[]) => {

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -8,11 +8,13 @@ import type { PrintFunction } from './types.d.ts';
 function hasNodeIgnoreComment({ comments }: StrictAstNode): boolean {
   // Prettier sets SourceUnit's comments to undefined after assigning comments
   // to each node.
-  return comments?.some(
-    (comment) =>
-      comment.value
-        .slice(2, isBlockComment(comment) ? -2 : undefined)
-        .trim() === 'prettier-ignore'
+  return Boolean(
+    comments?.some(
+      (comment) =>
+        comment.value
+          .slice(2, isBlockComment(comment) ? -2 : undefined)
+          .trim() === 'prettier-ignore'
+    )
   );
 }
 

--- a/src/slangSolidityParser.ts
+++ b/src/slangSolidityParser.ts
@@ -1,6 +1,6 @@
 // https://prettier.io/docs/en/plugins.html#parsers
 import { SourceUnit as SlangSourceUnit } from '@nomicfoundation/slang/ast';
-import { clearOffsets } from './slang-nodes/SlangNode.js';
+import { clearOffsets, clearComments } from './slang-nodes/SlangNode.js';
 import { createParser } from './slang-utils/create-parser.js';
 import { SourceUnit } from './slang-nodes/SourceUnit.js';
 
@@ -19,6 +19,10 @@ export default function parse(
     new SlangSourceUnit(parseOutput.tree.asNonterminalNode()),
     options
   );
+
+  // Because of comments being extracted like a russian doll, the order needs
+  // to be fixed at the end.
+  parsed.comments = clearComments().sort((a, b) => a.loc.start - b.loc.start);
   clearOffsets();
   return parsed;
 }


### PR DESCRIPTION
instead of gathering comments at each node and collecting them at the `updateMetadata` step, we store them in a single place and retrieve them at the end of the parsing step.