### PR TITLE
adding `printVariant` function to skip printing the variant node when possible

### DIFF
--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { Expression } from './Expression.js';
@@ -27,6 +28,11 @@ export class ArrayTypeName extends SlangNode {
   }
 
   print(path: AstPath<ArrayTypeName>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), '[', path.call(print, 'index'), ']'];
+    return [
+      path.call(printVariant(print), 'operand'),
+      '[',
+      path.call(printVariant(print), 'index'),
+      ']'
+    ];
   }
 }

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -32,10 +33,10 @@ export class AssignmentExpression extends SlangNode {
   print(path: AstPath<AssignmentExpression>, print: PrintFunction): Doc {
     const rightOperandVariant = this.rightOperand.variant;
     return [
-      path.call(print, 'leftOperand'),
+      path.call(printVariant(print), 'leftOperand'),
       ` ${this.operator}`,
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'rightOperand'),
+        path.call(printVariant(print), 'rightOperand'),
         !(rightOperandVariant instanceof TerminalNode) &&
           isBinaryOperation(rightOperandVariant)
       )

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { CallOptions } from './CallOptions.js';
@@ -25,6 +26,11 @@ export class CallOptionsExpression extends SlangNode {
   }
 
   print(path: AstPath<CallOptionsExpression>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), '{', path.call(print, 'options'), '}'];
+    return [
+      path.call(printVariant(print), 'operand'),
+      '{',
+      path.call(print, 'options'),
+      '}'
+    ];
   }
 }

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -28,7 +29,7 @@ function experimentalTernaries(
 
   // If the `condition` breaks into multiple lines, we add parentheses,
   // unless it already is a `TupleExpression`.
-  const operand = path.call(print, 'operand');
+  const operand = path.call(printVariant(print), 'operand');
   const operandDoc = group([
     node.operand.variant.kind === NonterminalKind.TupleExpression
       ? operand
@@ -41,7 +42,7 @@ function experimentalTernaries(
   // `trueExpression`.
   const trueExpressionDoc = indent([
     isNestedAsTrueExpression ? hardline : line,
-    path.call(print, 'trueExpression')
+    path.call(printVariant(print), 'trueExpression')
   ]);
 
   const groupId = Symbol('Slang.ConditionalExpression.trueExpression');
@@ -58,7 +59,7 @@ function experimentalTernaries(
       ? ' '.repeat(tabWidth - 1)
       : ' ';
 
-  const falseExpression = path.call(print, 'falseExpression');
+  const falseExpression = path.call(printVariant(print), 'falseExpression');
   const falseExpressionDoc = [
     isNested ? hardline : line,
     ':',
@@ -85,7 +86,7 @@ function traditionalTernaries(
   print: PrintFunction
 ): Doc {
   return group([
-    path.call(print, 'operand'),
+    path.call(printVariant(print), 'operand'),
     indent([
       // Nested trueExpression and falseExpression are always printed in a new
       // line
@@ -94,10 +95,10 @@ function traditionalTernaries(
         ? hardline
         : line,
       '? ',
-      path.call(print, 'trueExpression'),
+      path.call(printVariant(print), 'trueExpression'),
       line,
       ': ',
-      path.call(print, 'falseExpression')
+      path.call(printVariant(print), 'falseExpression')
     ])
   ]);
 }

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -30,11 +31,11 @@ export class ConstantDefinition extends SlangNode {
 
   print(path: AstPath<ConstantDefinition>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'typeName'),
       ' constant ',
       path.call(print, 'name'),
       ' = ',
-      path.call(print, 'value'),
+      path.call(printVariant(print), 'value'),
       ';'
     ];
   }

--- a/src/slang-nodes/ConstructorDefinition.ts
+++ b/src/slang-nodes/ConstructorDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 import { ConstructorAttributes } from './ConstructorAttributes.js';
@@ -30,6 +30,6 @@ export class ConstructorDefinition extends SlangNode {
   }
 
   print(path: AstPath<ConstructorDefinition>, print: PrintFunction): Doc {
-    return printFunction('constructor', this, path, print);
+    return printFunctionWithBody('constructor', this, path, print);
   }
 }

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 import { Expression } from './Expression.js';
@@ -29,14 +30,14 @@ export class DoWhileStatement extends SlangNode {
   }
 
   print(path: AstPath<DoWhileStatement>, print: PrintFunction): Doc {
-    const body = path.call(print, 'body');
+    const body = path.call(printVariant(print), 'body');
     return [
       'do',
       this.body.variant.kind === NonterminalKind.Block
         ? [' ', body, ' ']
         : printSeparatedItem(body, { firstSeparator: line }),
       'while (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(path.call(printVariant(print), 'condition')),
       ');'
     ];
   }

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 
@@ -31,7 +32,7 @@ export class ElseBranch extends SlangNode {
     return [
       'else',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        path.call(printVariant(print), 'body'),
         !isIfStatementOrBlock(this.body.variant)
       )
     ];

--- a/src/slang-nodes/EmitStatement.ts
+++ b/src/slang-nodes/EmitStatement.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
@@ -28,7 +29,7 @@ export class EmitStatement extends SlangNode {
     return [
       'emit ',
       path.call(print, 'event'),
-      path.call(print, 'arguments'),
+      path.call(printVariant(print), 'arguments'),
       ';'
     ];
   }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -29,7 +30,7 @@ export class ErrorParameter extends SlangNode {
 
   print(path: AstPath<ErrorParameter>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'typeName'),
       path.call(print, 'name')
     ]);
   }

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -32,7 +33,7 @@ export class EventParameter extends SlangNode {
 
   print(path: AstPath<EventParameter>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'typeName'),
       this.indexedKeyword,
       path.call(print, 'name')
     ]);

--- a/src/slang-nodes/ExperimentalPragma.ts
+++ b/src/slang-nodes/ExperimentalPragma.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ExperimentalFeature } from './ExperimentalFeature.js';
 
@@ -21,6 +22,6 @@ export class ExperimentalPragma extends SlangNode {
   }
 
   print(path: AstPath<ExperimentalPragma>, print: PrintFunction): Doc {
-    return ['experimental ', path.call(print, 'feature')];
+    return ['experimental ', path.call(printVariant(print), 'feature')];
   }
 }

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -21,6 +22,6 @@ export class ExpressionStatement extends SlangNode {
   }
 
   print(path: AstPath<ExpressionStatement>, print: PrintFunction): Doc {
-    return [path.call(print, 'expression'), ';'];
+    return [path.call(printVariant(print), 'expression'), ';'];
   }
 }

--- a/src/slang-nodes/FallbackFunctionDefinition.ts
+++ b/src/slang-nodes/FallbackFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 import { FallbackFunctionAttributes } from './FallbackFunctionAttributes.js';
@@ -57,6 +57,6 @@ export class FallbackFunctionDefinition extends SlangNode {
   }
 
   print(path: AstPath<FallbackFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunction('fallback', this, path, print);
+    return printFunctionWithBody('fallback', this, path, print);
   }
 }

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ForStatementInitialization } from './ForStatementInitialization.js';
 import { ForStatementCondition } from './ForStatementCondition.js';
@@ -48,9 +49,9 @@ export class ForStatement extends SlangNode {
   }
 
   print(path: AstPath<ForStatement>, print: PrintFunction): Doc {
-    const initialization = path.call(print, 'initialization');
-    const condition = path.call(print, 'condition');
-    const iterator = path.call(print, 'iterator');
+    const initialization = path.call(printVariant(print), 'initialization');
+    const condition = path.call(printVariant(print), 'condition');
+    const iterator = path.call(printVariant(print), 'iterator');
 
     return [
       'for (',
@@ -62,7 +63,7 @@ export class ForStatement extends SlangNode {
       }),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        path.call(printVariant(print), 'body'),
         this.body.variant.kind !== NonterminalKind.Block
       )
     ];

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { isLabel } from '../slang-utils/is-label.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
@@ -33,8 +34,8 @@ export class FunctionCallExpression extends SlangNode {
   }
 
   print(path: AstPath<FunctionCallExpression>, print: PrintFunction): Doc {
-    const operand = path.call(print, 'operand');
-    const argumentsDoc = path.call(print, 'arguments');
+    const operand = path.call(printVariant(print), 'operand');
+    const argumentsDoc = path.call(printVariant(print), 'arguments');
 
     // If we are at the end of a MemberAccessChain we should indent the
     // arguments accordingly.

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -1,6 +1,7 @@
 import { satisfies } from 'semver';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { FunctionName } from './FunctionName.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -64,8 +65,8 @@ export class FunctionDefinition extends SlangNode {
   }
 
   print(path: AstPath<FunctionDefinition>, print: PrintFunction): Doc {
-    return printFunction(
-      ['function ', path.call(print, 'name')],
+    return printFunctionWithBody(
+      ['function ', path.call(printVariant(print), 'name')],
       this,
       path,
       print

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -3,6 +3,7 @@ import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { isBlockComment } from '../slang-utils/is-comment.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
@@ -40,10 +41,10 @@ export class IfStatement extends SlangNode {
     const { kind: bodyKind, comments: bodyComments } = this.body.variant;
     return [
       'if (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(path.call(printVariant(print), 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        path.call(printVariant(print), 'body'),
         bodyKind !== NonterminalKind.Block,
         // `if` within `if`
         { shouldBreak: bodyKind === NonterminalKind.IfStatement }

--- a/src/slang-nodes/ImportDirective.ts
+++ b/src/slang-nodes/ImportDirective.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ImportClause } from './ImportClause.js';
 
@@ -21,6 +22,6 @@ export class ImportDirective extends SlangNode {
   }
 
   print(path: AstPath<ImportDirective>, print: PrintFunction): Doc {
-    return ['import ', path.call(print, 'clause'), ';'];
+    return ['import ', path.call(printVariant(print), 'clause'), ';'];
   }
 }

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -23,6 +24,6 @@ export class IndexAccessEnd extends SlangNode {
   }
 
   print(path: AstPath<IndexAccessEnd>, print: PrintFunction): Doc {
-    return [':', path.call(print, 'end')];
+    return [':', path.call(printVariant(print), 'end')];
   }
 }

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -3,6 +3,7 @@ import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
 import { isLabel } from '../slang-utils/is-label.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { IndexAccessEnd } from './IndexAccessEnd.js';
@@ -38,10 +39,13 @@ export class IndexAccessExpression extends SlangNode {
   }
 
   print(path: AstPath<IndexAccessExpression>, print: PrintFunction): Doc {
-    const operand = path.call(print, 'operand');
+    const operand = path.call(printVariant(print), 'operand');
     const indexDoc = [
       '[',
-      printSeparatedItem([path.call(print, 'start'), path.call(print, 'end')]),
+      printSeparatedItem([
+        path.call(printVariant(print), 'start'),
+        path.call(print, 'end')
+      ]),
       ']'
     ];
 

--- a/src/slang-nodes/InheritanceType.ts
+++ b/src/slang-nodes/InheritanceType.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
@@ -27,6 +28,9 @@ export class InheritanceType extends SlangNode {
   }
 
   print(path: AstPath<InheritanceType>, print: PrintFunction): Doc {
-    return [path.call(print, 'typeName'), path.call(print, 'arguments')];
+    return [
+      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'arguments')
+    ];
   }
 }

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { MappingKeyType } from './MappingKeyType.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -28,7 +29,7 @@ export class MappingKey extends SlangNode {
 
   print(path: AstPath<MappingKey>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'keyType'),
+      path.call(printVariant(print), 'keyType'),
       path.call(print, 'name')
     ]);
   }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -29,7 +30,7 @@ export class MappingValue extends SlangNode {
 
   print(path: AstPath<MappingValue>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'typeName'),
       path.call(print, 'name')
     ]);
   }

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { isLabel } from '../slang-utils/is-label.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -132,7 +133,7 @@ export class MemberAccessExpression extends SlangNode {
 
   print(path: AstPath<MemberAccessExpression>, print: PrintFunction): Doc {
     const document = [
-      path.call(print, 'operand'),
+      path.call(printVariant(print), 'operand'),
       label('separator', [softline, '.']),
       path.call(print, 'member')
     ].flat();

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -67,7 +67,7 @@ export class ModifierDefinition extends SlangNode {
   }
 
   print(path: AstPath<ModifierDefinition>, print: PrintFunction): Doc {
-    return printFunction(
+    return printFunctionWithBody(
       ['modifier ', path.call(print, 'name')],
       this,
       path,

--- a/src/slang-nodes/ModifierInvocation.ts
+++ b/src/slang-nodes/ModifierInvocation.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
@@ -39,6 +40,9 @@ export class ModifierInvocation extends SlangNode {
   }
 
   print(path: AstPath<ModifierInvocation>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), path.call(print, 'arguments')];
+    return [
+      path.call(print, 'name'),
+      path.call(printVariant(print), 'arguments')
+    ];
   }
 }

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
@@ -25,6 +26,10 @@ export class NamedArgument extends SlangNode {
   }
 
   print(path: AstPath<NamedArgument>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), ': ', path.call(print, 'value')];
+    return [
+      path.call(print, 'name'),
+      ': ',
+      path.call(printVariant(print), 'value')
+    ];
   }
 }

--- a/src/slang-nodes/NewExpression.ts
+++ b/src/slang-nodes/NewExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
@@ -21,6 +22,6 @@ export class NewExpression extends SlangNode {
   }
 
   print(path: AstPath<NewExpression>, print: PrintFunction): Doc {
-    return ['new ', path.call(print, 'typeName')];
+    return ['new ', path.call(printVariant(print), 'typeName')];
   }
 }

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { StorageLocation } from './StorageLocation.js';
@@ -39,7 +40,7 @@ export class Parameter extends SlangNode {
   print(path: AstPath<Parameter>, print: PrintFunction): Doc {
     return group(
       joinExisting(' ', [
-        path.call(print, 'typeName'),
+        path.call(printVariant(print), 'typeName'),
         path.call(print, 'storageLocation'),
         path.call(print, 'name')
       ])

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -24,6 +25,6 @@ export class PostfixExpression extends SlangNode {
   }
 
   print(path: AstPath<PostfixExpression>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), this.operator];
+    return [path.call(printVariant(print), 'operand'), this.operator];
   }
 }

--- a/src/slang-nodes/PragmaDirective.ts
+++ b/src/slang-nodes/PragmaDirective.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Pragma } from './Pragma.js';
 
@@ -21,6 +22,6 @@ export class PragmaDirective extends SlangNode {
   }
 
   print(path: AstPath<PragmaDirective>, print: PrintFunction): Doc {
-    return ['pragma ', path.call(print, 'pragma'), ';'];
+    return ['pragma ', path.call(printVariant(print), 'pragma'), ';'];
   }
 }

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -28,6 +29,6 @@ export class PrefixExpression extends SlangNode {
   }
 
   print(path: AstPath<PrefixExpression>, print: PrintFunction): Doc {
-    return [this.operator, path.call(print, 'operand')];
+    return [this.operator, path.call(printVariant(print), 'operand')];
   }
 }

--- a/src/slang-nodes/ReceiveFunctionDefinition.ts
+++ b/src/slang-nodes/ReceiveFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 import { ReceiveFunctionAttributes } from './ReceiveFunctionAttributes.js';
@@ -46,6 +46,6 @@ export class ReceiveFunctionDefinition extends SlangNode {
   }
 
   print(path: AstPath<ReceiveFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunction('receive', this, path, print);
+    return printFunctionWithBody('receive', this, path, print);
   }
 }

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -33,7 +34,7 @@ export class ReturnStatement extends SlangNode {
       'return',
       expressionVariantKind
         ? printIndentedGroupOrSpacedDocument(
-            path.call(print, 'expression'),
+            path.call(printVariant(print), 'expression'),
             expressionVariantKind !== NonterminalKind.TupleExpression &&
               (!options.experimentalTernaries ||
                 expressionVariantKind !== NonterminalKind.ConditionalExpression)

--- a/src/slang-nodes/RevertStatement.ts
+++ b/src/slang-nodes/RevertStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
@@ -30,7 +31,7 @@ export class RevertStatement extends SlangNode {
   print(path: AstPath<RevertStatement>, print: PrintFunction): Doc {
     return [
       joinExisting(' ', ['revert', path.call(print, 'error')]),
-      path.call(print, 'arguments'),
+      path.call(printVariant(print), 'arguments'),
       ';'
     ];
   }

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { StateVariableAttributes } from './StateVariableAttributes.js';
@@ -44,7 +45,7 @@ export class StateVariableDefinition extends SlangNode {
   print(path: AstPath<StateVariableDefinition>, print: PrintFunction): Doc {
     return printGroupAndIndentIfBreakPair(
       [
-        path.call(print, 'typeName'),
+        path.call(printVariant(print), 'typeName'),
         indent(path.call(print, 'attributes')),
         ' ',
         path.call(print, 'name')

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -31,7 +32,7 @@ export class StateVariableDefinitionValue extends SlangNode {
     return [
       ' =',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'value'),
+        path.call(printVariant(print), 'value'),
         this.value.variant.kind !== NonterminalKind.ArrayExpression
       )
     ];

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -30,7 +31,7 @@ export class StorageLayoutSpecifier extends SlangNode {
   print(path: AstPath<StorageLayoutSpecifier>, print: PrintFunction): Doc {
     return [
       'layout at',
-      printSeparatedItem(path.call(print, 'expression'), {
+      printSeparatedItem(path.call(printVariant(print), 'expression'), {
         firstSeparator: line,
         // If this is the second ContractSpecifier we have to delegate printing
         // the line to the ContractSpecifiers node.

--- a/src/slang-nodes/StructMember.ts
+++ b/src/slang-nodes/StructMember.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -25,6 +26,11 @@ export class StructMember extends SlangNode {
   }
 
   print(path: AstPath<StructMember>, print: PrintFunction): Doc {
-    return [path.call(print, 'typeName'), ' ', path.call(print, 'name'), ';'];
+    return [
+      path.call(printVariant(print), 'typeName'),
+      ' ',
+      path.call(print, 'name'),
+      ';'
+    ];
   }
 }

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { ReturnsDeclaration } from './ReturnsDeclaration.js';
@@ -47,7 +48,7 @@ export class TryStatement extends SlangNode {
   print(path: AstPath<TryStatement>, print: PrintFunction): Doc {
     return [
       'try',
-      printSeparatedItem(path.call(print, 'expression'), {
+      printSeparatedItem(path.call(printVariant(print), 'expression'), {
         firstSeparator: line
       }),
       joinExisting(' ', [

--- a/src/slang-nodes/TupleDeconstructionElement.ts
+++ b/src/slang-nodes/TupleDeconstructionElement.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TupleMember } from './TupleMember.js';
 
@@ -26,6 +27,6 @@ export class TupleDeconstructionElement extends SlangNode {
   }
 
   print(path: AstPath<TupleDeconstructionElement>, print: PrintFunction): Doc {
-    return path.call(print, 'member');
+    return path.call(printVariant(print), 'member');
   }
 }

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TupleDeconstructionElements } from './TupleDeconstructionElements.js';
 import { Expression } from './Expression.js';
@@ -37,7 +38,7 @@ export class TupleDeconstructionStatement extends SlangNode {
   ): Doc {
     return printGroupAndIndentIfBreakPair(
       [this.varKeyword ? 'var (' : '(', path.call(print, 'elements'), ') = '],
-      [path.call(print, 'expression'), ';']
+      [path.call(printVariant(print), 'expression'), ';']
     );
   }
 }

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -23,6 +24,6 @@ export class TupleValue extends SlangNode {
   }
 
   print(path: AstPath<TupleValue>, print: PrintFunction): Doc {
-    return path.call(print, 'expression');
+    return path.call(printVariant(print), 'expression');
   }
 }

--- a/src/slang-nodes/TypeExpression.ts
+++ b/src/slang-nodes/TypeExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
@@ -21,6 +22,6 @@ export class TypeExpression extends SlangNode {
   }
 
   print(path: AstPath<TypeExpression>, print: PrintFunction): Doc {
-    return ['type(', path.call(print, 'typeName'), ')'];
+    return ['type(', path.call(printVariant(print), 'typeName'), ')'];
   }
 }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { StorageLocation } from './StorageLocation.js';
@@ -33,7 +34,7 @@ export class TypedTupleMember extends SlangNode {
 
   print(path: AstPath<TypedTupleMember>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
+      path.call(printVariant(print), 'typeName'),
       path.call(print, 'storageLocation'),
       path.call(print, 'name')
     ]);

--- a/src/slang-nodes/UnnamedFunctionDefinition.ts
+++ b/src/slang-nodes/UnnamedFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunction } from '../slang-printers/print-function.js';
+import { printFunctionWithBody } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 import { UnnamedFunctionAttributes } from './UnnamedFunctionAttributes.js';
@@ -43,6 +43,6 @@ export class UnnamedFunctionDefinition extends SlangNode {
   }
 
   print(path: AstPath<UnnamedFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunction('function', this, path, print);
+    return printFunctionWithBody('function', this, path, print);
   }
 }

--- a/src/slang-nodes/UserDefinedValueTypeDefinition.ts
+++ b/src/slang-nodes/UserDefinedValueTypeDefinition.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { ElementaryType } from './ElementaryType.js';
@@ -31,7 +32,7 @@ export class UserDefinedValueTypeDefinition extends SlangNode {
       'type ',
       path.call(print, 'name'),
       ' is ',
-      path.call(print, 'valueType'),
+      path.call(printVariant(print), 'valueType'),
       ';'
     ];
   }

--- a/src/slang-nodes/UsingDirective.ts
+++ b/src/slang-nodes/UsingDirective.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { UsingClause } from './UsingClause.js';
 import { UsingTarget } from './UsingTarget.js';
@@ -30,9 +31,9 @@ export class UsingDirective extends SlangNode {
   print(path: AstPath<UsingDirective>, print: PrintFunction): Doc {
     return [
       'using ',
-      path.call(print, 'clause'),
+      path.call(printVariant(print), 'clause'),
       ' for ',
-      path.call(print, 'target'),
+      path.call(printVariant(print), 'target'),
       this.globalKeyword ? ' global;' : ';'
     ];
   }

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { VariableDeclarationType } from './VariableDeclarationType.js';
 import { StorageLocation } from './StorageLocation.js';
@@ -49,7 +50,7 @@ export class VariableDeclarationStatement extends SlangNode {
   ): Doc {
     return printGroupAndIndentIfBreakPair(
       [
-        path.call(print, 'variableType'),
+        path.call(printVariant(print), 'variableType'),
         this.storageLocation
           ? indent([line, path.call(print, 'storageLocation')])
           : '',

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -24,6 +25,6 @@ export class VariableDeclarationValue extends SlangNode {
   }
 
   print(path: AstPath<VariableDeclarationValue>, print: PrintFunction): Doc {
-    return [' = ', path.call(print, 'expression')];
+    return [' = ', path.call(printVariant(print), 'expression')];
   }
 }

--- a/src/slang-nodes/VersionRange.ts
+++ b/src/slang-nodes/VersionRange.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { VersionLiteral } from './VersionLiteral.js';
 
@@ -23,6 +24,10 @@ export class VersionRange extends SlangNode {
   }
 
   print(path: AstPath<VersionRange>, print: PrintFunction): Doc {
-    return [path.call(print, 'start'), ' - ', path.call(print, 'end')];
+    return [
+      path.call(printVariant(print), 'start'),
+      ' - ',
+      path.call(printVariant(print), 'end')
+    ];
   }
 }

--- a/src/slang-nodes/VersionTerm.ts
+++ b/src/slang-nodes/VersionTerm.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { VersionOperator } from './VersionOperator.js';
 import { VersionLiteral } from './VersionLiteral.js';
@@ -26,6 +27,9 @@ export class VersionTerm extends SlangNode {
   }
 
   print(path: AstPath<VersionTerm>, print: PrintFunction): Doc {
-    return [path.call(print, 'operator'), path.call(print, 'literal')];
+    return [
+      path.call(print, 'operator'),
+      path.call(printVariant(print), 'literal')
+    ];
   }
 }

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
@@ -29,10 +30,10 @@ export class WhileStatement extends SlangNode {
   print(path: AstPath<WhileStatement>, print: PrintFunction): Doc {
     return [
       'while (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(path.call(printVariant(print), 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        path.call(printVariant(print), 'body'),
         this.body.variant.kind !== NonterminalKind.Block
       )
     ];

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
 import { YulExpression } from './YulExpression.js';
@@ -42,7 +43,7 @@ export class YulForStatement extends SlangNode {
     return join(' ', [
       'for',
       path.call(print, 'initialization'),
-      path.call(print, 'condition'),
+      path.call(printVariant(print), 'condition'),
       path.call(print, 'iterator'),
       path.call(print, 'body')
     ]);

--- a/src/slang-nodes/YulFunctionCallExpression.ts
+++ b/src/slang-nodes/YulFunctionCallExpression.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
 import { YulArguments } from './YulArguments.js';
@@ -29,7 +30,7 @@ export class YulFunctionCallExpression extends SlangNode {
 
   print(path: AstPath<YulFunctionCallExpression>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'operand'),
+      path.call(printVariant(print), 'operand'),
       '(',
       path.call(print, 'arguments'),
       ')'

--- a/src/slang-nodes/YulIfStatement.ts
+++ b/src/slang-nodes/YulIfStatement.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
 import { YulBlock } from './YulBlock.js';
@@ -27,7 +28,7 @@ export class YulIfStatement extends SlangNode {
   print(path: AstPath<YulIfStatement>, print: PrintFunction): Doc {
     return [
       'if ',
-      path.call(print, 'condition'),
+      path.call(printVariant(print), 'condition'),
       ' ',
       path.call(print, 'body')
     ];

--- a/src/slang-nodes/YulStackAssignmentStatement.ts
+++ b/src/slang-nodes/YulStackAssignmentStatement.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulStackAssignmentOperator } from './YulStackAssignmentOperator.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -29,7 +30,7 @@ export class YulStackAssignmentStatement extends SlangNode {
 
   print(path: AstPath<YulStackAssignmentStatement>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'assignment'),
+      path.call(printVariant(print), 'assignment'),
       printSeparatedItem(path.call(print, 'variable'), {
         firstSeparator: line,
         lastSeparator: ''

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
 import { YulSwitchCases } from './YulSwitchCases.js';
@@ -30,7 +31,7 @@ export class YulSwitchStatement extends SlangNode {
   print(path: AstPath<YulSwitchStatement>, print: PrintFunction): Doc {
     return [
       'switch ',
-      path.call(print, 'expression'),
+      path.call(printVariant(print), 'expression'),
       hardline,
       path.call(print, 'cases')
     ];

--- a/src/slang-nodes/YulValueCase.ts
+++ b/src/slang-nodes/YulValueCase.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulBlock } from './YulBlock.js';
@@ -25,6 +26,11 @@ export class YulValueCase extends SlangNode {
   }
 
   print(path: AstPath<YulValueCase>, print: PrintFunction): Doc {
-    return ['case ', path.call(print, 'value'), ' ', path.call(print, 'body')];
+    return [
+      'case ',
+      path.call(printVariant(print), 'value'),
+      ' ',
+      path.call(print, 'body')
+    ];
   }
 }

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulPaths } from './YulPaths.js';
 import { YulAssignmentOperator } from './YulAssignmentOperator.js';
@@ -40,8 +41,8 @@ export class YulVariableAssignmentStatement extends SlangNode {
   ): Doc {
     return join(' ', [
       path.call(print, 'variables'),
-      path.call(print, 'assignment'),
-      path.call(print, 'expression')
+      path.call(printVariant(print), 'assignment'),
+      path.call(printVariant(print), 'expression')
     ]);
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationValue.ts
+++ b/src/slang-nodes/YulVariableDeclarationValue.ts
@@ -1,4 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulAssignmentOperator } from './YulAssignmentOperator.js';
 import { YulExpression } from './YulExpression.js';
@@ -29,9 +30,9 @@ export class YulVariableDeclarationValue extends SlangNode {
 
   print(path: AstPath<YulVariableDeclarationValue>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'assignment'),
+      path.call(printVariant(print), 'assignment'),
       ' ',
-      path.call(print, 'expression')
+      path.call(printVariant(print), 'expression')
     ];
   }
 }

--- a/src/slang-nodes/types.d.ts
+++ b/src/slang-nodes/types.d.ts
@@ -462,7 +462,7 @@ export type StrictAstNode =
 export type PolymorphicNode = Extract<StrictAstNode, { variant: unknown }>;
 
 export type StrictPolymorphicNode = Extract<
-  StrictAstNode,
+  PolymorphicNode,
   { variant: StrictAstNode | TerminalNode }
 >;
 

--- a/src/slang-printers/create-binary-operation-printer.ts
+++ b/src/slang-printers/create-binary-operation-printer.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
 import { TerminalNode } from '../slang-nodes/TerminalNode.js';
+import { printVariant } from './print-variant.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type {
@@ -19,7 +20,7 @@ function rightOperandPrint(
   print: PrintFunction,
   options: ParserOptions<AstNode>
 ): Doc {
-  const rightOperand = path.call(print, 'rightOperand');
+  const rightOperand = path.call(printVariant(print), 'rightOperand');
   const rightOperandDoc =
     options.experimentalOperatorPosition === 'end'
       ? [` ${operator}`, line, rightOperand]
@@ -58,7 +59,7 @@ export const createBinaryOperationPrinter =
     const indentRules = indentRulesBuilder(path, options);
 
     return groupRules([
-      path.call(print, 'leftOperand'),
+      path.call(printVariant(print), 'leftOperand'),
       indentRules(rightOperandPrint(node, path, print, options))
     ]);
   };

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -1,11 +1,15 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { joinExisting } from '../slang-utils/join-existing.js';
+import { printVariant } from './print-variant.js';
 
 import type { AstPath, Doc } from 'prettier';
-import type { FunctionLike } from '../slang-nodes/types.d.ts';
+import type {
+  FunctionLike,
+  StrictPolymorphicNode
+} from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-import type { FunctionDefinition } from '../slang-nodes/FunctionDefinition.ts';
+import type { FunctionBody } from '../slang-nodes/FunctionBody.js';
 
 const { dedent, group, indent, line } = doc.builders;
 
@@ -15,25 +19,39 @@ export function printFunction(
   path: AstPath<FunctionLike>,
   print: PrintFunction
 ): Doc {
+  const body = (node as Extract<FunctionLike, { body: FunctionBody }>).body;
+
+  return group([
+    functionName,
+    path.call(print, 'parameters'),
+    indent(
+      group([
+        joinExisting(line, [
+          path.call(print, 'attributes'),
+          path.call(print, 'returns')
+        ]),
+        body && (!body.variant || body.variant.kind === NonterminalKind.Block)
+          ? dedent(line)
+          : ''
+      ])
+    )
+  ]);
+}
+
+export function printFunctionWithBody(
+  functionName: Doc,
+  node: FunctionLike,
+  path: AstPath<Extract<FunctionLike, { body: unknown }>>,
+  print: PrintFunction
+): Doc {
   return [
-    group([
-      functionName,
-      path.call(print, 'parameters'),
-      group(
-        indent([
-          joinExisting(line, [
-            path.call(print, 'attributes'),
-            path.call(print, 'returns')
-          ]),
-          (node as FunctionDefinition).body &&
-          (!(node as FunctionDefinition).body.variant ||
-            (node as FunctionDefinition).body.variant.kind ===
-              NonterminalKind.Block)
-            ? dedent(line)
-            : ''
-        ])
-      )
-    ]),
-    path.call(print, 'body')
+    printFunction(functionName, node, path, print),
+    node.kind !== NonterminalKind.ConstructorDefinition
+      ? (
+          path as AstPath<
+            Extract<FunctionLike, { body: StrictPolymorphicNode }>
+          >
+        ).call(printVariant(print), 'body')
+      : path.call(print, 'body')
   ];
 }

--- a/src/slang-printers/print-variant.ts
+++ b/src/slang-printers/print-variant.ts
@@ -1,0 +1,13 @@
+import type { AstPath, Doc } from 'prettier';
+import type { PrintFunction } from '../types.d.ts';
+import type { StrictPolymorphicNode } from '../slang-nodes/types.d.ts';
+
+export const printVariant =
+  (print: PrintFunction) =>
+  (path: AstPath<StrictPolymorphicNode | undefined>): Doc => {
+    const node = path.node;
+    if (!node) return '';
+    return node.comments && node.comments.length > 0
+      ? print(path)
+      : path.call(print, 'variant');
+  };


### PR DESCRIPTION
prettier's `print` function on variants executes extra steps preparing the plugin's `print` function print comments and checking the position of the cursor in regards to the current node.

since we don't to repeat these steps another time when printing a polymorphic node which only delegates the printing to the variant, we simply avoid printing unless there's a comment attached to the polymorphic node.