### PR TITLE
using `printVariant` also for collections of variants

### DIFF
--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -20,6 +21,6 @@ export class ArrayValues extends SlangNode {
   }
 
   print(path: AstPath<ArrayValues>, print: PrintFunction): Doc {
-    return printSeparatedList(path.map(print, 'items'));
+    return printSeparatedList(path.map(printVariant(print), 'items'));
   }
 }

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ConstructorAttribute } from './ConstructorAttribute.js';
 
@@ -27,6 +28,6 @@ export class ConstructorAttributes extends SlangNode {
   }
 
   print(path: AstPath<ConstructorAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/ContractSpecifiers.ts
+++ b/src/slang-nodes/ContractSpecifiers.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortContractSpecifiers } from '../slang-utils/sort-contract-specifiers.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ContractSpecifier } from './ContractSpecifier.js';
 
@@ -26,7 +27,7 @@ export class ContractSpecifiers extends SlangNode {
   }
 
   print(path: AstPath<ContractSpecifiers>, print: PrintFunction): Doc {
-    const [specifier1, specifier2] = path.map(print, 'items');
+    const [specifier1, specifier2] = path.map(printVariant(print), 'items');
 
     if (specifier1 === undefined) return '';
 

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { FallbackFunctionAttribute } from './FallbackFunctionAttribute.js';
 
@@ -30,6 +31,6 @@ export class FallbackFunctionAttributes extends SlangNode {
   }
 
   print(path: AstPath<FallbackFunctionAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { FunctionAttribute } from './FunctionAttribute.js';
 
@@ -25,6 +26,6 @@ export class FunctionAttributes extends SlangNode {
   }
 
   print(path: AstPath<FunctionAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { FunctionTypeAttribute } from './FunctionTypeAttribute.js';
 
@@ -24,6 +25,6 @@ export class FunctionTypeAttributes extends SlangNode {
   }
 
   print(path: AstPath<FunctionTypeAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ModifierAttribute } from './ModifierAttribute.js';
 
@@ -24,6 +25,6 @@ export class ModifierAttributes extends SlangNode {
   }
 
   print(path: AstPath<ModifierAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printComments } from '../slang-printers/print-comments.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -27,7 +28,7 @@ export class PositionalArguments extends SlangNode {
     options: ParserOptions<AstNode>
   ): Doc {
     if (this.items.length > 0) {
-      return printSeparatedList(path.map(print, 'items'));
+      return printSeparatedList(path.map(printVariant(print), 'items'));
     }
     const argumentComments = printComments(path, options);
 

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ReceiveFunctionAttribute } from './ReceiveFunctionAttribute.js';
 
@@ -30,6 +31,6 @@ export class ReceiveFunctionAttributes extends SlangNode {
   }
 
   print(path: AstPath<ReceiveFunctionAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { StateVariableAttribute } from './StateVariableAttribute.js';
 
@@ -25,7 +26,7 @@ export class StateVariableAttributes extends SlangNode {
 
   print(path: AstPath<StateVariableAttributes>, print: PrintFunction): Doc {
     return this.items.length
-      ? path.map(print, 'items').map((item) => [line, item])
+      ? path.map(printVariant(print), 'items').map((item) => [line, item])
       : '';
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { UnnamedFunctionAttribute } from './UnnamedFunctionAttribute.js';
 
@@ -30,6 +31,6 @@ export class UnnamedFunctionAttributes extends SlangNode {
   }
 
   print(path: AstPath<UnnamedFunctionAttributes>, print: PrintFunction): Doc {
-    return path.map(print, 'items').map((item) => [line, item]);
+    return path.map(printVariant(print), 'items').map((item) => [line, item]);
   }
 }

--- a/src/slang-nodes/VersionExpressionSet.ts
+++ b/src/slang-nodes/VersionExpressionSet.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { VersionExpression } from './VersionExpression.js';
 
@@ -21,6 +22,6 @@ export class VersionExpressionSet extends SlangNode {
   }
 
   print(path: AstPath<VersionExpressionSet>, print: PrintFunction): Doc {
-    return join(' ', path.map(print, 'items'));
+    return join(' ', path.map(printVariant(print), 'items'));
   }
 }

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
 
@@ -20,6 +21,6 @@ export class YulArguments extends SlangNode {
   }
 
   print(path: AstPath<YulArguments>, print: PrintFunction): Doc {
-    return printSeparatedList(path.map(print, 'items'));
+    return printSeparatedList(path.map(printVariant(print), 'items'));
   }
 }

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
+import { printVariant } from '../slang-printers/print-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulSwitchCase } from './YulSwitchCase.js';
 
@@ -22,6 +23,6 @@ export class YulSwitchCases extends SlangNode {
   }
 
   print(path: AstPath<YulSwitchCases>, print: PrintFunction): Doc {
-    return join(hardline, path.map(print, 'items'));
+    return join(hardline, path.map(printVariant(print), 'items'));
   }
 }

--- a/src/slang-printers/print-preserving-empty-lines.ts
+++ b/src/slang-printers/print-preserving-empty-lines.ts
@@ -26,7 +26,9 @@ export function printPreservingEmptyLines(
             node.variant.kind !== NonterminalKind.YulLabel)
             ? hardline
             : '',
-          print(childPath),
+          node.comments && node.comments.length === 0
+            ? childPath.call(print, 'variant')
+            : print(childPath),
           // Only attempt to append an empty line if `node` is not the last item
           !childPath.isLast &&
           // Append an empty line if the original text already had an one after the


### PR DESCRIPTION
initially I had prepared a `printVariantCollection` helper but upon looking deeply, I noticed the same `printVariant` could be used.