### PR TITLE
removing `ContractMember`, `SourceUnitMember`, `Statement`, and `YulStatement` from the AST tree

### DIFF
--- a/src/slang-comments/handlers/handle-else-branch-comments.ts
+++ b/src/slang-comments/handlers/handle-else-branch-comments.ts
@@ -17,15 +17,12 @@ export default function handleElseBranchComments({
 
   if (
     followingNode === enclosingNode.body &&
-    followingNode.variant.kind === NonterminalKind.IfStatement
+    followingNode.kind === NonterminalKind.IfStatement
   ) {
-    if (followingNode.variant.body.variant.kind === NonterminalKind.Block) {
-      addCollectionFirstComment(
-        followingNode.variant.body.variant.statements,
-        comment
-      );
+    if (followingNode.body.kind === NonterminalKind.Block) {
+      addCollectionFirstComment(followingNode.body.statements, comment);
     } else {
-      addLeadingComment(followingNode.variant.body.variant, comment);
+      addLeadingComment(followingNode.body, comment);
     }
     return true;
   }

--- a/src/slang-comments/handlers/handle-if-statement-comments.ts
+++ b/src/slang-comments/handlers/handle-if-statement-comments.ts
@@ -39,15 +39,15 @@ export default function handleIfStatementComments({
     precedingNode === enclosingNode.body &&
     followingNode === enclosingNode.elseBranch
   ) {
-    addTrailingComment(precedingNode.variant, comment);
+    addTrailingComment(precedingNode, comment);
     return true;
   }
 
   if (followingNode.kind === NonterminalKind.IfStatement) {
-    if (followingNode.body.variant.kind === NonterminalKind.Block) {
-      addCollectionFirstComment(followingNode.body.variant.statements, comment);
+    if (followingNode.body.kind === NonterminalKind.Block) {
+      addCollectionFirstComment(followingNode.body.statements, comment);
     } else {
-      addLeadingComment(followingNode.body.variant, comment);
+      addLeadingComment(followingNode.body, comment);
     }
     return true;
   }
@@ -56,8 +56,8 @@ export default function handleIfStatementComments({
   // before the consequent without brackets on, such as
   // if (a) /* comment */ true
   if (enclosingNode.body === followingNode) {
-    if (followingNode.variant.kind === NonterminalKind.Block) {
-      addCollectionFirstComment(followingNode.variant.statements, comment);
+    if (followingNode.kind === NonterminalKind.Block) {
+      addCollectionFirstComment(followingNode.statements, comment);
     } else {
       addLeadingComment(followingNode, comment);
     }

--- a/src/slang-comments/handlers/handle-while-statement-comments.ts
+++ b/src/slang-comments/handlers/handle-while-statement-comments.ts
@@ -36,8 +36,8 @@ export default function handleWhileStatementComments({
   }
 
   if (enclosingNode.body === followingNode) {
-    if (followingNode.variant.kind === NonterminalKind.Block) {
-      addCollectionFirstComment(followingNode.variant.statements, comment);
+    if (followingNode.kind === NonterminalKind.Block) {
+      addCollectionFirstComment(followingNode.statements, comment);
     } else {
       addLeadingComment(followingNode, comment);
     }

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -41,12 +41,12 @@ export class ContractDefinition extends SlangNode {
     // Older versions of Solidity defined a constructor as a function having
     // the same name as the contract.
     if (!satisfies(options.compiler, '>=0.5.0')) {
-      for (const { variant } of this.members.items) {
+      for (const member of this.members.items) {
         if (
-          variant.kind === NonterminalKind.FunctionDefinition &&
-          variant.name.variant.value !== this.name.value
+          member.kind === NonterminalKind.FunctionDefinition &&
+          member.name.variant.value !== this.name.value
         ) {
-          variant.cleanModifierInvocationArguments();
+          member.cleanModifierInvocationArguments();
         }
       }
     }

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { PolymorphicNode } from './PolymorphicNode.js';
+import { SlangNode } from './SlangNode.js';
 import { UsingDirective } from './UsingDirective.js';
 import { FunctionDefinition } from './FunctionDefinition.js';
 import { ConstructorDefinition } from './ConstructorDefinition.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class ContractMember extends PolymorphicNode {
+export class ContractMember extends SlangNode {
   readonly kind = NonterminalKind.ContractMember;
 
   variant:

--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ContractMember } from './ContractMember.js';
 
@@ -15,12 +16,14 @@ const { hardline } = doc.builders;
 export class ContractMembers extends SlangNode {
   readonly kind = NonterminalKind.ContractMembers;
 
-  items: ContractMember[];
+  items: ContractMember['variant'][];
 
   constructor(ast: ast.ContractMembers, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new ContractMember(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new ContractMember(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 import { Expression } from './Expression.js';
@@ -16,24 +17,24 @@ const { line } = doc.builders;
 export class DoWhileStatement extends SlangNode {
   readonly kind = NonterminalKind.DoWhileStatement;
 
-  body: Statement;
+  body: Statement['variant'];
 
   condition: Expression;
 
   constructor(ast: ast.DoWhileStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.body = new Statement(ast.body, options);
+    this.body = extractVariant(new Statement(ast.body, options));
     this.condition = new Expression(ast.condition, options);
 
     this.updateMetadata(this.body, this.condition);
   }
 
   print(path: AstPath<DoWhileStatement>, print: PrintFunction): Doc {
-    const body = path.call(printVariant(print), 'body');
+    const body = path.call(print, 'body');
     return [
       'do',
-      this.body.variant.kind === NonterminalKind.Block
+      this.body.kind === NonterminalKind.Block
         ? [' ', body, ' ']
         : printSeparatedItem(body, { firstSeparator: line }),
       'while (',

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 
@@ -18,12 +18,12 @@ const isIfStatementOrBlock = createKindCheckFunction([
 export class ElseBranch extends SlangNode {
   readonly kind = NonterminalKind.ElseBranch;
 
-  body: Statement;
+  body: Statement['variant'];
 
   constructor(ast: ast.ElseBranch, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.body = new Statement(ast.body, options);
+    this.body = extractVariant(new Statement(ast.body, options));
 
     this.updateMetadata(this.body);
   }
@@ -32,8 +32,8 @@ export class ElseBranch extends SlangNode {
     return [
       'else',
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'body'),
-        !isIfStatementOrBlock(this.body.variant)
+        path.call(print, 'body'),
+        !isIfStatementOrBlock(this.body)
       )
     ];
   }

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -3,6 +3,7 @@ import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ForStatementInitialization } from './ForStatementInitialization.js';
 import { ForStatementCondition } from './ForStatementCondition.js';
@@ -25,7 +26,7 @@ export class ForStatement extends SlangNode {
 
   iterator?: Expression;
 
-  body: Statement;
+  body: Statement['variant'];
 
   constructor(ast: ast.ForStatement, options: ParserOptions<AstNode>) {
     super(ast);
@@ -38,7 +39,7 @@ export class ForStatement extends SlangNode {
     if (ast.iterator) {
       this.iterator = new Expression(ast.iterator, options);
     }
-    this.body = new Statement(ast.body, options);
+    this.body = extractVariant(new Statement(ast.body, options));
 
     this.updateMetadata(
       this.initialization,
@@ -63,8 +64,8 @@ export class ForStatement extends SlangNode {
       }),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'body'),
-        this.body.variant.kind !== NonterminalKind.Block
+        path.call(print, 'body'),
+        this.body.kind !== NonterminalKind.Block
       )
     ];
   }

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -4,6 +4,7 @@ import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { isBlockComment } from '../slang-utils/is-comment.js';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
@@ -21,7 +22,7 @@ export class IfStatement extends SlangNode {
 
   condition: Expression;
 
-  body: Statement;
+  body: Statement['variant'];
 
   elseBranch?: ElseBranch;
 
@@ -29,7 +30,7 @@ export class IfStatement extends SlangNode {
     super(ast);
 
     this.condition = new Expression(ast.condition, options);
-    this.body = new Statement(ast.body, options);
+    this.body = extractVariant(new Statement(ast.body, options));
     if (ast.elseBranch) {
       this.elseBranch = new ElseBranch(ast.elseBranch, options);
     }
@@ -38,13 +39,13 @@ export class IfStatement extends SlangNode {
   }
 
   print(path: AstPath<IfStatement>, print: PrintFunction): Doc {
-    const { kind: bodyKind, comments: bodyComments } = this.body.variant;
+    const { kind: bodyKind, comments: bodyComments } = this.body;
     return [
       'if (',
       printSeparatedItem(path.call(printVariant(print), 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'body'),
+        path.call(print, 'body'),
         bodyKind !== NonterminalKind.Block,
         // `if` within `if`
         { shouldBreak: bodyKind === NonterminalKind.IfStatement }

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ContractMember } from './ContractMember.js';
 
@@ -15,12 +16,14 @@ const { hardline } = doc.builders;
 export class InterfaceMembers extends SlangNode {
   readonly kind = NonterminalKind.InterfaceMembers;
 
-  items: ContractMember[];
+  items: ContractMember['variant'][];
 
   constructor(ast: ast.InterfaceMembers, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new ContractMember(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new ContractMember(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ContractMember } from './ContractMember.js';
 
@@ -15,12 +16,14 @@ const { hardline } = doc.builders;
 export class LibraryMembers extends SlangNode {
   readonly kind = NonterminalKind.LibraryMembers;
 
-  items: ContractMember[];
+  items: ContractMember['variant'][];
 
   constructor(ast: ast.LibraryMembers, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new ContractMember(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new ContractMember(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { PolymorphicNode } from './PolymorphicNode.js';
+import { SlangNode } from './SlangNode.js';
 import { PragmaDirective } from './PragmaDirective.js';
 import { ImportDirective } from './ImportDirective.js';
 import { ContractDefinition } from './ContractDefinition.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class SourceUnitMember extends PolymorphicNode {
+export class SourceUnitMember extends SlangNode {
   readonly kind = NonterminalKind.SourceUnitMember;
 
   variant:

--- a/src/slang-nodes/SourceUnitMembers.ts
+++ b/src/slang-nodes/SourceUnitMembers.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { SourceUnitMember } from './SourceUnitMember.js';
 
@@ -11,12 +12,14 @@ import type { AstNode } from './types.d.ts';
 export class SourceUnitMembers extends SlangNode {
   readonly kind = NonterminalKind.SourceUnitMembers;
 
-  items: SourceUnitMember[];
+  items: SourceUnitMember['variant'][];
 
   constructor(ast: ast.SourceUnitMembers, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new SourceUnitMember(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new SourceUnitMember(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { PolymorphicNode } from './PolymorphicNode.js';
+import { SlangNode } from './SlangNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
@@ -81,7 +81,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class Statement extends PolymorphicNode {
+export class Statement extends SlangNode {
   readonly kind = NonterminalKind.Statement;
 
   variant:

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 
@@ -15,12 +16,14 @@ const { hardline } = doc.builders;
 export class Statements extends SlangNode {
   readonly kind = NonterminalKind.Statements;
 
-  items: Statement[];
+  items: Statement['variant'][];
 
   constructor(ast: ast.Statements, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new Statement(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new Statement(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
@@ -16,13 +17,13 @@ export class WhileStatement extends SlangNode {
 
   condition: Expression;
 
-  body: Statement;
+  body: Statement['variant'];
 
   constructor(ast: ast.WhileStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.condition = new Expression(ast.condition, options);
-    this.body = new Statement(ast.body, options);
+    this.body = extractVariant(new Statement(ast.body, options));
 
     this.updateMetadata(this.condition, this.body);
   }
@@ -33,8 +34,8 @@ export class WhileStatement extends SlangNode {
       printSeparatedItem(path.call(printVariant(print), 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'body'),
-        this.body.variant.kind !== NonterminalKind.Block
+        path.call(print, 'body'),
+        this.body.kind !== NonterminalKind.Block
       )
     ];
   }

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -1,6 +1,6 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { PolymorphicNode } from './PolymorphicNode.js';
+import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
 import { YulFunctionDefinition } from './YulFunctionDefinition.js';
 import { YulVariableDeclarationStatement } from './YulVariableDeclarationStatement.js';
@@ -65,7 +65,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class YulStatement extends PolymorphicNode {
+export class YulStatement extends SlangNode {
   readonly kind = NonterminalKind.YulStatement;
 
   variant:

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulStatement } from './YulStatement.js';
 
@@ -15,12 +16,14 @@ const { hardline } = doc.builders;
 export class YulStatements extends SlangNode {
   readonly kind = NonterminalKind.YulStatements;
 
-  items: YulStatement[];
+  items: YulStatement['variant'][];
 
   constructor(ast: ast.YulStatements, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new YulStatement(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new YulStatement(item, options))
+    );
   }
 
   print(

--- a/src/slang-nodes/types.d.ts
+++ b/src/slang-nodes/types.d.ts
@@ -475,7 +475,7 @@ export type NodeCollection = Extract<
 
 export type LineCollection = Extract<
   NodeCollection,
-  { items: StrictPolymorphicNode[] }
+  { items: StrictPolymorphicNode['variant'][] }
 >;
 
 export type BinaryOperation = Extract<

--- a/src/slang-printers/print-preserving-empty-lines.ts
+++ b/src/slang-printers/print-preserving-empty-lines.ts
@@ -22,13 +22,10 @@ export function printPreservingEmptyLines(
           // Only attempt to prepend an empty line if `node` is not the first item
           !childPath.isFirst &&
           // YulLabel adds a dedented line so we don't have to prepend a hardline.
-          (node.kind !== NonterminalKind.YulStatement ||
-            node.variant.kind !== NonterminalKind.YulLabel)
+          node.kind !== NonterminalKind.YulLabel
             ? hardline
             : '',
-          node.comments && node.comments.length === 0
-            ? childPath.call(print, 'variant')
-            : print(childPath),
+          print(childPath),
           // Only attempt to append an empty line if `node` is not the last item
           !childPath.isLast &&
           // Append an empty line if the original text already had an one after the

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -13,6 +13,10 @@ import type { ModifierAttribute } from './slang-nodes/ModifierAttribute.js';
 import type { ReceiveFunctionAttribute } from './slang-nodes/ReceiveFunctionAttribute.js';
 import type { StateVariableAttribute } from './slang-nodes/StateVariableAttribute.js';
 import type { UnnamedFunctionAttribute } from './slang-nodes/UnnamedFunctionAttribute.js';
+import type { ContractMember } from './slang-nodes/ContractMember.js';
+import type { SourceUnitMember } from './slang-nodes/SourceUnitMember.js';
+import type { Statement } from './slang-nodes/Statement.js';
+import type { YulStatement } from './slang-nodes/YulStatement.js';
 
 function hasNodeIgnoreComment({ comments }: StrictAstNode): boolean {
   // Prettier sets SourceUnit's comments to undefined after assigning comments
@@ -74,6 +78,10 @@ function genericPrint(
       | ReceiveFunctionAttribute
       | StateVariableAttribute
       | UnnamedFunctionAttribute
+      | ContractMember
+      | SourceUnitMember
+      | Statement
+      | YulStatement
     >
   >,
   options: ParserOptions<AstNode>,


### PR DESCRIPTION
Continuing the process of extracting variants.

In this PR we tackle all variants that can be given to the `printPreservingEmptyLines` function as an argument.