### PR TITLE
removing `Expression` from the AST tree

### DIFF
--- a/src/slang-comments/handlers/add-collection-first-comment.ts
+++ b/src/slang-comments/handlers/add-collection-first-comment.ts
@@ -1,11 +1,11 @@
 import { util } from 'prettier';
 
-import type { Comment, NodeCollection } from '../../slang-nodes/types.d.ts';
+import type { Comment, StrictCollection } from '../../slang-nodes/types.d.ts';
 
 const { addDanglingComment, addLeadingComment } = util;
 
 export default function addCollectionFirstComment(
-  node: NodeCollection,
+  node: StrictCollection,
   comment: Comment
 ): void {
   if (node.items.length === 0) {

--- a/src/slang-comments/handlers/add-collection-last-comment.ts
+++ b/src/slang-comments/handlers/add-collection-last-comment.ts
@@ -1,11 +1,11 @@
 import { util } from 'prettier';
 
-import type { Comment, NodeCollection } from '../../slang-nodes/types.d.ts';
+import type { Comment, StrictCollection } from '../../slang-nodes/types.d.ts';
 
 const { addDanglingComment, addTrailingComment } = util;
 
 export default function addCollectionLastComment(
-  node: NodeCollection,
+  node: StrictCollection,
   comment: Comment
 ): void {
   if (node.items.length === 0) {

--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -28,18 +29,20 @@ const printAdditiveExpression = printBinaryOperation(
 export class AdditiveExpression extends SlangNode {
   readonly kind = NonterminalKind.AdditiveExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AdditiveExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/AndExpression.ts
+++ b/src/slang-nodes/AndExpression.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printLogicalOperation } from '../slang-printers/print-logical-operation.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,18 +12,20 @@ import type { AstNode } from './types.d.ts';
 export class AndExpression extends SlangNode {
   readonly kind = NonterminalKind.AndExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AndExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
   }

--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { Expression } from './Expression.js';
@@ -14,14 +15,14 @@ export class ArrayTypeName extends SlangNode {
 
   operand: TypeName;
 
-  index?: Expression;
+  index?: Expression['variant'];
 
   constructor(ast: ast.ArrayTypeName, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.operand = new TypeName(ast.operand, options);
     if (ast.index) {
-      this.index = new Expression(ast.index, options);
+      this.index = extractVariant(new Expression(ast.index, options));
     }
 
     this.updateMetadata(this.operand, this.index);
@@ -31,7 +32,7 @@ export class ArrayTypeName extends SlangNode {
     return [
       path.call(printVariant(print), 'operand'),
       '[',
-      path.call(printVariant(print), 'index'),
+      path.call(print, 'index'),
       ']'
     ];
   }

--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -12,15 +12,17 @@ import type { AstNode } from './types.d.ts';
 export class ArrayValues extends SlangNode {
   readonly kind = NonterminalKind.ArrayValues;
 
-  items: Expression[];
+  items: Expression['variant'][];
 
   constructor(ast: ast.ArrayValues, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new Expression(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new Expression(item, options))
+    );
   }
 
   print(path: AstPath<ArrayValues>, print: PrintFunction): Doc {
-    return printSeparatedList(path.map(printVariant(print), 'items'));
+    return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -14,31 +14,32 @@ import type { AstNode } from './types.d.ts';
 export class AssignmentExpression extends SlangNode {
   readonly kind = NonterminalKind.AssignmentExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AssignmentExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
   }
 
   print(path: AstPath<AssignmentExpression>, print: PrintFunction): Doc {
-    const rightOperandVariant = this.rightOperand.variant;
     return [
-      path.call(printVariant(print), 'leftOperand'),
+      path.call(print, 'leftOperand'),
       ` ${this.operator}`,
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'rightOperand'),
-        !(rightOperandVariant instanceof TerminalNode) &&
-          isBinaryOperation(rightOperandVariant)
+        path.call(print, 'rightOperand'),
+        !(this.rightOperand instanceof TerminalNode) &&
+          isBinaryOperation(this.rightOperand)
       )
     ];
   }

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -24,18 +25,20 @@ const printBitwiseAndExpression = printBinaryOperation(
 export class BitwiseAndExpression extends SlangNode {
   readonly kind = NonterminalKind.BitwiseAndExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseAndExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -34,18 +35,20 @@ const printBitwiseOrExpression = printBinaryOperation(
 export class BitwiseOrExpression extends SlangNode {
   readonly kind = NonterminalKind.BitwiseOrExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseOrExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -24,18 +25,20 @@ const printBitwiseXorExpression = printBinaryOperation(
 export class BitwiseXorExpression extends SlangNode {
   readonly kind = NonterminalKind.BitwiseXorExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseXorExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { CallOptions } from './CallOptions.js';
@@ -12,25 +12,20 @@ import type { AstNode } from './types.d.ts';
 export class CallOptionsExpression extends SlangNode {
   readonly kind = NonterminalKind.CallOptionsExpression;
 
-  operand: Expression;
+  operand: Expression['variant'];
 
   options: CallOptions;
 
   constructor(ast: ast.CallOptionsExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.operand = new Expression(ast.operand, options);
+    this.operand = extractVariant(new Expression(ast.operand, options));
     this.options = new CallOptions(ast.options, options);
 
     this.updateMetadata(this.operand, this.options);
   }
 
   print(path: AstPath<CallOptionsExpression>, print: PrintFunction): Doc {
-    return [
-      path.call(printVariant(print), 'operand'),
-      '{',
-      path.call(print, 'options'),
-      '}'
-    ];
+    return [path.call(print, 'operand'), '{', path.call(print, 'options'), '}'];
   }
 }

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -1,5 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -17,14 +18,14 @@ export class ConstantDefinition extends SlangNode {
 
   name: TerminalNode;
 
-  value: Expression;
+  value: Expression['variant'];
 
   constructor(ast: ast.ConstantDefinition, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.typeName = new TypeName(ast.typeName, options);
     this.name = new TerminalNode(ast.name);
-    this.value = new Expression(ast.value, options);
+    this.value = extractVariant(new Expression(ast.value, options));
 
     this.updateMetadata(this.typeName, this.value);
   }
@@ -35,7 +36,7 @@ export class ConstantDefinition extends SlangNode {
       ' constant ',
       path.call(print, 'name'),
       ' = ',
-      path.call(printVariant(print), 'value'),
+      path.call(print, 'value'),
       ';'
     ];
   }

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
-import { printVariant } from '../slang-printers/print-variant.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
@@ -19,13 +18,13 @@ export class DoWhileStatement extends SlangNode {
 
   body: Statement['variant'];
 
-  condition: Expression;
+  condition: Expression['variant'];
 
   constructor(ast: ast.DoWhileStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.body = extractVariant(new Statement(ast.body, options));
-    this.condition = new Expression(ast.condition, options);
+    this.condition = extractVariant(new Expression(ast.condition, options));
 
     this.updateMetadata(this.body, this.condition);
   }
@@ -38,7 +37,7 @@ export class DoWhileStatement extends SlangNode {
         ? [' ', body, ' ']
         : printSeparatedItem(body, { firstSeparator: line }),
       'while (',
-      printSeparatedItem(path.call(printVariant(print), 'condition')),
+      printSeparatedItem(path.call(print, 'condition')),
       ');'
     ];
   }

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -22,18 +23,20 @@ const printEqualityExpression = printBinaryOperation(
 export class EqualityExpression extends SlangNode {
   readonly kind = NonterminalKind.EqualityExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.EqualityExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -4,6 +4,7 @@ import { createBinaryOperationPrinter } from '../slang-printers/create-binary-op
 import { binaryIndentRulesBuilder } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -39,11 +40,11 @@ const printExponentiationExpression = createBinaryOperationPrinter(
 export class ExponentiationExpression extends SlangNode {
   readonly kind = NonterminalKind.ExponentiationExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(
     ast: ast.ExponentiationExpression,
@@ -51,9 +52,11 @@ export class ExponentiationExpression extends SlangNode {
   ) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -4,7 +4,7 @@ import {
   TerminalNode as SlangTerminalNode
 } from '@nomicfoundation/slang/cst';
 import { extractVariant } from '../slang-utils/extract-variant.js';
-import { PolymorphicNode } from './PolymorphicNode.js';
+import { SlangNode } from './SlangNode.js';
 import { AssignmentExpression } from './AssignmentExpression.js';
 import { ConditionalExpression } from './ConditionalExpression.js';
 import { OrExpression } from './OrExpression.js';
@@ -126,7 +126,7 @@ function createNonterminalVariant(
   return exhaustiveCheck;
 }
 
-export class Expression extends PolymorphicNode {
+export class Expression extends SlangNode {
   readonly kind = NonterminalKind.Expression;
 
   variant:

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,17 +11,17 @@ import type { AstNode } from './types.d.ts';
 export class ExpressionStatement extends SlangNode {
   readonly kind = NonterminalKind.ExpressionStatement;
 
-  expression: Expression;
+  expression: Expression['variant'];
 
   constructor(ast: ast.ExpressionStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.expression = new Expression(ast.expression, options);
+    this.expression = extractVariant(new Expression(ast.expression, options));
 
     this.updateMetadata(this.expression);
   }
 
   print(path: AstPath<ExpressionStatement>, print: PrintFunction): Doc {
-    return [path.call(printVariant(print), 'expression'), ';'];
+    return [path.call(print, 'expression'), ';'];
   }
 }

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -24,7 +24,7 @@ export class ForStatement extends SlangNode {
 
   condition: ForStatementCondition;
 
-  iterator?: Expression;
+  iterator?: Expression['variant'];
 
   body: Statement['variant'];
 
@@ -37,7 +37,7 @@ export class ForStatement extends SlangNode {
     );
     this.condition = new ForStatementCondition(ast.condition, options);
     if (ast.iterator) {
-      this.iterator = new Expression(ast.iterator, options);
+      this.iterator = extractVariant(new Expression(ast.iterator, options));
     }
     this.body = extractVariant(new Statement(ast.body, options));
 
@@ -52,7 +52,7 @@ export class ForStatement extends SlangNode {
   print(path: AstPath<ForStatement>, print: PrintFunction): Doc {
     const initialization = path.call(printVariant(print), 'initialization');
     const condition = path.call(printVariant(print), 'condition');
-    const iterator = path.call(printVariant(print), 'iterator');
+    const iterator = path.call(print, 'iterator');
 
     return [
       'for (',

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -2,7 +2,6 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { isLabel } from '../slang-utils/is-label.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
-import { printVariant } from '../slang-printers/print-variant.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
@@ -18,7 +17,7 @@ const { label } = doc.builders;
 export class FunctionCallExpression extends SlangNode {
   readonly kind = NonterminalKind.FunctionCallExpression;
 
-  operand: Expression;
+  operand: Expression['variant'];
 
   arguments: ArgumentsDeclaration['variant'];
 
@@ -28,7 +27,7 @@ export class FunctionCallExpression extends SlangNode {
   ) {
     super(ast);
 
-    this.operand = new Expression(ast.operand, options);
+    this.operand = extractVariant(new Expression(ast.operand, options));
     this.arguments = extractVariant(
       new ArgumentsDeclaration(ast.arguments, options)
     );
@@ -37,7 +36,7 @@ export class FunctionCallExpression extends SlangNode {
   }
 
   print(path: AstPath<FunctionCallExpression>, print: PrintFunction): Doc {
-    const operand = path.call(printVariant(print), 'operand');
+    const operand = path.call(print, 'operand');
     const argumentsDoc = path.call(print, 'arguments');
 
     // If we are at the end of a MemberAccessChain we should indent the

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -3,7 +3,6 @@ import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { isBlockComment } from '../slang-utils/is-comment.js';
-import { printVariant } from '../slang-printers/print-variant.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
@@ -20,7 +19,7 @@ const { hardline } = doc.builders;
 export class IfStatement extends SlangNode {
   readonly kind = NonterminalKind.IfStatement;
 
-  condition: Expression;
+  condition: Expression['variant'];
 
   body: Statement['variant'];
 
@@ -29,7 +28,7 @@ export class IfStatement extends SlangNode {
   constructor(ast: ast.IfStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.condition = new Expression(ast.condition, options);
+    this.condition = extractVariant(new Expression(ast.condition, options));
     this.body = extractVariant(new Statement(ast.body, options));
     if (ast.elseBranch) {
       this.elseBranch = new ElseBranch(ast.elseBranch, options);
@@ -42,7 +41,7 @@ export class IfStatement extends SlangNode {
     const { kind: bodyKind, comments: bodyComments } = this.body;
     return [
       'if (',
-      printSeparatedItem(path.call(printVariant(print), 'condition')),
+      printSeparatedItem(path.call(print, 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
         path.call(print, 'body'),

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,19 +11,19 @@ import type { AstNode } from './types.d.ts';
 export class IndexAccessEnd extends SlangNode {
   readonly kind = NonterminalKind.IndexAccessEnd;
 
-  end?: Expression;
+  end?: Expression['variant'];
 
   constructor(ast: ast.IndexAccessEnd, options: ParserOptions<AstNode>) {
     super(ast);
 
     if (ast.end) {
-      this.end = new Expression(ast.end, options);
+      this.end = extractVariant(new Expression(ast.end, options));
     }
 
     this.updateMetadata(this.end);
   }
 
   print(path: AstPath<IndexAccessEnd>, print: PrintFunction): Doc {
-    return [':', path.call(printVariant(print), 'end')];
+    return [':', path.call(print, 'end')];
   }
 }

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -3,7 +3,7 @@ import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
 import { isLabel } from '../slang-utils/is-label.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { IndexAccessEnd } from './IndexAccessEnd.js';
@@ -18,18 +18,18 @@ const { label } = doc.builders;
 export class IndexAccessExpression extends SlangNode {
   readonly kind = NonterminalKind.IndexAccessExpression;
 
-  operand: Expression;
+  operand: Expression['variant'];
 
-  start?: Expression;
+  start?: Expression['variant'];
 
   end?: IndexAccessEnd;
 
   constructor(ast: ast.IndexAccessExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.operand = new Expression(ast.operand, options);
+    this.operand = extractVariant(new Expression(ast.operand, options));
     if (ast.start) {
-      this.start = new Expression(ast.start, options);
+      this.start = extractVariant(new Expression(ast.start, options));
     }
     if (ast.end) {
       this.end = new IndexAccessEnd(ast.end, options);
@@ -39,13 +39,10 @@ export class IndexAccessExpression extends SlangNode {
   }
 
   print(path: AstPath<IndexAccessExpression>, print: PrintFunction): Doc {
-    const operand = path.call(printVariant(print), 'operand');
+    const operand = path.call(print, 'operand');
     const indexDoc = [
       '[',
-      printSeparatedItem([
-        path.call(printVariant(print), 'start'),
-        path.call(print, 'end')
-      ]),
+      printSeparatedItem([path.call(print, 'start'), path.call(print, 'end')]),
       ']'
     ];
 

--- a/src/slang-nodes/InequalityExpression.ts
+++ b/src/slang-nodes/InequalityExpression.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -20,18 +21,20 @@ const printComparisonExpression = printBinaryOperation(
 export class InequalityExpression extends SlangNode {
   readonly kind = NonterminalKind.InequalityExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.InequalityExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
   }

--- a/src/slang-nodes/MultiplicativeExpression.ts
+++ b/src/slang-nodes/MultiplicativeExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -31,11 +32,11 @@ const printMultiplicativeExpression = printBinaryOperation(
 export class MultiplicativeExpression extends SlangNode {
   readonly kind = NonterminalKind.MultiplicativeExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(
     ast: ast.MultiplicativeExpression,
@@ -43,9 +44,11 @@ export class MultiplicativeExpression extends SlangNode {
   ) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
@@ -14,22 +14,18 @@ export class NamedArgument extends SlangNode {
 
   name: TerminalNode;
 
-  value: Expression;
+  value: Expression['variant'];
 
   constructor(ast: ast.NamedArgument, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.name = new TerminalNode(ast.name);
-    this.value = new Expression(ast.value, options);
+    this.value = extractVariant(new Expression(ast.value, options));
 
     this.updateMetadata(this.value);
   }
 
   print(path: AstPath<NamedArgument>, print: PrintFunction): Doc {
-    return [
-      path.call(print, 'name'),
-      ': ',
-      path.call(printVariant(print), 'value')
-    ];
+    return [path.call(print, 'name'), ': ', path.call(print, 'value')];
   }
 }

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -1,6 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printLogicalOperation } from '../slang-printers/print-logical-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -14,18 +15,20 @@ const tryToHug = createHugFunction(['&&']);
 export class OrExpression extends SlangNode {
   readonly kind = NonterminalKind.OrExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.OrExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printComments } from '../slang-printers/print-comments.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -14,12 +14,14 @@ import type { AstNode } from './types.d.ts';
 export class PositionalArguments extends SlangNode {
   readonly kind = NonterminalKind.PositionalArguments;
 
-  items: Expression[];
+  items: Expression['variant'][];
 
   constructor(ast: ast.PositionalArguments, options: ParserOptions<AstNode>) {
     super(ast, true);
 
-    this.items = ast.items.map((item) => new Expression(item, options));
+    this.items = ast.items.map((item) =>
+      extractVariant(new Expression(item, options))
+    );
   }
 
   print(
@@ -28,7 +30,7 @@ export class PositionalArguments extends SlangNode {
     options: ParserOptions<AstNode>
   ): Doc {
     if (this.items.length > 0) {
-      return printSeparatedList(path.map(printVariant(print), 'items'));
+      return printSeparatedList(path.map(print, 'items'));
     }
     const argumentComments = printComments(path, options);
 

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,20 +11,20 @@ import type { AstNode } from './types.d.ts';
 export class PostfixExpression extends SlangNode {
   readonly kind = NonterminalKind.PostfixExpression;
 
-  operand: Expression;
+  operand: Expression['variant'];
 
   operator: string;
 
   constructor(ast: ast.PostfixExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.operand = new Expression(ast.operand, options);
+    this.operand = extractVariant(new Expression(ast.operand, options));
     this.operator = ast.operator.unparse();
 
     this.updateMetadata(this.operand);
   }
 
   print(path: AstPath<PostfixExpression>, print: PrintFunction): Doc {
-    return [path.call(printVariant(print), 'operand'), this.operator];
+    return [path.call(print, 'operand'), this.operator];
   }
 }

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -13,13 +13,13 @@ export class PrefixExpression extends SlangNode {
 
   operator: string;
 
-  operand: Expression;
+  operand: Expression['variant'];
 
   constructor(ast: ast.PrefixExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
     this.operator = ast.operator.unparse();
-    this.operand = new Expression(ast.operand, options);
+    this.operand = extractVariant(new Expression(ast.operand, options));
 
     this.updateMetadata(this.operand);
 
@@ -29,6 +29,6 @@ export class PrefixExpression extends SlangNode {
   }
 
   print(path: AstPath<PrefixExpression>, print: PrintFunction): Doc {
-    return [this.operator, path.call(printVariant(print), 'operand')];
+    return [this.operator, path.call(print, 'operand')];
   }
 }

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -12,13 +12,13 @@ import type { AstNode } from './types.d.ts';
 export class ReturnStatement extends SlangNode {
   readonly kind = NonterminalKind.ReturnStatement;
 
-  expression?: Expression;
+  expression?: Expression['variant'];
 
   constructor(ast: ast.ReturnStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
     if (ast.expression) {
-      this.expression = new Expression(ast.expression, options);
+      this.expression = extractVariant(new Expression(ast.expression, options));
     }
 
     this.updateMetadata(this.expression);
@@ -29,12 +29,12 @@ export class ReturnStatement extends SlangNode {
     print: PrintFunction,
     options: ParserOptions<AstNode>
   ): Doc {
-    const expressionVariantKind = this.expression?.variant.kind;
+    const expressionVariantKind = this.expression?.kind;
     return [
       'return',
       expressionVariantKind
         ? printIndentedGroupOrSpacedDocument(
-            path.call(printVariant(print), 'expression'),
+            path.call(print, 'expression'),
             expressionVariantKind !== NonterminalKind.TupleExpression &&
               (!options.experimentalTernaries ||
                 expressionVariantKind !== NonterminalKind.ConditionalExpression)

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -2,6 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -36,18 +37,20 @@ const printShiftExpression = printBinaryOperation(
 export class ShiftExpression extends SlangNode {
   readonly kind = NonterminalKind.ShiftExpression;
 
-  leftOperand: Expression;
+  leftOperand: Expression['variant'];
 
   operator: string;
 
-  rightOperand: Expression;
+  rightOperand: Expression['variant'];
 
   constructor(ast: ast.ShiftExpression, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.leftOperand = new Expression(ast.leftOperand, options);
+    this.leftOperand = extractVariant(new Expression(ast.leftOperand, options));
     this.operator = ast.operator.unparse();
-    this.rightOperand = new Expression(ast.rightOperand, options);
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, options)
+    );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
 

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -12,7 +12,7 @@ import type { AstNode } from './types.d.ts';
 export class StateVariableDefinitionValue extends SlangNode {
   readonly kind = NonterminalKind.StateVariableDefinitionValue;
 
-  value: Expression;
+  value: Expression['variant'];
 
   constructor(
     ast: ast.StateVariableDefinitionValue,
@@ -20,7 +20,7 @@ export class StateVariableDefinitionValue extends SlangNode {
   ) {
     super(ast);
 
-    this.value = new Expression(ast.value, options);
+    this.value = extractVariant(new Expression(ast.value, options));
 
     this.updateMetadata(this.value);
   }
@@ -32,8 +32,8 @@ export class StateVariableDefinitionValue extends SlangNode {
     return [
       ' =',
       printIndentedGroupOrSpacedDocument(
-        path.call(printVariant(print), 'value'),
-        this.value.variant.kind !== NonterminalKind.ArrayExpression
+        path.call(print, 'value'),
+        this.value.kind !== NonterminalKind.ArrayExpression
       )
     ];
   }

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -15,7 +15,7 @@ const { line } = doc.builders;
 export class StorageLayoutSpecifier extends SlangNode {
   readonly kind = NonterminalKind.StorageLayoutSpecifier;
 
-  expression: Expression;
+  expression: Expression['variant'];
 
   constructor(
     ast: ast.StorageLayoutSpecifier,
@@ -23,7 +23,7 @@ export class StorageLayoutSpecifier extends SlangNode {
   ) {
     super(ast);
 
-    this.expression = new Expression(ast.expression, options);
+    this.expression = extractVariant(new Expression(ast.expression, options));
 
     this.updateMetadata(this.expression);
   }
@@ -31,7 +31,7 @@ export class StorageLayoutSpecifier extends SlangNode {
   print(path: AstPath<StorageLayoutSpecifier>, print: PrintFunction): Doc {
     return [
       'layout at',
-      printSeparatedItem(path.call(printVariant(print), 'expression'), {
+      printSeparatedItem(path.call(print, 'expression'), {
         firstSeparator: line,
         // If this is the second ContractSpecifier we have to delegate printing
         // the line to the ContractSpecifiers node.

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { joinExisting } from '../slang-utils/join-existing.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 import { ReturnsDeclaration } from './ReturnsDeclaration.js';
@@ -19,7 +19,7 @@ const { line } = doc.builders;
 export class TryStatement extends SlangNode {
   readonly kind = NonterminalKind.TryStatement;
 
-  expression: Expression;
+  expression: Expression['variant'];
 
   returns?: ReturnsDeclaration;
 
@@ -30,7 +30,7 @@ export class TryStatement extends SlangNode {
   constructor(ast: ast.TryStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.expression = new Expression(ast.expression, options);
+    this.expression = extractVariant(new Expression(ast.expression, options));
     if (ast.returns) {
       this.returns = new ReturnsDeclaration(ast.returns, options);
     }
@@ -48,7 +48,7 @@ export class TryStatement extends SlangNode {
   print(path: AstPath<TryStatement>, print: PrintFunction): Doc {
     return [
       'try',
-      printSeparatedItem(path.call(printVariant(print), 'expression'), {
+      printSeparatedItem(path.call(print, 'expression'), {
         firstSeparator: line
       }),
       joinExisting(' ', [

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TupleDeconstructionElements } from './TupleDeconstructionElements.js';
 import { Expression } from './Expression.js';
@@ -17,7 +17,7 @@ export class TupleDeconstructionStatement extends SlangNode {
 
   elements: TupleDeconstructionElements;
 
-  expression: Expression;
+  expression: Expression['variant'];
 
   constructor(
     ast: ast.TupleDeconstructionStatement,
@@ -27,7 +27,7 @@ export class TupleDeconstructionStatement extends SlangNode {
 
     this.varKeyword = ast.varKeyword?.unparse();
     this.elements = new TupleDeconstructionElements(ast.elements, options);
-    this.expression = new Expression(ast.expression, options);
+    this.expression = extractVariant(new Expression(ast.expression, options));
 
     this.updateMetadata(this.elements, this.expression);
   }
@@ -38,7 +38,7 @@ export class TupleDeconstructionStatement extends SlangNode {
   ): Doc {
     return printGroupAndIndentIfBreakPair(
       [this.varKeyword ? 'var (' : '(', path.call(print, 'elements'), ') = '],
-      [path.call(printVariant(print), 'expression'), ';']
+      [path.call(print, 'expression'), ';']
     );
   }
 }

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,19 +11,19 @@ import type { AstNode } from './types.d.ts';
 export class TupleValue extends SlangNode {
   readonly kind = NonterminalKind.TupleValue;
 
-  expression?: Expression;
+  expression?: Expression['variant'];
 
   constructor(ast: ast.TupleValue, options: ParserOptions<AstNode>) {
     super(ast);
 
     if (ast.expression) {
-      this.expression = new Expression(ast.expression, options);
+      this.expression = extractVariant(new Expression(ast.expression, options));
     }
 
     this.updateMetadata(this.expression);
   }
 
   print(path: AstPath<TupleValue>, print: PrintFunction): Doc {
-    return path.call(printVariant(print), 'expression');
+    return path.call(print, 'expression');
   }
 }

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -22,17 +22,17 @@ export class TupleValues extends SlangNode {
     this.items = ast.items.map((item) => new TupleValue(item, options));
   }
 
-  getSingleExpression(): Expression | undefined {
+  getSingleExpression(): Expression['variant'] | undefined {
     const items = this.items;
     return items.length === 1 ? items[0].expression : undefined;
   }
 
   print(path: AstPath<TupleValues>, print: PrintFunction): Doc {
-    const singleExpressionVariant = this.getSingleExpression()?.variant;
+    const singleExpression = this.getSingleExpression();
     const items = path.map(print, 'items');
-    return singleExpressionVariant &&
-      !(singleExpressionVariant instanceof TerminalNode) &&
-      isBinaryOperation(singleExpressionVariant)
+    return singleExpression &&
+      !(singleExpression instanceof TerminalNode) &&
+      isBinaryOperation(singleExpression)
       ? items
       : printSeparatedList(items);
   }

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printVariant } from '../slang-printers/print-variant.js';
+import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
@@ -11,7 +11,7 @@ import type { AstNode } from './types.d.ts';
 export class VariableDeclarationValue extends SlangNode {
   readonly kind = NonterminalKind.VariableDeclarationValue;
 
-  expression: Expression;
+  expression: Expression['variant'];
 
   constructor(
     ast: ast.VariableDeclarationValue,
@@ -19,12 +19,12 @@ export class VariableDeclarationValue extends SlangNode {
   ) {
     super(ast);
 
-    this.expression = new Expression(ast.expression, options);
+    this.expression = extractVariant(new Expression(ast.expression, options));
 
     this.updateMetadata(this.expression);
   }
 
   print(path: AstPath<VariableDeclarationValue>, print: PrintFunction): Doc {
-    return [' = ', path.call(printVariant(print), 'expression')];
+    return [' = ', path.call(print, 'expression')];
   }
 }

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
-import { printVariant } from '../slang-printers/print-variant.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
@@ -15,14 +14,14 @@ import type { AstNode } from './types.d.ts';
 export class WhileStatement extends SlangNode {
   readonly kind = NonterminalKind.WhileStatement;
 
-  condition: Expression;
+  condition: Expression['variant'];
 
   body: Statement['variant'];
 
   constructor(ast: ast.WhileStatement, options: ParserOptions<AstNode>) {
     super(ast);
 
-    this.condition = new Expression(ast.condition, options);
+    this.condition = extractVariant(new Expression(ast.condition, options));
     this.body = extractVariant(new Statement(ast.body, options));
 
     this.updateMetadata(this.condition, this.body);
@@ -31,7 +30,7 @@ export class WhileStatement extends SlangNode {
   print(path: AstPath<WhileStatement>, print: PrintFunction): Doc {
     return [
       'while (',
-      printSeparatedItem(path.call(printVariant(print), 'condition')),
+      printSeparatedItem(path.call(print, 'condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
         path.call(print, 'body'),

--- a/src/slang-nodes/types.d.ts
+++ b/src/slang-nodes/types.d.ts
@@ -468,22 +468,22 @@ export type StrictPolymorphicNode = Extract<
 
 export type Collection = Extract<StrictAstNode, { items: unknown[] }>;
 
-export type NodeCollection = Extract<
+export type StrictCollection = Extract<
   Collection,
-  { items: StrictAstNode[] | TerminalNode[] }
+  { items: (StrictAstNode | TerminalNode)[] }
 >;
 
 export type LineCollection = Extract<
-  NodeCollection,
+  StrictCollection,
   { items: StrictPolymorphicNode['variant'][] }
 >;
 
 export type BinaryOperation = Extract<
   StrictAstNode,
   {
-    leftOperand: Expression;
+    leftOperand: Expression['variant'];
     operator: string;
-    rightOperand: Expression;
+    rightOperand: Expression['variant'];
   }
 >;
 

--- a/src/slang-printers/create-binary-operation-printer.ts
+++ b/src/slang-printers/create-binary-operation-printer.ts
@@ -2,7 +2,6 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
 import { TerminalNode } from '../slang-nodes/TerminalNode.js';
-import { printVariant } from './print-variant.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type {
@@ -20,7 +19,7 @@ function rightOperandPrint(
   print: PrintFunction,
   options: ParserOptions<AstNode>
 ): Doc {
-  const rightOperand = path.call(printVariant(print), 'rightOperand');
+  const rightOperand = path.call(print, 'rightOperand');
   const rightOperandDoc =
     options.experimentalOperatorPosition === 'end'
       ? [` ${operator}`, line, rightOperand]
@@ -28,13 +27,11 @@ function rightOperandPrint(
 
   // If there's only a single binary expression, we want to create a group in
   // order to avoid having a small right part like -1 be on its own line.
-  const leftOperandVariant = leftOperand.variant;
-  const grandparentNode = path.grandparent as StrictAstNode;
+  const parent = path.parent as StrictAstNode;
   const shouldGroup =
-    (leftOperandVariant instanceof TerminalNode ||
-      !isBinaryOperation(leftOperandVariant)) &&
-    (!isBinaryOperation(grandparentNode) ||
-      grandparentNode.kind === NonterminalKind.AssignmentExpression);
+    (leftOperand instanceof TerminalNode || !isBinaryOperation(leftOperand)) &&
+    (!isBinaryOperation(parent) ||
+      parent.kind === NonterminalKind.AssignmentExpression);
 
   return shouldGroup ? group(rightOperandDoc) : rightOperandDoc;
 }
@@ -59,7 +56,7 @@ export const createBinaryOperationPrinter =
     const indentRules = indentRulesBuilder(path, options);
 
     return groupRules([
-      path.call(printVariant(print), 'leftOperand'),
+      path.call(print, 'leftOperand'),
       indentRules(rightOperandPrint(node, path, print, options))
     ]);
   };

--- a/src/slang-printers/print-binary-operation.ts
+++ b/src/slang-printers/print-binary-operation.ts
@@ -18,9 +18,9 @@ export const binaryGroupRulesBuilder =
   (shouldGroup: (node: BinaryOperation) => boolean) =>
   (path: AstPath<BinaryOperation>) =>
   (document: Doc): Doc => {
-    const grandparentNode = path.grandparent as StrictAstNode;
-    if (!isBinaryOperation(grandparentNode)) return group(document);
-    if (shouldGroup(grandparentNode)) return group(document);
+    const parent = path.parent as StrictAstNode;
+    if (!isBinaryOperation(parent)) return group(document);
+    if (shouldGroup(parent)) return group(document);
     return document;
   };
 
@@ -44,13 +44,13 @@ export const binaryIndentRulesBuilder =
   (shouldIndent: (node: BinaryOperation) => boolean) =>
   (path: AstPath<BinaryOperation>) =>
   (document: Doc): Doc => {
-    for (let i = 2, node = path.node; ; i += 2) {
-      const grandparentNode = path.getNode(i) as StrictAstNode;
-      if (shouldNotIndent(grandparentNode, path, i)) break;
-      if (!isBinaryOperation(grandparentNode)) return indent(document);
-      if (shouldIndent(grandparentNode)) return indent(document);
-      if (node === grandparentNode.rightOperand.variant) break;
-      node = grandparentNode;
+    for (let i = 1, node = path.node; ; i++) {
+      const parent = path.getNode(i) as StrictAstNode;
+      if (shouldNotIndent(parent, path, i)) break;
+      if (!isBinaryOperation(parent)) return indent(document);
+      if (shouldIndent(parent)) return indent(document);
+      if (node === parent.rightOperand) break;
+      node = parent;
     }
     return document;
   };

--- a/src/slang-printers/print-logical-operation.ts
+++ b/src/slang-printers/print-logical-operation.ts
@@ -21,18 +21,18 @@ const logicalGroupRulesBuilder = binaryGroupRulesBuilder(() => false);
 const logicalIndentRulesBuilder =
   (path: AstPath<BinaryOperation>, options: ParserOptions<AstNode>) =>
   (document: Doc): Doc => {
-    for (let i = 2, node = path.node; ; i += 2) {
-      const grandparentNode = path.getNode(i) as StrictAstNode;
-      if (shouldNotIndent(grandparentNode, path, i)) break;
+    for (let i = 1, node = path.node; ; i++) {
+      const parent = path.getNode(i) as StrictAstNode;
+      if (shouldNotIndent(parent, path, i)) break;
       if (
         options.experimentalTernaries &&
-        grandparentNode.kind === NonterminalKind.ConditionalExpression &&
-        grandparentNode.operand.variant === node
+        parent.kind === NonterminalKind.ConditionalExpression &&
+        parent.operand === node
       )
         break;
-      if (!isBinaryOperation(grandparentNode)) return indent(document);
-      if (node === grandparentNode.rightOperand.variant) break;
-      node = grandparentNode;
+      if (!isBinaryOperation(parent)) return indent(document);
+      if (node === parent.rightOperand) break;
+      node = parent;
     }
     return document;
   };

--- a/src/slang-utils/create-hug-function.ts
+++ b/src/slang-utils/create-hug-function.ts
@@ -1,55 +1,50 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { Expression } from '../slang-nodes/Expression.js';
 import { TupleExpression } from '../slang-nodes/TupleExpression.js';
 import { TupleValues } from '../slang-nodes/TupleValues.js';
 import { TupleValue } from '../slang-nodes/TupleValue.js';
 import { TerminalNode } from '../slang-nodes/TerminalNode.js';
 import { isBinaryOperation } from './is-binary-operation.js';
 
+import type { Expression } from '../slang-nodes/Expression.js';
+
 export function createHugFunction(
   huggableOperators: string[]
-): (node: Expression) => Expression {
+): (node: Expression['variant']) => Expression['variant'] {
   const operators = new Set(huggableOperators);
-  return (node: Expression): Expression => {
-    const variant = node.variant;
+  return (node: Expression['variant']): Expression['variant'] => {
     if (
-      !(variant instanceof TerminalNode) &&
-      isBinaryOperation(variant) &&
-      operators.has(variant.operator)
+      !(node instanceof TerminalNode) &&
+      isBinaryOperation(node) &&
+      operators.has(node.operator)
     ) {
       const loc = node.loc;
-      return Object.assign(Object.create(Expression.prototype) as Expression, {
-        kind: NonterminalKind.Expression,
-        loc: { ...loc },
-        comments: [],
-        variant: Object.assign(
-          Object.create(TupleExpression.prototype) as TupleExpression,
-          {
-            kind: NonterminalKind.TupleExpression,
-            loc: { ...loc },
-            comments: [],
-            items: Object.assign(
-              Object.create(TupleValues.prototype) as TupleValues,
-              {
-                kind: NonterminalKind.TupleValues,
-                loc: { ...loc },
-                comments: [],
-                items: [
-                  Object.assign(
-                    Object.create(TupleValue.prototype) as TupleValue,
-                    {
-                      kind: NonterminalKind.TupleValue,
-                      loc: { ...loc },
-                      comments: [],
-                      expression: node
-                    }
-                  )
-                ]
-              }
-            )
-          }
-        )
-      });
+      return Object.assign(
+        Object.create(TupleExpression.prototype) as TupleExpression,
+        {
+          kind: NonterminalKind.TupleExpression,
+          loc: { ...loc },
+          comments: [],
+          items: Object.assign(
+            Object.create(TupleValues.prototype) as TupleValues,
+            {
+              kind: NonterminalKind.TupleValues,
+              loc: { ...loc },
+              comments: [],
+              items: [
+                Object.assign(
+                  Object.create(TupleValue.prototype) as TupleValue,
+                  {
+                    kind: NonterminalKind.TupleValue,
+                    loc: { ...loc },
+                    comments: [],
+                    expression: node
+                  }
+                )
+              ]
+            }
+          )
+        }
+      );
     }
 
     return node;

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -20,6 +20,7 @@ import type { YulStatement } from './slang-nodes/YulStatement.js';
 import type { ContractSpecifier } from './slang-nodes/ContractSpecifier.js';
 import type { ElementaryType } from './slang-nodes/ElementaryType.js';
 import type { ExperimentalFeature } from './slang-nodes/ExperimentalFeature.js';
+import type { Expression } from './slang-nodes/Expression.js';
 
 function hasNodeIgnoreComment({ comments }: StrictAstNode): boolean {
   // Prettier sets SourceUnit's comments to undefined after assigning comments
@@ -88,6 +89,7 @@ function genericPrint(
       | ContractSpecifier
       | ElementaryType
       | ExperimentalFeature
+      | Expression
     >
   >,
   options: ParserOptions<AstNode>,


### PR DESCRIPTION
This is one of the biggest changes in the process of removing `PolymorphicNode`s from the tree.

`Expression`s are used over all the AST tree therefore there's already a vast amount of files that needed to change.

Also the queries for the `grandparent` node were designed this way because we would navigate through an `Expression`. By removing the `Expression` all of these queries needed to be redesigned to a `parent` query. In this case there are some for loops that where increasing the index by 2 to skip the `Expression`, now they increase by 1.

`createHugFunction` now has to create a smaller tree when adding parentheses because there is no need for `Expression` now.