### PR TITLE
updating metadata of `CatchClauses` array

### DIFF
--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -19,6 +19,8 @@ export class CatchClauses extends SlangNode {
     super(ast, true);
 
     this.items = ast.items.map((item) => new CatchClause(item, options));
+
+    this.updateMetadata(...this.items);
   }
 
   print(path: AstPath<CatchClauses>, print: PrintFunction): Doc {

--- a/tests/format/TryCatch/TryCatch.sol
+++ b/tests/format/TryCatch/TryCatch.sol
@@ -101,3 +101,17 @@ contract FeedConsumer {
         }
     }
 }
+
+contract Test {
+    function getAdjustedBalance(IERC20 token) internal view returns (uint256) {
+        uint256 balance;
+
+        try token.balanceOf(address(this)) returns (uint256 result) {
+            balance = result;
+        } catch {
+            return 0;
+        }
+
+        return balance - 100;
+    }
+}

--- a/tests/format/TryCatch/__snapshots__/format.test.js.snap
+++ b/tests/format/TryCatch/__snapshots__/format.test.js.snap
@@ -110,6 +110,19 @@ contract FeedConsumer {
     }
 }
 
+contract Test {
+    function getAdjustedBalance(IERC20 token) internal view returns (uint256) {
+        uint256 balance;
+
+        try token.balanceOf(address(this)) returns (uint256 result) {
+            balance = result;
+        } catch {
+            return 0;
+        }
+
+        return balance - 100;
+    }
+}
 =====================================output=====================================
 pragma solidity ^0.6.0;
 
@@ -217,6 +230,20 @@ contract FeedConsumer {
             errorCount++;
             return (0, false);
         }
+    }
+}
+
+contract Test {
+    function getAdjustedBalance(IERC20 token) internal view returns (uint256) {
+        uint256 balance;
+
+        try token.balanceOf(address(this)) returns (uint256 result) {
+            balance = result;
+        } catch {
+            return 0;
+        }
+
+        return balance - 100;
     }
 }
 


### PR DESCRIPTION
closes #1293

Normally collections don't need a call to `updateMetadata` since they tend to be items belonging to a single line or printed by `printPreservingEmptyLines`.

`CatchClauses` is printed within the `TryStatement` so we need to take care of updating the `loc`.