### PR TITLE
throwing instead of returning a variable with type never

### DIFF
--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -18,7 +18,7 @@ function createNonterminalVariant(
     return new NamedArgumentsDeclaration(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ArgumentsDeclaration extends SlangNode {

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -62,7 +62,7 @@ function createNonterminalVariant(
     return new UserDefinedValueTypeDefinition(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ContractMember extends SlangNode {

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -18,7 +18,7 @@ function createNonterminalVariant(
     return new StorageLayoutSpecifier(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ContractSpecifier extends SlangNode {

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -123,7 +123,7 @@ function createNonterminalVariant(
     return extractVariant(new ElementaryType(variant));
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class Expression extends SlangNode {

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new OverrideSpecifier(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class FallbackFunctionAttribute extends SlangNode {

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -29,7 +29,7 @@ function createNonterminalVariant(
     return new TupleDeconstructionStatement(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ForStatementInitialization extends SlangNode {

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new OverrideSpecifier(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class FunctionAttribute extends SlangNode {

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new ImportDeconstruction(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ImportClause extends SlangNode {

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -15,7 +15,7 @@ function createNonterminalVariant(
     return new IdentifierPath(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class MappingKeyType extends SlangNode {

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new VersionPragma(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class Pragma extends SlangNode {

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new OverrideSpecifier(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class ReceiveFunctionAttribute extends SlangNode {

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -62,7 +62,7 @@ function createNonterminalVariant(
     return new EventDefinition(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class SourceUnitMember extends SlangNode {

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -78,7 +78,7 @@ function createNonterminalVariant(
     return new UncheckedBlock(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class Statement extends SlangNode {

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -30,7 +30,7 @@ function createNonterminalVariant(
     return new UnicodeStringLiterals(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class StringExpression extends SlangNode {

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -18,7 +18,7 @@ function createNonterminalVariant(
     return new UntypedTupleMember(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class TupleMember extends SlangNode {

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -31,7 +31,7 @@ function createNonterminalVariant(
     return new IdentifierPath(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class TypeName extends SlangNode {

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -14,7 +14,7 @@ function createNonterminalVariant(
     return new UsingDeconstruction(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class UsingClause extends SlangNode {

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -14,7 +14,7 @@ function createNonterminalVariant(
     return new VersionTerm(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class VersionExpression extends SlangNode {

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -23,7 +23,7 @@ function createNonterminalVariant(
     return new YulPath(variant);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class YulExpression extends SlangNode {

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -22,7 +22,7 @@ function createNonterminalVariant(
     return new StringLiteral(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class YulLiteral extends SlangNode {

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -63,7 +63,7 @@ function createNonterminalVariant(
     return extractVariant(new YulExpression(variant, options));
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class YulStatement extends SlangNode {

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -18,7 +18,7 @@ function createNonterminalVariant(
     return new YulValueCase(variant, options);
   }
   const exhaustiveCheck: never = variant;
-  return exhaustiveCheck;
+  throw new Error(`Unexpected variant: ${JSON.stringify(exhaustiveCheck)}`);
 }
 
 export class YulSwitchCase extends SlangNode {


### PR DESCRIPTION
it just feels safer to throw instead of relying on typescript's `never` type.