### PR TITLE
using the latest `print` signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ import { locEnd, locStart } from './slang-utils/loc.js';
 import { hasPrettierIgnore } from './slang-utils/has-prettier-ignore.js';
 
 import type {
+  AstPath,
+  Doc,
   Parser,
+  ParserOptions,
   Printer,
   RequiredOptions,
   SupportLanguage
@@ -77,7 +80,12 @@ const slangPrinter: Printer<PrintableNode | undefined> = {
   handleComments,
   isBlockComment,
   massageAstNode,
-  print: slangPrint,
+  print: slangPrint as (
+    path: AstPath<PrintableNode | undefined>,
+    options: ParserOptions<PrintableNode | undefined>,
+    print: (path: AstPath<PrintableNode | undefined>) => Doc,
+    args?: unknown
+  ) => Doc,
   hasPrettierIgnore,
   printComment
 };

--- a/src/slang-nodes/AbicoderPragma.ts
+++ b/src/slang-nodes/AbicoderPragma.ts
@@ -20,6 +20,6 @@ export class AbicoderPragma extends SlangNode {
   }
 
   print(path: AstPath<AbicoderPragma>, print: PrintFunction): Doc {
-    return ['abicoder ', path.call(print, 'version')];
+    return ['abicoder ', print('version')];
   }
 }

--- a/src/slang-nodes/AbicoderPragma.ts
+++ b/src/slang-nodes/AbicoderPragma.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { AbicoderVersion } from './AbicoderVersion.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class AbicoderPragma extends SlangNode {
@@ -19,7 +19,7 @@ export class AbicoderPragma extends SlangNode {
     this.updateMetadata(this.version);
   }
 
-  print(path: AstPath<AbicoderPragma>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['abicoder ', print('version')];
   }
 }

--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -57,8 +57,8 @@ export class AdditiveExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<AdditiveExpression>,
     print: PrintFunction,
+    path: AstPath<AdditiveExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printAdditiveExpression(this, path, print, options);

--- a/src/slang-nodes/AndExpression.ts
+++ b/src/slang-nodes/AndExpression.ts
@@ -37,8 +37,8 @@ export class AndExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<AndExpression>,
     print: PrintFunction,
+    path: AstPath<AndExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printLogicalOperation(this, path, print, options);

--- a/src/slang-nodes/ArrayExpression.ts
+++ b/src/slang-nodes/ArrayExpression.ts
@@ -25,6 +25,6 @@ export class ArrayExpression extends SlangNode {
   }
 
   print(path: AstPath<ArrayExpression>, print: PrintFunction): Doc {
-    return ['[', path.call(print, 'items'), ']'];
+    return ['[', print('items'), ']'];
   }
 }

--- a/src/slang-nodes/ArrayExpression.ts
+++ b/src/slang-nodes/ArrayExpression.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { ArrayValues } from './ArrayValues.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class ArrayExpression extends SlangNode {
     this.updateMetadata(this.items);
   }
 
-  print(path: AstPath<ArrayExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['[', print('items'), ']'];
   }
 }

--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -5,7 +5,7 @@ import { TypeName } from './TypeName.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -35,7 +35,7 @@ export class ArrayTypeName extends SlangNode {
     this.updateMetadata(this.operand, this.index);
   }
 
-  print(path: AstPath<ArrayTypeName>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('operand'), '[', print('index'), ']'];
   }
 }

--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -36,6 +36,6 @@ export class ArrayTypeName extends SlangNode {
   }
 
   print(path: AstPath<ArrayTypeName>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), '[', path.call(print, 'index'), ']'];
+    return [print('operand'), '[', print('index'), ']'];
   }
 }

--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -26,7 +26,7 @@ export class ArrayValues extends SlangNode {
     );
   }
 
-  print(path: AstPath<ArrayValues>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ArrayValues>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/AssemblyFlags.ts
+++ b/src/slang-nodes/AssemblyFlags.ts
@@ -25,7 +25,7 @@ export class AssemblyFlags extends SlangNode {
     );
   }
 
-  print(path: AstPath<AssemblyFlags>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<AssemblyFlags>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/AssemblyFlagsDeclaration.ts
+++ b/src/slang-nodes/AssemblyFlagsDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { AssemblyFlags } from './AssemblyFlags.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class AssemblyFlagsDeclaration extends SlangNode {
     this.updateMetadata(this.flags);
   }
 
-  print(path: AstPath<AssemblyFlagsDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('flags'), ')'];
   }
 }

--- a/src/slang-nodes/AssemblyFlagsDeclaration.ts
+++ b/src/slang-nodes/AssemblyFlagsDeclaration.ts
@@ -25,6 +25,6 @@ export class AssemblyFlagsDeclaration extends SlangNode {
   }
 
   print(path: AstPath<AssemblyFlagsDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'flags'), ')'];
+    return ['(', print('flags'), ')'];
   }
 }

--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -6,7 +6,7 @@ import { AssemblyFlagsDeclaration } from './AssemblyFlagsDeclaration.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -37,7 +37,7 @@ export class AssemblyStatement extends SlangNode {
     this.updateMetadata(this.label, this.flags, this.body);
   }
 
-  print(path: AstPath<AssemblyStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [
       'assembly',
       print('label'),

--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -40,9 +40,9 @@ export class AssemblyStatement extends SlangNode {
   print(path: AstPath<AssemblyStatement>, print: PrintFunction): Doc {
     return joinExisting(' ', [
       'assembly',
-      path.call(print, 'label'),
-      path.call(print, 'flags'),
-      path.call(print, 'body')
+      print('label'),
+      print('flags'),
+      print('body')
     ]);
   }
 }

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -38,12 +38,9 @@ export class AssignmentExpression extends SlangNode {
 
   print(path: AstPath<AssignmentExpression>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'leftOperand'),
+      print('leftOperand'),
       ` ${this.operator}`,
-      printAssignmentRightSide(
-        path.call(print, 'rightOperand'),
-        this.rightOperand
-      )
+      printAssignmentRightSide(print('rightOperand'), this.rightOperand)
     ];
   }
 }

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -5,7 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -36,7 +36,7 @@ export class AssignmentExpression extends SlangNode {
     this.updateMetadata(this.leftOperand, this.rightOperand);
   }
 
-  print(path: AstPath<AssignmentExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       print('leftOperand'),
       ` ${this.operator}`,

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -53,8 +53,8 @@ export class BitwiseAndExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<BitwiseAndExpression>,
     print: PrintFunction,
+    path: AstPath<BitwiseAndExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printBitwiseAndExpression(this, path, print, options);

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -63,8 +63,8 @@ export class BitwiseOrExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<BitwiseOrExpression>,
     print: PrintFunction,
+    path: AstPath<BitwiseOrExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printBitwiseOrExpression(this, path, print, options);

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -53,8 +53,8 @@ export class BitwiseXorExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<BitwiseXorExpression>,
     print: PrintFunction,
+    path: AstPath<BitwiseXorExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printBitwiseXorExpression(this, path, print, options);

--- a/src/slang-nodes/Block.ts
+++ b/src/slang-nodes/Block.ts
@@ -25,6 +25,6 @@ export class Block extends SlangNode {
   }
 
   print(path: AstPath<Block>, print: PrintFunction): Doc {
-    return ['{', path.call(print, 'statements'), '}'];
+    return ['{', print('statements'), '}'];
   }
 }

--- a/src/slang-nodes/Block.ts
+++ b/src/slang-nodes/Block.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { Statements } from './Statements.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class Block extends SlangNode {
     this.updateMetadata(this.statements);
   }
 
-  print(path: AstPath<Block>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['{', print('statements'), '}'];
   }
 }

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -29,8 +29,8 @@ export class CallOptions extends SlangNode {
   }
 
   print(
-    path: AstPath<CallOptions>,
     print: PrintFunction,
+    path: AstPath<CallOptions>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printSeparatedList(path.map(print, 'items'), {

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -5,7 +5,7 @@ import { Expression } from './Expression.js';
 import { CallOptions } from './CallOptions.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class CallOptionsExpression extends SlangNode {
     this.updateMetadata(this.operand, this.options);
   }
 
-  print(path: AstPath<CallOptionsExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('operand'), '{', print('options'), '}'];
   }
 }

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -32,6 +32,6 @@ export class CallOptionsExpression extends SlangNode {
   }
 
   print(path: AstPath<CallOptionsExpression>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), '{', path.call(print, 'options'), '}'];
+    return [print('operand'), '{', print('options'), '}'];
   }
 }

--- a/src/slang-nodes/CatchClause.ts
+++ b/src/slang-nodes/CatchClause.ts
@@ -31,6 +31,6 @@ export class CatchClause extends SlangNode {
   }
 
   print(path: AstPath<CatchClause>, print: PrintFunction): Doc {
-    return ['catch ', path.call(print, 'error'), path.call(print, 'body')];
+    return ['catch ', print('error'), print('body')];
   }
 }

--- a/src/slang-nodes/CatchClause.ts
+++ b/src/slang-nodes/CatchClause.ts
@@ -4,7 +4,7 @@ import { CatchClauseError } from './CatchClauseError.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -30,7 +30,7 @@ export class CatchClause extends SlangNode {
     this.updateMetadata(this.error, this.body);
   }
 
-  print(path: AstPath<CatchClause>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['catch ', print('error'), print('body')];
   }
 }

--- a/src/slang-nodes/CatchClauseError.ts
+++ b/src/slang-nodes/CatchClauseError.ts
@@ -5,7 +5,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -37,7 +37,7 @@ export class CatchClauseError extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<CatchClauseError>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('name'), group(print('parameters')), ' '];
   }
 }

--- a/src/slang-nodes/CatchClauseError.ts
+++ b/src/slang-nodes/CatchClauseError.ts
@@ -38,10 +38,6 @@ export class CatchClauseError extends SlangNode {
   }
 
   print(path: AstPath<CatchClauseError>, print: PrintFunction): Doc {
-    return [
-      path.call(print, 'name'),
-      group(path.call(print, 'parameters')),
-      ' '
-    ];
+    return [print('name'), group(print('parameters')), ' '];
   }
 }

--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -29,7 +29,7 @@ export class CatchClauses extends SlangNode {
     this.updateMetadata(...this.items);
   }
 
-  print(path: AstPath<CatchClauses>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<CatchClauses>): Doc {
     return join(' ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -28,7 +28,7 @@ function experimentalTernaries(
 
   // If the `condition` breaks into multiple lines, we add parentheses,
   // unless it already is a `TupleExpression`.
-  const operand = path.call(print, 'operand');
+  const operand = print('operand');
   const operandDoc = group([
     node.operand.kind === NonterminalKind.TupleExpression
       ? operand
@@ -41,7 +41,7 @@ function experimentalTernaries(
   // `trueExpression`.
   const trueExpressionDoc = indent([
     isNestedAsTrueExpression ? hardline : line,
-    path.call(print, 'trueExpression')
+    print('trueExpression')
   ]);
 
   const groupId = Symbol('Slang.ConditionalExpression.trueExpression');
@@ -58,7 +58,7 @@ function experimentalTernaries(
       ? ' '.repeat(tabWidth - 1)
       : ' ';
 
-  const falseExpression = path.call(print, 'falseExpression');
+  const falseExpression = print('falseExpression');
   const falseExpressionDoc = [
     isNested ? hardline : line,
     ':',
@@ -81,7 +81,7 @@ function traditionalTernaries(
   print: PrintFunction
 ): Doc {
   return group([
-    path.call(print, 'operand'),
+    print('operand'),
     indent([
       // Nested trueExpression and falseExpression are always printed in a new
       // line
@@ -89,10 +89,10 @@ function traditionalTernaries(
         ? hardline
         : line,
       '? ',
-      path.call(print, 'trueExpression'),
+      print('trueExpression'),
       line,
       ': ',
-      path.call(print, 'falseExpression')
+      print('falseExpression')
     ])
   ]);
 }

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -156,8 +156,8 @@ export class ConditionalExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<ConditionalExpression>,
     print: PrintFunction,
+    path: AstPath<ConditionalExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return options.experimentalTernaries

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -38,11 +38,11 @@ export class ConstantDefinition extends SlangNode {
 
   print(path: AstPath<ConstantDefinition>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'typeName'),
+      print('typeName'),
       ' constant ',
-      path.call(print, 'name'),
+      print('name'),
       ' =',
-      printAssignmentRightSide(path.call(print, 'value'), this.value),
+      printAssignmentRightSide(print('value'), this.value),
       ';'
     ];
   }

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -7,7 +7,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -36,7 +36,7 @@ export class ConstantDefinition extends SlangNode {
     this.updateMetadata(this.typeName, this.value);
   }
 
-  print(path: AstPath<ConstantDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       print('typeName'),
       ' constant ',

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -31,7 +31,7 @@ export class ConstructorAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<ConstructorAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ConstructorAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -32,6 +32,6 @@ export class ConstructorAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<ConstructorAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/ConstructorDefinition.ts
+++ b/src/slang-nodes/ConstructorDefinition.ts
@@ -6,7 +6,7 @@ import { ConstructorAttributes } from './ConstructorAttributes.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -41,7 +41,7 @@ export class ConstructorDefinition extends SlangNode {
     this.updateMetadata(this.parameters, this.attributes, this.body);
   }
 
-  print(path: AstPath<ConstructorDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody('constructor', this, path, print);
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody('constructor', this, print);
   }
 }

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -7,7 +7,7 @@ import { ContractSpecifiers } from './ContractSpecifiers.js';
 import { ContractMembers } from './ContractMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -58,7 +58,7 @@ export class ContractDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<ContractDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       group([
         this.abstractKeyword ? 'abstract ' : '',

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -63,12 +63,12 @@ export class ContractDefinition extends SlangNode {
       group([
         this.abstractKeyword ? 'abstract ' : '',
         'contract ',
-        path.call(print, 'name'),
-        path.call(print, 'specifiers'),
+        print('name'),
+        print('specifiers'),
         this.specifiers.items.length > 0 ? '' : line,
         '{'
       ]),
-      path.call(print, 'members'),
+      print('members'),
       '}'
     ];
   }

--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -31,8 +31,8 @@ export class ContractMembers extends SlangNode {
   }
 
   print(
-    path: AstPath<ContractMembers>,
     print: PrintFunction,
+    path: AstPath<ContractMembers>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return this.items.length > 0 || (this.comments?.length || 0) > 0

--- a/src/slang-nodes/ContractSpecifiers.ts
+++ b/src/slang-nodes/ContractSpecifiers.ts
@@ -32,7 +32,7 @@ export class ContractSpecifiers extends SlangNode {
     this.items.sort(sortContractSpecifiers);
   }
 
-  print(path: AstPath<ContractSpecifiers>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ContractSpecifiers>): Doc {
     const [specifier1, specifier2] = path.map(print, 'items');
 
     if (specifier1 === undefined) return '';

--- a/src/slang-nodes/DecimalNumberExpression.ts
+++ b/src/slang-nodes/DecimalNumberExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { NumberUnit } from './NumberUnit.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class DecimalNumberExpression extends SlangNode {
@@ -25,7 +25,7 @@ export class DecimalNumberExpression extends SlangNode {
     this.updateMetadata(this.unit);
   }
 
-  print(path: AstPath<DecimalNumberExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [this.literal, print('unit')]);
   }
 }

--- a/src/slang-nodes/DecimalNumberExpression.ts
+++ b/src/slang-nodes/DecimalNumberExpression.ts
@@ -26,6 +26,6 @@ export class DecimalNumberExpression extends SlangNode {
   }
 
   print(path: AstPath<DecimalNumberExpression>, print: PrintFunction): Doc {
-    return joinExisting(' ', [this.literal, path.call(print, 'unit')]);
+    return joinExisting(' ', [this.literal, print('unit')]);
   }
 }

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -36,14 +36,14 @@ export class DoWhileStatement extends SlangNode {
   }
 
   print(path: AstPath<DoWhileStatement>, print: PrintFunction): Doc {
-    const body = path.call(print, 'body');
+    const body = print('body');
     return [
       'do',
       this.body.kind === NonterminalKind.Block
         ? [' ', body, ' ']
         : printSeparatedItem(body, { firstSeparator: line }),
       'while (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(print('condition')),
       ');'
     ];
   }

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -7,7 +7,7 @@ import { Statement } from './Statement.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -35,7 +35,7 @@ export class DoWhileStatement extends SlangNode {
     this.updateMetadata(this.body, this.condition);
   }
 
-  print(path: AstPath<DoWhileStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     const body = print('body');
     return [
       'do',

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -6,7 +6,7 @@ import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -32,7 +32,7 @@ export class ElseBranch extends SlangNode {
     this.updateMetadata(this.body);
   }
 
-  print(path: AstPath<ElseBranch>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'else',
       printIndentedGroupOrSpacedDocument(

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -36,7 +36,7 @@ export class ElseBranch extends SlangNode {
     return [
       'else',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        print('body'),
         !isIfStatementOrBlock(this.body)
       )
     ];

--- a/src/slang-nodes/EmitStatement.ts
+++ b/src/slang-nodes/EmitStatement.ts
@@ -5,7 +5,7 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class EmitStatement extends SlangNode {
     this.updateMetadata(this.event, this.arguments);
   }
 
-  print(path: AstPath<EmitStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['emit ', print('event'), print('arguments'), ';'];
   }
 }

--- a/src/slang-nodes/EmitStatement.ts
+++ b/src/slang-nodes/EmitStatement.ts
@@ -32,11 +32,6 @@ export class EmitStatement extends SlangNode {
   }
 
   print(path: AstPath<EmitStatement>, print: PrintFunction): Doc {
-    return [
-      'emit ',
-      path.call(print, 'event'),
-      path.call(print, 'arguments'),
-      ';'
-    ];
+    return ['emit ', print('event'), print('arguments'), ';'];
   }
 }

--- a/src/slang-nodes/EnumDefinition.ts
+++ b/src/slang-nodes/EnumDefinition.ts
@@ -4,7 +4,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { EnumMembers } from './EnumMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class EnumDefinition extends SlangNode {
@@ -23,7 +23,7 @@ export class EnumDefinition extends SlangNode {
     this.updateMetadata(this.members);
   }
 
-  print(path: AstPath<EnumDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['enum ', print('name'), ' {', print('members'), '}'];
   }
 }

--- a/src/slang-nodes/EnumDefinition.ts
+++ b/src/slang-nodes/EnumDefinition.ts
@@ -24,12 +24,6 @@ export class EnumDefinition extends SlangNode {
   }
 
   print(path: AstPath<EnumDefinition>, print: PrintFunction): Doc {
-    return [
-      'enum ',
-      path.call(print, 'name'),
-      ' {',
-      path.call(print, 'members'),
-      '}'
-    ];
+    return ['enum ', print('name'), ' {', print('members'), '}'];
   }
 }

--- a/src/slang-nodes/EnumMembers.ts
+++ b/src/slang-nodes/EnumMembers.ts
@@ -21,7 +21,7 @@ export class EnumMembers extends SlangNode {
     this.items = ast.items.map((item) => new TerminalNode(item, collected));
   }
 
-  print(path: AstPath<EnumMembers>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<EnumMembers>): Doc {
     return printSeparatedList(path.map(print, 'items'), {
       firstSeparator: hardline
     });

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -50,8 +50,8 @@ export class EqualityExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<EqualityExpression>,
     print: PrintFunction,
+    path: AstPath<EqualityExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printEqualityExpression(this, path, print, options);

--- a/src/slang-nodes/ErrorDefinition.ts
+++ b/src/slang-nodes/ErrorDefinition.ts
@@ -33,11 +33,6 @@ export class ErrorDefinition extends SlangNode {
   }
 
   print(path: AstPath<ErrorDefinition>, print: PrintFunction): Doc {
-    return [
-      'error ',
-      path.call(print, 'name'),
-      path.call(print, 'members'),
-      ';'
-    ];
+    return ['error ', print('name'), print('members'), ';'];
   }
 }

--- a/src/slang-nodes/ErrorDefinition.ts
+++ b/src/slang-nodes/ErrorDefinition.ts
@@ -4,7 +4,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { ErrorParametersDeclaration } from './ErrorParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -32,7 +32,7 @@ export class ErrorDefinition extends SlangNode {
     this.updateMetadata(this.members);
   }
 
-  print(path: AstPath<ErrorDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['error ', print('name'), print('members'), ';'];
   }
 }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -35,9 +35,6 @@ export class ErrorParameter extends SlangNode {
   }
 
   print(path: AstPath<ErrorParameter>, print: PrintFunction): Doc {
-    return joinExisting(' ', [
-      path.call(print, 'typeName'),
-      path.call(print, 'name')
-    ]);
+    return joinExisting(' ', [print('typeName'), print('name')]);
   }
 }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -6,7 +6,7 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class ErrorParameter extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<ErrorParameter>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [print('typeName'), print('name')]);
   }
 }

--- a/src/slang-nodes/ErrorParameters.ts
+++ b/src/slang-nodes/ErrorParameters.ts
@@ -25,7 +25,7 @@ export class ErrorParameters extends SlangNode {
     );
   }
 
-  print(path: AstPath<ErrorParameters>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ErrorParameters>): Doc {
     return this.items.length > 0
       ? printSeparatedList(path.map(print, 'items'))
       : '';

--- a/src/slang-nodes/ErrorParametersDeclaration.ts
+++ b/src/slang-nodes/ErrorParametersDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { ErrorParameters } from './ErrorParameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class ErrorParametersDeclaration extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<ErrorParametersDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/ErrorParametersDeclaration.ts
+++ b/src/slang-nodes/ErrorParametersDeclaration.ts
@@ -25,6 +25,6 @@ export class ErrorParametersDeclaration extends SlangNode {
   }
 
   print(path: AstPath<ErrorParametersDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'parameters'), ')'];
+    return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/EventDefinition.ts
+++ b/src/slang-nodes/EventDefinition.ts
@@ -4,7 +4,7 @@ import { EventParametersDeclaration } from './EventParametersDeclaration.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -35,7 +35,7 @@ export class EventDefinition extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<EventDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'event ',
       print('name'),

--- a/src/slang-nodes/EventDefinition.ts
+++ b/src/slang-nodes/EventDefinition.ts
@@ -38,8 +38,8 @@ export class EventDefinition extends SlangNode {
   print(path: AstPath<EventDefinition>, print: PrintFunction): Doc {
     return [
       'event ',
-      path.call(print, 'name'),
-      path.call(print, 'parameters'),
+      print('name'),
+      print('parameters'),
       this.anonymousKeyword ? ' anonymous;' : ';'
     ];
   }

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -39,9 +39,9 @@ export class EventParameter extends SlangNode {
 
   print(path: AstPath<EventParameter>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
+      print('typeName'),
       this.indexedKeyword,
-      path.call(print, 'name')
+      print('name')
     ]);
   }
 }

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -6,7 +6,7 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -37,7 +37,7 @@ export class EventParameter extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<EventParameter>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [
       print('typeName'),
       this.indexedKeyword,

--- a/src/slang-nodes/EventParameters.ts
+++ b/src/slang-nodes/EventParameters.ts
@@ -25,7 +25,7 @@ export class EventParameters extends SlangNode {
     );
   }
 
-  print(path: AstPath<EventParameters>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<EventParameters>): Doc {
     return this.items.length > 0
       ? printSeparatedList(path.map(print, 'items'))
       : '';

--- a/src/slang-nodes/EventParametersDeclaration.ts
+++ b/src/slang-nodes/EventParametersDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { EventParameters } from './EventParameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class EventParametersDeclaration extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<EventParametersDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/EventParametersDeclaration.ts
+++ b/src/slang-nodes/EventParametersDeclaration.ts
@@ -25,6 +25,6 @@ export class EventParametersDeclaration extends SlangNode {
   }
 
   print(path: AstPath<EventParametersDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'parameters'), ')'];
+    return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/ExperimentalPragma.ts
+++ b/src/slang-nodes/ExperimentalPragma.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { ExperimentalFeature } from './ExperimentalFeature.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class ExperimentalPragma extends SlangNode {
     this.updateMetadata(this.feature);
   }
 
-  print(path: AstPath<ExperimentalPragma>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['experimental ', print('feature')];
   }
 }

--- a/src/slang-nodes/ExperimentalPragma.ts
+++ b/src/slang-nodes/ExperimentalPragma.ts
@@ -28,6 +28,6 @@ export class ExperimentalPragma extends SlangNode {
   }
 
   print(path: AstPath<ExperimentalPragma>, print: PrintFunction): Doc {
-    return ['experimental ', path.call(print, 'feature')];
+    return ['experimental ', print('feature')];
   }
 }

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -68,8 +68,8 @@ export class ExponentiationExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<ExponentiationExpression>,
     print: PrintFunction,
+    path: AstPath<ExponentiationExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printExponentiationExpression(this, path, print, options);

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -28,6 +28,6 @@ export class ExpressionStatement extends SlangNode {
   }
 
   print(path: AstPath<ExpressionStatement>, print: PrintFunction): Doc {
-    return [path.call(print, 'expression'), ';'];
+    return [print('expression'), ';'];
   }
 }

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class ExpressionStatement extends SlangNode {
     this.updateMetadata(this.expression);
   }
 
-  print(path: AstPath<ExpressionStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('expression'), ';'];
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -32,6 +32,6 @@ export class FallbackFunctionAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<FallbackFunctionAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -31,7 +31,7 @@ export class FallbackFunctionAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<FallbackFunctionAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<FallbackFunctionAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/FallbackFunctionDefinition.ts
+++ b/src/slang-nodes/FallbackFunctionDefinition.ts
@@ -8,7 +8,7 @@ import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -59,7 +59,7 @@ export class FallbackFunctionDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<FallbackFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody('fallback', this, path, print);
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody('fallback', this, print);
   }
 }

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -10,7 +10,7 @@ import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -55,7 +55,7 @@ export class ForStatement extends SlangNode {
     );
   }
 
-  print(path: AstPath<ForStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     const initialization = print('initialization');
     const condition = print('condition');
     const iterator = print('iterator');

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -56,9 +56,9 @@ export class ForStatement extends SlangNode {
   }
 
   print(path: AstPath<ForStatement>, print: PrintFunction): Doc {
-    const initialization = path.call(print, 'initialization');
-    const condition = path.call(print, 'condition');
-    const iterator = path.call(print, 'iterator');
+    const initialization = print('initialization');
+    const condition = print('condition');
+    const iterator = print('iterator');
 
     return [
       'for (',
@@ -70,7 +70,7 @@ export class ForStatement extends SlangNode {
       }),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        print('body'),
         this.body.kind !== NonterminalKind.Block
       )
     ];

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -31,7 +31,7 @@ export class FunctionAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<FunctionAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<FunctionAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -32,6 +32,6 @@ export class FunctionAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<FunctionAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -36,8 +36,8 @@ export class FunctionCallExpression extends SlangNode {
 
   print(path: AstPath<FunctionCallExpression>, print: PrintFunction): Doc {
     return printPossibleMemberAccessChainItem(
-      path.call(print, 'operand'),
-      path.call(print, 'arguments')
+      print('operand'),
+      print('arguments')
     );
   }
 }

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -6,7 +6,7 @@ import { Expression } from './Expression.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class FunctionCallExpression extends SlangNode {
     this.updateMetadata(this.operand, this.arguments);
   }
 
-  print(path: AstPath<FunctionCallExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return printPossibleMemberAccessChainItem(
       print('operand'),
       print('arguments')

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -10,7 +10,7 @@ import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -75,12 +75,7 @@ export class FunctionDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<FunctionDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody(
-      ['function ', print('name')],
-      this,
-      path,
-      print
-    );
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody(['function ', print('name')], this, print);
   }
 }

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -77,7 +77,7 @@ export class FunctionDefinition extends SlangNode {
 
   print(path: AstPath<FunctionDefinition>, print: PrintFunction): Doc {
     return printFunctionWithBody(
-      ['function ', path.call(print, 'name')],
+      ['function ', print('name')],
       this,
       path,
       print

--- a/src/slang-nodes/FunctionType.ts
+++ b/src/slang-nodes/FunctionType.ts
@@ -6,7 +6,7 @@ import { FunctionTypeAttributes } from './FunctionTypeAttributes.js';
 import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -39,7 +39,7 @@ export class FunctionType extends SlangNode {
     this.updateMetadata(this.parameters, this.attributes, this.returns);
   }
 
-  print(path: AstPath<FunctionType>, print: PrintFunction): Doc {
-    return printFunction('function', this, path, print);
+  print(print: PrintFunction): Doc {
+    return printFunction('function', this, print);
   }
 }

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -26,7 +26,7 @@ export class FunctionTypeAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<FunctionTypeAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<FunctionTypeAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -27,6 +27,6 @@ export class FunctionTypeAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<FunctionTypeAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/HexNumberExpression.ts
+++ b/src/slang-nodes/HexNumberExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { NumberUnit } from './NumberUnit.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class HexNumberExpression extends SlangNode {
@@ -25,7 +25,7 @@ export class HexNumberExpression extends SlangNode {
     this.updateMetadata(this.unit);
   }
 
-  print(path: AstPath<HexNumberExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [this.literal, print('unit')]);
   }
 }

--- a/src/slang-nodes/HexNumberExpression.ts
+++ b/src/slang-nodes/HexNumberExpression.ts
@@ -26,6 +26,6 @@ export class HexNumberExpression extends SlangNode {
   }
 
   print(path: AstPath<HexNumberExpression>, print: PrintFunction): Doc {
-    return joinExisting(' ', [this.literal, path.call(print, 'unit')]);
+    return joinExisting(' ', [this.literal, print('unit')]);
   }
 }

--- a/src/slang-nodes/HexStringLiterals.ts
+++ b/src/slang-nodes/HexStringLiterals.ts
@@ -27,7 +27,7 @@ export class HexStringLiterals extends SlangNode {
     );
   }
 
-  print(path: AstPath<HexStringLiterals>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<HexStringLiterals>): Doc {
     return join(hardline, path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/IdentifierPath.ts
+++ b/src/slang-nodes/IdentifierPath.ts
@@ -20,7 +20,7 @@ export class IdentifierPath extends SlangNode {
     this.items = ast.items.map((item) => new TerminalNode(item, collected));
   }
 
-  print(path: AstPath<IdentifierPath>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<IdentifierPath>): Doc {
     return join('.', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -47,10 +47,10 @@ export class IfStatement extends SlangNode {
     const { kind: bodyKind, comments: bodyComments } = this.body;
     return [
       'if (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(print('condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        print('body'),
         bodyKind !== NonterminalKind.Block,
         // `if` within `if`
         { shouldBreak: bodyKind === NonterminalKind.IfStatement }
@@ -64,7 +64,7 @@ export class IfStatement extends SlangNode {
             ) // or if body has trailing single line comments or a block comment on a new line
               ? hardline
               : ' ',
-            path.call(print, 'elseBranch')
+            print('elseBranch')
           ]
         : ''
     ];

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -10,7 +10,7 @@ import { Statement } from './Statement.js';
 import { ElseBranch } from './ElseBranch.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -43,7 +43,7 @@ export class IfStatement extends SlangNode {
     this.updateMetadata(this.condition, this.body, this.elseBranch);
   }
 
-  print(path: AstPath<IfStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     const { kind: bodyKind, comments: bodyComments } = this.body;
     return [
       'if (',

--- a/src/slang-nodes/ImportAlias.ts
+++ b/src/slang-nodes/ImportAlias.ts
@@ -18,6 +18,6 @@ export class ImportAlias extends SlangNode {
   }
 
   print(path: AstPath<ImportAlias>, print: PrintFunction): Doc {
-    return [' as ', path.call(print, 'identifier')];
+    return [' as ', print('identifier')];
   }
 }

--- a/src/slang-nodes/ImportAlias.ts
+++ b/src/slang-nodes/ImportAlias.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class ImportAlias extends SlangNode {
@@ -17,7 +17,7 @@ export class ImportAlias extends SlangNode {
     this.identifier = new TerminalNode(ast.identifier, collected);
   }
 
-  print(path: AstPath<ImportAlias>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [' as ', print('identifier')];
   }
 }

--- a/src/slang-nodes/ImportDeconstruction.ts
+++ b/src/slang-nodes/ImportDeconstruction.ts
@@ -4,7 +4,7 @@ import { ImportDeconstructionSymbols } from './ImportDeconstructionSymbols.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -28,7 +28,7 @@ export class ImportDeconstruction extends SlangNode {
     this.updateMetadata(this.symbols, this.path);
   }
 
-  print(path: AstPath<ImportDeconstruction>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['{', print('symbols'), '} from ', print('path')];
   }
 }

--- a/src/slang-nodes/ImportDeconstruction.ts
+++ b/src/slang-nodes/ImportDeconstruction.ts
@@ -29,11 +29,6 @@ export class ImportDeconstruction extends SlangNode {
   }
 
   print(path: AstPath<ImportDeconstruction>, print: PrintFunction): Doc {
-    return [
-      '{',
-      path.call(print, 'symbols'),
-      '} from ',
-      path.call(print, 'path')
-    ];
+    return ['{', print('symbols'), '} from ', print('path')];
   }
 }

--- a/src/slang-nodes/ImportDeconstructionSymbol.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbol.ts
@@ -4,7 +4,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { ImportAlias } from './ImportAlias.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class ImportDeconstructionSymbol extends SlangNode {
@@ -28,7 +28,7 @@ export class ImportDeconstructionSymbol extends SlangNode {
     this.updateMetadata(this.alias);
   }
 
-  print(path: AstPath<ImportDeconstructionSymbol>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('name'), print('alias')];
   }
 }

--- a/src/slang-nodes/ImportDeconstructionSymbol.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbol.ts
@@ -29,6 +29,6 @@ export class ImportDeconstructionSymbol extends SlangNode {
   }
 
   print(path: AstPath<ImportDeconstructionSymbol>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), path.call(print, 'alias')];
+    return [print('name'), print('alias')];
   }
 }

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -29,8 +29,8 @@ export class ImportDeconstructionSymbols extends SlangNode {
   }
 
   print(
-    path: AstPath<ImportDeconstructionSymbols>,
     print: PrintFunction,
+    path: AstPath<ImportDeconstructionSymbols>,
     { compiler, bracketSpacing }: ParserOptions<PrintableNode>
   ): Doc {
     const items = path.map(print, 'items');

--- a/src/slang-nodes/ImportDirective.ts
+++ b/src/slang-nodes/ImportDirective.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { ImportClause } from './ImportClause.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class ImportDirective extends SlangNode {
     this.updateMetadata(this.clause);
   }
 
-  print(path: AstPath<ImportDirective>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['import ', print('clause'), ';'];
   }
 }

--- a/src/slang-nodes/ImportDirective.ts
+++ b/src/slang-nodes/ImportDirective.ts
@@ -28,6 +28,6 @@ export class ImportDirective extends SlangNode {
   }
 
   print(path: AstPath<ImportDirective>, print: PrintFunction): Doc {
-    return ['import ', path.call(print, 'clause'), ';'];
+    return ['import ', print('clause'), ';'];
   }
 }

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class IndexAccessEnd extends SlangNode {
     this.updateMetadata(this.end);
   }
 
-  print(path: AstPath<IndexAccessEnd>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [':', print('end')];
   }
 }

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -28,6 +28,6 @@ export class IndexAccessEnd extends SlangNode {
   }
 
   print(path: AstPath<IndexAccessEnd>, print: PrintFunction): Doc {
-    return [':', path.call(print, 'end')];
+    return [':', print('end')];
   }
 }

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -43,9 +43,9 @@ export class IndexAccessExpression extends SlangNode {
   }
 
   print(path: AstPath<IndexAccessExpression>, print: PrintFunction): Doc {
-    return printPossibleMemberAccessChainItem(path.call(print, 'operand'), [
+    return printPossibleMemberAccessChainItem(print('operand'), [
       '[',
-      printSeparatedItem([path.call(print, 'start'), path.call(print, 'end')]),
+      printSeparatedItem([print('start'), print('end')]),
       ']'
     ]);
   }

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -7,7 +7,7 @@ import { Expression } from './Expression.js';
 import { IndexAccessEnd } from './IndexAccessEnd.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -42,7 +42,7 @@ export class IndexAccessExpression extends SlangNode {
     this.updateMetadata(this.operand, this.start, this.end);
   }
 
-  print(path: AstPath<IndexAccessExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return printPossibleMemberAccessChainItem(print('operand'), [
       '[',
       printSeparatedItem([print('start'), print('end')]),

--- a/src/slang-nodes/InequalityExpression.ts
+++ b/src/slang-nodes/InequalityExpression.ts
@@ -46,8 +46,8 @@ export class InequalityExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<InequalityExpression>,
     print: PrintFunction,
+    path: AstPath<InequalityExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printComparisonExpression(this, path, print, options);

--- a/src/slang-nodes/InheritanceSpecifier.ts
+++ b/src/slang-nodes/InheritanceSpecifier.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { InheritanceTypes } from './InheritanceTypes.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class InheritanceSpecifier extends SlangNode {
     this.updateMetadata(this.types);
   }
 
-  print(path: AstPath<InheritanceSpecifier>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['is', print('types')];
   }
 }

--- a/src/slang-nodes/InheritanceSpecifier.ts
+++ b/src/slang-nodes/InheritanceSpecifier.ts
@@ -25,6 +25,6 @@ export class InheritanceSpecifier extends SlangNode {
   }
 
   print(path: AstPath<InheritanceSpecifier>, print: PrintFunction): Doc {
-    return ['is', path.call(print, 'types')];
+    return ['is', print('types')];
   }
 }

--- a/src/slang-nodes/InheritanceType.ts
+++ b/src/slang-nodes/InheritanceType.ts
@@ -34,6 +34,6 @@ export class InheritanceType extends SlangNode {
   }
 
   print(path: AstPath<InheritanceType>, print: PrintFunction): Doc {
-    return [path.call(print, 'typeName'), path.call(print, 'arguments')];
+    return [print('typeName'), print('arguments')];
   }
 }

--- a/src/slang-nodes/InheritanceType.ts
+++ b/src/slang-nodes/InheritanceType.ts
@@ -5,7 +5,7 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -33,7 +33,7 @@ export class InheritanceType extends SlangNode {
     this.updateMetadata(this.typeName, this.arguments);
   }
 
-  print(path: AstPath<InheritanceType>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('typeName'), print('arguments')];
   }
 }

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -28,7 +28,7 @@ export class InheritanceTypes extends SlangNode {
     );
   }
 
-  print(path: AstPath<InheritanceTypes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<InheritanceTypes>): Doc {
     return printSeparatedList(path.map(print, 'items'), {
       firstSeparator: line
     });

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -6,7 +6,7 @@ import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { InterfaceMembers } from './InterfaceMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -41,7 +41,7 @@ export class InterfaceDefinition extends SlangNode {
     this.updateMetadata(this.inheritance, this.members);
   }
 
-  print(path: AstPath<InterfaceDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       group([
         'interface ',

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -45,11 +45,11 @@ export class InterfaceDefinition extends SlangNode {
     return [
       group([
         'interface ',
-        path.call(print, 'name'),
-        this.inheritance ? [' ', path.call(print, 'inheritance')] : line,
+        print('name'),
+        this.inheritance ? [' ', print('inheritance')] : line,
         '{'
       ]),
-      path.call(print, 'members'),
+      print('members'),
       '}'
     ];
   }

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -31,8 +31,8 @@ export class InterfaceMembers extends SlangNode {
   }
 
   print(
-    path: AstPath<InterfaceMembers>,
     print: PrintFunction,
+    path: AstPath<InterfaceMembers>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return this.items.length > 0 || (this.comments?.length || 0) > 0

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -6,7 +6,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { LibraryMembers } from './LibraryMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -44,7 +44,7 @@ export class LibraryDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<LibraryDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       group(['library ', print('name'), line, '{']),
       print('members'),

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -46,8 +46,8 @@ export class LibraryDefinition extends SlangNode {
 
   print(path: AstPath<LibraryDefinition>, print: PrintFunction): Doc {
     return [
-      group(['library ', path.call(print, 'name'), line, '{']),
-      path.call(print, 'members'),
+      group(['library ', print('name'), line, '{']),
+      print('members'),
       '}'
     ];
   }

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -31,8 +31,8 @@ export class LibraryMembers extends SlangNode {
   }
 
   print(
-    path: AstPath<LibraryMembers>,
     print: PrintFunction,
+    path: AstPath<LibraryMembers>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return this.items.length > 0 || (this.comments?.length || 0) > 0

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -28,9 +28,6 @@ export class MappingKey extends SlangNode {
   }
 
   print(path: AstPath<MappingKey>, print: PrintFunction): Doc {
-    return joinExisting(' ', [
-      path.call(print, 'keyType'),
-      path.call(print, 'name')
-    ]);
+    return joinExisting(' ', [print('keyType'), print('name')]);
   }
 }

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -6,7 +6,7 @@ import { MappingKeyType } from './MappingKeyType.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class MappingKey extends SlangNode {
@@ -27,7 +27,7 @@ export class MappingKey extends SlangNode {
     this.updateMetadata(this.keyType);
   }
 
-  print(path: AstPath<MappingKey>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [print('keyType'), print('name')]);
   }
 }

--- a/src/slang-nodes/MappingType.ts
+++ b/src/slang-nodes/MappingType.ts
@@ -4,7 +4,7 @@ import { MappingKey } from './MappingKey.js';
 import { MappingValue } from './MappingValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -28,7 +28,7 @@ export class MappingType extends SlangNode {
     this.updateMetadata(this.keyType, this.valueType);
   }
 
-  print(path: AstPath<MappingType>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['mapping(', print('keyType'), ' => ', print('valueType'), ')'];
   }
 }

--- a/src/slang-nodes/MappingType.ts
+++ b/src/slang-nodes/MappingType.ts
@@ -29,12 +29,6 @@ export class MappingType extends SlangNode {
   }
 
   print(path: AstPath<MappingType>, print: PrintFunction): Doc {
-    return [
-      'mapping(',
-      path.call(print, 'keyType'),
-      ' => ',
-      path.call(print, 'valueType'),
-      ')'
-    ];
+    return ['mapping(', print('keyType'), ' => ', print('valueType'), ')'];
   }
 }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -6,7 +6,7 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class MappingValue extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<MappingValue>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [print('typeName'), print('name')]);
   }
 }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -35,9 +35,6 @@ export class MappingValue extends SlangNode {
   }
 
   print(path: AstPath<MappingValue>, print: PrintFunction): Doc {
-    return joinExisting(' ', [
-      path.call(print, 'typeName'),
-      path.call(print, 'name')
-    ]);
+    return joinExisting(' ', [print('typeName'), print('name')]);
   }
 }

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -131,7 +131,7 @@ export class MemberAccessExpression extends SlangNode {
   }
 
   print(path: AstPath<MemberAccessExpression>, print: PrintFunction): Doc {
-    let operandDoc = path.call(print, 'operand');
+    let operandDoc = print('operand');
     if (Array.isArray(operandDoc)) {
       operandDoc = operandDoc.flat();
     }
@@ -139,7 +139,7 @@ export class MemberAccessExpression extends SlangNode {
     const document = [
       operandDoc,
       label(separatorLabel, [softline, '.']),
-      path.call(print, 'member')
+      print('member')
     ].flat();
 
     return isEndOfChain(this, path) ? processChain(document) : document;

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -130,7 +130,7 @@ export class MemberAccessExpression extends SlangNode {
     this.updateMetadata(this.operand);
   }
 
-  print(path: AstPath<MemberAccessExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<MemberAccessExpression>): Doc {
     let operandDoc = print('operand');
     if (Array.isArray(operandDoc)) {
       operandDoc = operandDoc.flat();

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -27,6 +27,6 @@ export class ModifierAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<ModifierAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -26,7 +26,7 @@ export class ModifierAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<ModifierAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ModifierAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -79,7 +79,7 @@ export class ModifierDefinition extends SlangNode {
 
   print(path: AstPath<ModifierDefinition>, print: PrintFunction): Doc {
     return printFunctionWithBody(
-      ['modifier ', path.call(print, 'name')],
+      ['modifier ', print('name')],
       this,
       path,
       print

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -9,7 +9,7 @@ import { ModifierAttributes } from './ModifierAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type {
   AstLocation,
   CollectedMetadata,
@@ -62,13 +62,13 @@ export class ModifierDefinition extends SlangNode {
         {
           kind: NonterminalKind.ParametersDeclaration,
           loc: { ...parametersLoc },
-          comments: [],
+          comments: undefined,
           parameters: Object.assign(
             Object.create(Parameters.prototype) as Parameters,
             {
               kind: NonterminalKind.Parameters,
               loc: { ...parametersLoc },
-              comments: [],
+              comments: undefined,
               items: []
             }
           )
@@ -77,12 +77,7 @@ export class ModifierDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<ModifierDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody(
-      ['modifier ', print('name')],
-      this,
-      path,
-      print
-    );
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody(['modifier ', print('name')], this, print);
   }
 }

--- a/src/slang-nodes/ModifierInvocation.ts
+++ b/src/slang-nodes/ModifierInvocation.ts
@@ -5,7 +5,7 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -38,11 +38,11 @@ export class ModifierInvocation extends SlangNode {
       this.arguments?.kind === NonterminalKind.PositionalArgumentsDeclaration &&
       this.arguments.isEmpty
     ) {
-      delete this.arguments;
+      this.arguments = undefined;
     }
   }
 
-  print(path: AstPath<ModifierInvocation>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('name'), print('arguments')];
   }
 }

--- a/src/slang-nodes/ModifierInvocation.ts
+++ b/src/slang-nodes/ModifierInvocation.ts
@@ -43,6 +43,6 @@ export class ModifierInvocation extends SlangNode {
   }
 
   print(path: AstPath<ModifierInvocation>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), path.call(print, 'arguments')];
+    return [print('name'), print('arguments')];
   }
 }

--- a/src/slang-nodes/MultiplicativeExpression.ts
+++ b/src/slang-nodes/MultiplicativeExpression.ts
@@ -67,8 +67,8 @@ export class MultiplicativeExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<MultiplicativeExpression>,
     print: PrintFunction,
+    path: AstPath<MultiplicativeExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printMultiplicativeExpression(this, path, print, options);

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -30,6 +30,6 @@ export class NamedArgument extends SlangNode {
   }
 
   print(path: AstPath<NamedArgument>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), ': ', path.call(print, 'value')];
+    return [print('name'), ': ', print('value')];
   }
 }

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -5,7 +5,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -29,7 +29,7 @@ export class NamedArgument extends SlangNode {
     this.updateMetadata(this.value);
   }
 
-  print(path: AstPath<NamedArgument>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('name'), ': ', print('value')];
   }
 }

--- a/src/slang-nodes/NamedArgumentGroup.ts
+++ b/src/slang-nodes/NamedArgumentGroup.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { NamedArguments } from './NamedArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class NamedArgumentGroup extends SlangNode {
     this.updateMetadata(this.arguments);
   }
 
-  print(path: AstPath<NamedArgumentGroup>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['{', print('arguments'), '}'];
   }
 }

--- a/src/slang-nodes/NamedArgumentGroup.ts
+++ b/src/slang-nodes/NamedArgumentGroup.ts
@@ -25,6 +25,6 @@ export class NamedArgumentGroup extends SlangNode {
   }
 
   print(path: AstPath<NamedArgumentGroup>, print: PrintFunction): Doc {
-    return ['{', path.call(print, 'arguments'), '}'];
+    return ['{', print('arguments'), '}'];
   }
 }

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -29,8 +29,8 @@ export class NamedArguments extends SlangNode {
   }
 
   print(
-    path: AstPath<NamedArguments>,
     print: PrintFunction,
+    path: AstPath<NamedArguments>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printSeparatedList(path.map(print, 'items'), {

--- a/src/slang-nodes/NamedArgumentsDeclaration.ts
+++ b/src/slang-nodes/NamedArgumentsDeclaration.ts
@@ -31,6 +31,6 @@ export class NamedArgumentsDeclaration extends SlangNode {
   }
 
   print(path: AstPath<NamedArgumentsDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'arguments'), ')'];
+    return ['(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/NamedArgumentsDeclaration.ts
+++ b/src/slang-nodes/NamedArgumentsDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { NamedArgumentGroup } from './NamedArgumentGroup.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -30,7 +30,7 @@ export class NamedArgumentsDeclaration extends SlangNode {
     this.updateMetadata(this.arguments);
   }
 
-  print(path: AstPath<NamedArgumentsDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/NamedImport.ts
+++ b/src/slang-nodes/NamedImport.ts
@@ -29,6 +29,6 @@ export class NamedImport extends SlangNode {
   }
 
   print(path: AstPath<NamedImport>, print: PrintFunction): Doc {
-    return ['*', path.call(print, 'alias'), ' from ', path.call(print, 'path')];
+    return ['*', print('alias'), ' from ', print('path')];
   }
 }

--- a/src/slang-nodes/NamedImport.ts
+++ b/src/slang-nodes/NamedImport.ts
@@ -4,7 +4,7 @@ import { ImportAlias } from './ImportAlias.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -28,7 +28,7 @@ export class NamedImport extends SlangNode {
     this.updateMetadata(this.alias, this.path);
   }
 
-  print(path: AstPath<NamedImport>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['*', print('alias'), ' from ', print('path')];
   }
 }

--- a/src/slang-nodes/NewExpression.ts
+++ b/src/slang-nodes/NewExpression.ts
@@ -28,6 +28,6 @@ export class NewExpression extends SlangNode {
   }
 
   print(path: AstPath<NewExpression>, print: PrintFunction): Doc {
-    return ['new ', path.call(print, 'typeName')];
+    return ['new ', print('typeName')];
   }
 }

--- a/src/slang-nodes/NewExpression.ts
+++ b/src/slang-nodes/NewExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class NewExpression extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<NewExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['new ', print('typeName')];
   }
 }

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -43,8 +43,8 @@ export class OrExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<OrExpression>,
     print: PrintFunction,
+    path: AstPath<OrExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printLogicalOperation(this, path, print, options);

--- a/src/slang-nodes/OverridePaths.ts
+++ b/src/slang-nodes/OverridePaths.ts
@@ -18,7 +18,7 @@ export class OverridePaths extends SlangNode {
     this.items = ast.items.map((item) => new IdentifierPath(item, collected));
   }
 
-  print(path: AstPath<OverridePaths>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<OverridePaths>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/OverridePathsDeclaration.ts
+++ b/src/slang-nodes/OverridePathsDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { OverridePaths } from './OverridePaths.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class OverridePathsDeclaration extends SlangNode {
@@ -19,7 +19,7 @@ export class OverridePathsDeclaration extends SlangNode {
     this.updateMetadata(this.paths);
   }
 
-  print(path: AstPath<OverridePathsDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('paths'), ')'];
   }
 }

--- a/src/slang-nodes/OverridePathsDeclaration.ts
+++ b/src/slang-nodes/OverridePathsDeclaration.ts
@@ -20,6 +20,6 @@ export class OverridePathsDeclaration extends SlangNode {
   }
 
   print(path: AstPath<OverridePathsDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'paths'), ')'];
+    return ['(', print('paths'), ')'];
   }
 }

--- a/src/slang-nodes/OverrideSpecifier.ts
+++ b/src/slang-nodes/OverrideSpecifier.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { OverridePathsDeclaration } from './OverridePathsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class OverrideSpecifier extends SlangNode {
@@ -21,7 +21,7 @@ export class OverrideSpecifier extends SlangNode {
     this.updateMetadata(this.overridden);
   }
 
-  print(path: AstPath<OverrideSpecifier>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['override', print('overridden')];
   }
 }

--- a/src/slang-nodes/OverrideSpecifier.ts
+++ b/src/slang-nodes/OverrideSpecifier.ts
@@ -22,6 +22,6 @@ export class OverrideSpecifier extends SlangNode {
   }
 
   print(path: AstPath<OverrideSpecifier>, print: PrintFunction): Doc {
-    return ['override', path.call(print, 'overridden')];
+    return ['override', print('overridden')];
   }
 }

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -49,9 +49,9 @@ export class Parameter extends SlangNode {
   print(path: AstPath<Parameter>, print: PrintFunction): Doc {
     return group(
       joinExisting(' ', [
-        path.call(print, 'typeName'),
-        path.call(print, 'storageLocation'),
-        path.call(print, 'name')
+        print('typeName'),
+        print('storageLocation'),
+        print('name')
       ])
     );
   }

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -8,7 +8,7 @@ import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -46,7 +46,7 @@ export class Parameter extends SlangNode {
     this.updateMetadata(this.typeName, this.storageLocation);
   }
 
-  print(path: AstPath<Parameter>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return group(
       joinExisting(' ', [
         print('typeName'),

--- a/src/slang-nodes/Parameters.ts
+++ b/src/slang-nodes/Parameters.ts
@@ -28,8 +28,8 @@ export class Parameters extends SlangNode {
   }
 
   print(
-    path: AstPath<Parameters>,
     print: PrintFunction,
+    path: AstPath<Parameters>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     if (this.items.length > 0) {

--- a/src/slang-nodes/ParametersDeclaration.ts
+++ b/src/slang-nodes/ParametersDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { Parameters } from './Parameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class ParametersDeclaration extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<ParametersDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/ParametersDeclaration.ts
+++ b/src/slang-nodes/ParametersDeclaration.ts
@@ -25,6 +25,6 @@ export class ParametersDeclaration extends SlangNode {
   }
 
   print(path: AstPath<ParametersDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'parameters'), ')'];
+    return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/PathImport.ts
+++ b/src/slang-nodes/PathImport.ts
@@ -4,7 +4,7 @@ import { StringLiteral } from './StringLiteral.js';
 import { ImportAlias } from './ImportAlias.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -30,7 +30,7 @@ export class PathImport extends SlangNode {
     this.updateMetadata(this.path, this.alias);
   }
 
-  print(path: AstPath<PathImport>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('path'), print('alias')];
   }
 }

--- a/src/slang-nodes/PathImport.ts
+++ b/src/slang-nodes/PathImport.ts
@@ -31,6 +31,6 @@ export class PathImport extends SlangNode {
   }
 
   print(path: AstPath<PathImport>, print: PrintFunction): Doc {
-    return [path.call(print, 'path'), path.call(print, 'alias')];
+    return [print('path'), print('alias')];
   }
 }

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -29,8 +29,8 @@ export class PositionalArguments extends SlangNode {
   }
 
   print(
-    path: AstPath<PositionalArguments>,
     print: PrintFunction,
+    path: AstPath<PositionalArguments>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     if (this.items.length > 0) {

--- a/src/slang-nodes/PositionalArgumentsDeclaration.ts
+++ b/src/slang-nodes/PositionalArgumentsDeclaration.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { PositionalArguments } from './PositionalArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -35,10 +35,7 @@ export class PositionalArgumentsDeclaration extends SlangNode {
       !ast.cst.children().some(({ node }) => isBlockComment(node)); // no block comments
   }
 
-  print(
-    path: AstPath<PositionalArgumentsDeclaration>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/PositionalArgumentsDeclaration.ts
+++ b/src/slang-nodes/PositionalArgumentsDeclaration.ts
@@ -39,6 +39,6 @@ export class PositionalArgumentsDeclaration extends SlangNode {
     path: AstPath<PositionalArgumentsDeclaration>,
     print: PrintFunction
   ): Doc {
-    return ['(', path.call(print, 'arguments'), ')'];
+    return ['(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -30,7 +30,7 @@ export class PostfixExpression extends SlangNode {
     this.updateMetadata(this.operand);
   }
 
-  print(path: AstPath<PostfixExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('operand'), this.operator];
   }
 }

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -31,6 +31,6 @@ export class PostfixExpression extends SlangNode {
   }
 
   print(path: AstPath<PostfixExpression>, print: PrintFunction): Doc {
-    return [path.call(print, 'operand'), this.operator];
+    return [print('operand'), this.operator];
   }
 }

--- a/src/slang-nodes/PragmaDirective.ts
+++ b/src/slang-nodes/PragmaDirective.ts
@@ -26,6 +26,6 @@ export class PragmaDirective extends SlangNode {
   }
 
   print(path: AstPath<PragmaDirective>, print: PrintFunction): Doc {
-    return ['pragma ', path.call(print, 'pragma'), ';'];
+    return ['pragma ', print('pragma'), ';'];
   }
 }

--- a/src/slang-nodes/PragmaDirective.ts
+++ b/src/slang-nodes/PragmaDirective.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Pragma } from './Pragma.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -25,7 +25,7 @@ export class PragmaDirective extends SlangNode {
     this.updateMetadata(this.pragma);
   }
 
-  print(path: AstPath<PragmaDirective>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['pragma ', print('pragma'), ';'];
   }
 }

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class PrefixExpression extends SlangNode {
     }
   }
 
-  print(path: AstPath<PrefixExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [this.operator, print('operand')];
   }
 }

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -35,6 +35,6 @@ export class PrefixExpression extends SlangNode {
   }
 
   print(path: AstPath<PrefixExpression>, print: PrintFunction): Doc {
-    return [this.operator, path.call(print, 'operand')];
+    return [this.operator, print('operand')];
   }
 }

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -31,7 +31,7 @@ export class ReceiveFunctionAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<ReceiveFunctionAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<ReceiveFunctionAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -32,6 +32,6 @@ export class ReceiveFunctionAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<ReceiveFunctionAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/ReceiveFunctionDefinition.ts
+++ b/src/slang-nodes/ReceiveFunctionDefinition.ts
@@ -7,7 +7,7 @@ import { ReceiveFunctionAttributes } from './ReceiveFunctionAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -48,7 +48,7 @@ export class ReceiveFunctionDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<ReceiveFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody('receive', this, path, print);
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody('receive', this, print);
   }
 }

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -40,7 +40,7 @@ export class ReturnStatement extends SlangNode {
       'return',
       expressionVariantKind
         ? printIndentedGroupOrSpacedDocument(
-            path.call(print, 'expression'),
+            print('expression'),
             expressionVariantKind !== NonterminalKind.TupleExpression &&
               (!options.experimentalTernaries ||
                 expressionVariantKind !== NonterminalKind.ConditionalExpression)

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -31,8 +31,8 @@ export class ReturnStatement extends SlangNode {
   }
 
   print(
-    path: AstPath<ReturnStatement>,
     print: PrintFunction,
+    _path: AstPath<ReturnStatement>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     const expressionVariantKind = this.expression?.kind;

--- a/src/slang-nodes/ReturnsDeclaration.ts
+++ b/src/slang-nodes/ReturnsDeclaration.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class ReturnsDeclaration extends SlangNode {
     this.updateMetadata(this.variables);
   }
 
-  print(path: AstPath<ReturnsDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['returns ', group(print('variables'))];
   }
 }

--- a/src/slang-nodes/ReturnsDeclaration.ts
+++ b/src/slang-nodes/ReturnsDeclaration.ts
@@ -32,6 +32,6 @@ export class ReturnsDeclaration extends SlangNode {
   }
 
   print(path: AstPath<ReturnsDeclaration>, print: PrintFunction): Doc {
-    return ['returns ', group(path.call(print, 'variables'))];
+    return ['returns ', group(print('variables'))];
   }
 }

--- a/src/slang-nodes/RevertStatement.ts
+++ b/src/slang-nodes/RevertStatement.ts
@@ -5,7 +5,7 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class RevertStatement extends SlangNode {
     this.updateMetadata(this.error, this.arguments);
   }
 
-  print(path: AstPath<RevertStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['revert ', print('error'), print('arguments'), ';'];
   }
 }

--- a/src/slang-nodes/RevertStatement.ts
+++ b/src/slang-nodes/RevertStatement.ts
@@ -32,11 +32,6 @@ export class RevertStatement extends SlangNode {
   }
 
   print(path: AstPath<RevertStatement>, print: PrintFunction): Doc {
-    return [
-      'revert ',
-      path.call(print, 'error'),
-      path.call(print, 'arguments'),
-      ';'
-    ];
+    return ['revert ', print('error'), print('arguments'), ';'];
   }
 }

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -65,8 +65,8 @@ export class ShiftExpression extends SlangNode {
   }
 
   print(
-    path: AstPath<ShiftExpression>,
     print: PrintFunction,
+    path: AstPath<ShiftExpression>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printShiftExpression(this, path, print, options);

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -33,7 +33,7 @@ export class SourceUnit extends SlangNode {
     options: ParserOptions<PrintableNode>
   ): Doc {
     return [
-      path.call(print, 'members'),
+      print('members'),
       // Prettier's Markdown formatter already appends a new line on code
       // blocks, therefore we avoid trailing with a new line at the end of
       // a file in this case.

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -28,8 +28,8 @@ export class SourceUnit extends SlangNode {
   }
 
   print(
-    path: AstPath<SourceUnit>,
     print: PrintFunction,
+    _path: AstPath<SourceUnit>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return [

--- a/src/slang-nodes/SourceUnitMembers.ts
+++ b/src/slang-nodes/SourceUnitMembers.ts
@@ -27,8 +27,8 @@ export class SourceUnitMembers extends SlangNode {
   }
 
   print(
-    path: AstPath<SourceUnitMembers>,
     print: PrintFunction,
+    path: AstPath<SourceUnitMembers>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printPreservingEmptyLines(this, path, print, options);

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -27,6 +27,6 @@ export class StateVariableAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<StateVariableAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -26,7 +26,7 @@ export class StateVariableAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<StateVariableAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<StateVariableAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -9,7 +9,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { StateVariableDefinitionValue } from './StateVariableDefinitionValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -49,7 +49,7 @@ export class StateVariableDefinition extends SlangNode {
     this.updateMetadata(this.typeName, this.attributes, this.value);
   }
 
-  print(path: AstPath<StateVariableDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return printGroupAndIndentIfBreakPair(
       [print('typeName'), indent(print('attributes')), ' ', print('name')],
       [print('value'), ';']

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -51,13 +51,8 @@ export class StateVariableDefinition extends SlangNode {
 
   print(path: AstPath<StateVariableDefinition>, print: PrintFunction): Doc {
     return printGroupAndIndentIfBreakPair(
-      [
-        path.call(print, 'typeName'),
-        indent(path.call(print, 'attributes')),
-        ' ',
-        path.call(print, 'name')
-      ],
-      [path.call(print, 'value'), ';']
+      [print('typeName'), indent(print('attributes')), ' ', print('name')],
+      [print('value'), ';']
     );
   }
 }

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -30,9 +30,6 @@ export class StateVariableDefinitionValue extends SlangNode {
     path: AstPath<StateVariableDefinitionValue>,
     print: PrintFunction
   ): Doc {
-    return [
-      ' =',
-      printAssignmentRightSide(path.call(print, 'value'), this.value)
-    ];
+    return [' =', printAssignmentRightSide(print('value'), this.value)];
   }
 }

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -5,7 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -26,10 +26,7 @@ export class StateVariableDefinitionValue extends SlangNode {
     this.updateMetadata(this.value);
   }
 
-  print(
-    path: AstPath<StateVariableDefinitionValue>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return [' =', printAssignmentRightSide(print('value'), this.value)];
   }
 }

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -31,8 +31,8 @@ export class Statements extends SlangNode {
   }
 
   print(
-    path: AstPath<Statements>,
     print: PrintFunction,
+    path: AstPath<Statements>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return this.items.length > 0 || (this.comments?.length || 0) > 0

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -31,7 +31,7 @@ export class StorageLayoutSpecifier extends SlangNode {
     this.updateMetadata(this.expression);
   }
 
-  print(path: AstPath<StorageLayoutSpecifier>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<StorageLayoutSpecifier>): Doc {
     return [
       'layout at',
       printSeparatedItem(print('expression'), {

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -34,7 +34,7 @@ export class StorageLayoutSpecifier extends SlangNode {
   print(path: AstPath<StorageLayoutSpecifier>, print: PrintFunction): Doc {
     return [
       'layout at',
-      printSeparatedItem(path.call(print, 'expression'), {
+      printSeparatedItem(print('expression'), {
         firstSeparator: line,
         // If this is the second ContractSpecifier we have to delegate printing
         // the line to the ContractSpecifiers node.

--- a/src/slang-nodes/StringLiterals.ts
+++ b/src/slang-nodes/StringLiterals.ts
@@ -27,7 +27,7 @@ export class StringLiterals extends SlangNode {
     );
   }
 
-  print(path: AstPath<StringLiterals>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<StringLiterals>): Doc {
     return join(hardline, path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/StructDefinition.ts
+++ b/src/slang-nodes/StructDefinition.ts
@@ -4,7 +4,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { StructMembers } from './StructMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -28,7 +28,7 @@ export class StructDefinition extends SlangNode {
     this.updateMetadata(this.members);
   }
 
-  print(path: AstPath<StructDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['struct ', print('name'), ' {', print('members'), '}'];
   }
 }

--- a/src/slang-nodes/StructDefinition.ts
+++ b/src/slang-nodes/StructDefinition.ts
@@ -29,12 +29,6 @@ export class StructDefinition extends SlangNode {
   }
 
   print(path: AstPath<StructDefinition>, print: PrintFunction): Doc {
-    return [
-      'struct ',
-      path.call(print, 'name'),
-      ' {',
-      path.call(print, 'members'),
-      '}'
-    ];
+    return ['struct ', print('name'), ' {', print('members'), '}'];
   }
 }

--- a/src/slang-nodes/StructMember.ts
+++ b/src/slang-nodes/StructMember.ts
@@ -5,7 +5,7 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class StructMember extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<StructMember>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('typeName'), ' ', print('name'), ';'];
   }
 }

--- a/src/slang-nodes/StructMember.ts
+++ b/src/slang-nodes/StructMember.ts
@@ -32,6 +32,6 @@ export class StructMember extends SlangNode {
   }
 
   print(path: AstPath<StructMember>, print: PrintFunction): Doc {
-    return [path.call(print, 'typeName'), ' ', path.call(print, 'name'), ';'];
+    return [print('typeName'), ' ', print('name'), ';'];
   }
 }

--- a/src/slang-nodes/StructMembers.ts
+++ b/src/slang-nodes/StructMembers.ts
@@ -28,7 +28,7 @@ export class StructMembers extends SlangNode {
     );
   }
 
-  print(path: AstPath<StructMembers>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<StructMembers>): Doc {
     return this.items.length > 0
       ? printSeparatedList(path.map(print, 'items'), {
           firstSeparator: hardline,

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -54,13 +54,13 @@ export class TryStatement extends SlangNode {
   print(path: AstPath<TryStatement>, print: PrintFunction): Doc {
     return [
       'try',
-      printSeparatedItem(path.call(print, 'expression'), {
+      printSeparatedItem(print('expression'), {
         firstSeparator: line
       }),
       joinExisting(' ', [
-        path.call(print, 'returns'),
-        path.call(print, 'body'),
-        path.call(print, 'catchClauses')
+        print('returns'),
+        print('body'),
+        print('catchClauses')
       ])
     ];
   }

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -10,7 +10,7 @@ import { Block } from './Block.js';
 import { CatchClauses } from './CatchClauses.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -51,7 +51,7 @@ export class TryStatement extends SlangNode {
     );
   }
 
-  print(path: AstPath<TryStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'try',
       printSeparatedItem(print('expression'), {

--- a/src/slang-nodes/TupleDeconstructionElement.ts
+++ b/src/slang-nodes/TupleDeconstructionElement.ts
@@ -30,6 +30,6 @@ export class TupleDeconstructionElement extends SlangNode {
   }
 
   print(path: AstPath<TupleDeconstructionElement>, print: PrintFunction): Doc {
-    return path.call(print, 'member');
+    return print('member');
   }
 }

--- a/src/slang-nodes/TupleDeconstructionElement.ts
+++ b/src/slang-nodes/TupleDeconstructionElement.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { TupleMember } from './TupleMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -29,7 +29,7 @@ export class TupleDeconstructionElement extends SlangNode {
     this.updateMetadata(this.member);
   }
 
-  print(path: AstPath<TupleDeconstructionElement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return print('member');
   }
 }

--- a/src/slang-nodes/TupleDeconstructionElements.ts
+++ b/src/slang-nodes/TupleDeconstructionElements.ts
@@ -25,7 +25,7 @@ export class TupleDeconstructionElements extends SlangNode {
     );
   }
 
-  print(path: AstPath<TupleDeconstructionElements>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<TupleDeconstructionElements>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -6,7 +6,7 @@ import { TupleDeconstructionElements } from './TupleDeconstructionElements.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -39,10 +39,7 @@ export class TupleDeconstructionStatement extends SlangNode {
     this.updateMetadata(this.elements, this.expression);
   }
 
-  print(
-    path: AstPath<TupleDeconstructionStatement>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return printGroupAndIndentIfBreakPair(
       [this.varKeyword ? 'var (' : '(', print('elements'), ') = '],
       [print('expression'), ';']

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -44,8 +44,8 @@ export class TupleDeconstructionStatement extends SlangNode {
     print: PrintFunction
   ): Doc {
     return printGroupAndIndentIfBreakPair(
-      [this.varKeyword ? 'var (' : '(', path.call(print, 'elements'), ') = '],
-      [path.call(print, 'expression'), ';']
+      [this.varKeyword ? 'var (' : '(', print('elements'), ') = '],
+      [print('expression'), ';']
     );
   }
 }

--- a/src/slang-nodes/TupleExpression.ts
+++ b/src/slang-nodes/TupleExpression.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { TupleValues } from './TupleValues.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class TupleExpression extends SlangNode {
     this.updateMetadata(this.items);
   }
 
-  print(path: AstPath<TupleExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('items'), ')'];
   }
 }

--- a/src/slang-nodes/TupleExpression.ts
+++ b/src/slang-nodes/TupleExpression.ts
@@ -25,6 +25,6 @@ export class TupleExpression extends SlangNode {
   }
 
   print(path: AstPath<TupleExpression>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'items'), ')'];
+    return ['(', print('items'), ')'];
   }
 }

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -29,7 +29,7 @@ export class TupleValue extends SlangNode {
     this.updateMetadata(this.expression);
   }
 
-  print(path: AstPath<TupleValue>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return print('expression');
   }
 }

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -30,6 +30,6 @@ export class TupleValue extends SlangNode {
   }
 
   print(path: AstPath<TupleValue>, print: PrintFunction): Doc {
-    return path.call(print, 'expression');
+    return print('expression');
   }
 }

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -32,7 +32,7 @@ export class TupleValues extends SlangNode {
     return items.length === 1 ? items[0].expression : undefined;
   }
 
-  print(path: AstPath<TupleValues>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<TupleValues>): Doc {
     const singleExpression = this.getSingleExpression();
     const items = path.map(print, 'items');
     return singleExpression && isBinaryOperation(singleExpression)

--- a/src/slang-nodes/TypeExpression.ts
+++ b/src/slang-nodes/TypeExpression.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -27,7 +27,7 @@ export class TypeExpression extends SlangNode {
     this.updateMetadata(this.typeName);
   }
 
-  print(path: AstPath<TypeExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['type(', print('typeName'), ')'];
   }
 }

--- a/src/slang-nodes/TypeExpression.ts
+++ b/src/slang-nodes/TypeExpression.ts
@@ -28,6 +28,6 @@ export class TypeExpression extends SlangNode {
   }
 
   print(path: AstPath<TypeExpression>, print: PrintFunction): Doc {
-    return ['type(', path.call(print, 'typeName'), ')'];
+    return ['type(', print('typeName'), ')'];
   }
 }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -43,9 +43,9 @@ export class TypedTupleMember extends SlangNode {
 
   print(path: AstPath<TypedTupleMember>, print: PrintFunction): Doc {
     return joinExisting(' ', [
-      path.call(print, 'typeName'),
-      path.call(print, 'storageLocation'),
-      path.call(print, 'name')
+      print('typeName'),
+      print('storageLocation'),
+      print('name')
     ]);
   }
 }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -7,7 +7,7 @@ import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -41,7 +41,7 @@ export class TypedTupleMember extends SlangNode {
     this.updateMetadata(this.typeName, this.storageLocation);
   }
 
-  print(path: AstPath<TypedTupleMember>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [
       print('typeName'),
       print('storageLocation'),

--- a/src/slang-nodes/UncheckedBlock.ts
+++ b/src/slang-nodes/UncheckedBlock.ts
@@ -25,6 +25,6 @@ export class UncheckedBlock extends SlangNode {
   }
 
   print(path: AstPath<UncheckedBlock>, print: PrintFunction): Doc {
-    return ['unchecked ', path.call(print, 'block')];
+    return ['unchecked ', print('block')];
   }
 }

--- a/src/slang-nodes/UncheckedBlock.ts
+++ b/src/slang-nodes/UncheckedBlock.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class UncheckedBlock extends SlangNode {
     this.updateMetadata(this.block);
   }
 
-  print(path: AstPath<UncheckedBlock>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['unchecked ', print('block')];
   }
 }

--- a/src/slang-nodes/UnicodeStringLiterals.ts
+++ b/src/slang-nodes/UnicodeStringLiterals.ts
@@ -27,7 +27,7 @@ export class UnicodeStringLiterals extends SlangNode {
     );
   }
 
-  print(path: AstPath<UnicodeStringLiterals>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<UnicodeStringLiterals>): Doc {
     return join(hardline, path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -32,6 +32,6 @@ export class UnnamedFunctionAttributes extends SlangNode {
   }
 
   print(print: PrintFunction, path: AstPath<UnnamedFunctionAttributes>): Doc {
-    return path.map(() => [line, print(path)], 'items');
+    return path.map(() => [line, print()], 'items');
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -31,7 +31,7 @@ export class UnnamedFunctionAttributes extends SlangNode {
     this.items.sort(sortFunctionAttributes);
   }
 
-  print(path: AstPath<UnnamedFunctionAttributes>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<UnnamedFunctionAttributes>): Doc {
     return path.map(() => [line, print(path)], 'items');
   }
 }

--- a/src/slang-nodes/UnnamedFunctionDefinition.ts
+++ b/src/slang-nodes/UnnamedFunctionDefinition.ts
@@ -7,7 +7,7 @@ import { UnnamedFunctionAttributes } from './UnnamedFunctionAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -48,7 +48,7 @@ export class UnnamedFunctionDefinition extends SlangNode {
     }
   }
 
-  print(path: AstPath<UnnamedFunctionDefinition>, print: PrintFunction): Doc {
-    return printFunctionWithBody('function', this, path, print);
+  print(print: PrintFunction): Doc {
+    return printFunctionWithBody('function', this, print);
   }
 }

--- a/src/slang-nodes/UntypedTupleMember.ts
+++ b/src/slang-nodes/UntypedTupleMember.ts
@@ -5,7 +5,7 @@ import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class UntypedTupleMember extends SlangNode {
@@ -29,7 +29,7 @@ export class UntypedTupleMember extends SlangNode {
     this.updateMetadata(this.storageLocation);
   }
 
-  print(path: AstPath<UntypedTupleMember>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [print('storageLocation'), print('name')]);
   }
 }

--- a/src/slang-nodes/UntypedTupleMember.ts
+++ b/src/slang-nodes/UntypedTupleMember.ts
@@ -30,9 +30,6 @@ export class UntypedTupleMember extends SlangNode {
   }
 
   print(path: AstPath<UntypedTupleMember>, print: PrintFunction): Doc {
-    return joinExisting(' ', [
-      path.call(print, 'storageLocation'),
-      path.call(print, 'name')
-    ]);
+    return joinExisting(' ', [print('storageLocation'), print('name')]);
   }
 }

--- a/src/slang-nodes/UserDefinedValueTypeDefinition.ts
+++ b/src/slang-nodes/UserDefinedValueTypeDefinition.ts
@@ -33,12 +33,6 @@ export class UserDefinedValueTypeDefinition extends SlangNode {
     path: AstPath<UserDefinedValueTypeDefinition>,
     print: PrintFunction
   ): Doc {
-    return [
-      'type ',
-      path.call(print, 'name'),
-      ' is ',
-      path.call(print, 'valueType'),
-      ';'
-    ];
+    return ['type ', print('name'), ' is ', print('valueType'), ';'];
   }
 }

--- a/src/slang-nodes/UserDefinedValueTypeDefinition.ts
+++ b/src/slang-nodes/UserDefinedValueTypeDefinition.ts
@@ -5,7 +5,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { ElementaryType } from './ElementaryType.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class UserDefinedValueTypeDefinition extends SlangNode {
@@ -29,10 +29,7 @@ export class UserDefinedValueTypeDefinition extends SlangNode {
     this.updateMetadata(this.valueType);
   }
 
-  print(
-    path: AstPath<UserDefinedValueTypeDefinition>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return ['type ', print('name'), ' is ', print('valueType'), ';'];
   }
 }

--- a/src/slang-nodes/UsingAlias.ts
+++ b/src/slang-nodes/UsingAlias.ts
@@ -20,6 +20,6 @@ export class UsingAlias extends SlangNode {
   }
 
   print(path: AstPath<UsingAlias>, print: PrintFunction): Doc {
-    return [' as ', path.call(print, 'operator')];
+    return [' as ', print('operator')];
   }
 }

--- a/src/slang-nodes/UsingAlias.ts
+++ b/src/slang-nodes/UsingAlias.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { UsingOperator } from './UsingOperator.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class UsingAlias extends SlangNode {
@@ -19,7 +19,7 @@ export class UsingAlias extends SlangNode {
     this.updateMetadata(this.operator);
   }
 
-  print(path: AstPath<UsingAlias>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [' as ', print('operator')];
   }
 }

--- a/src/slang-nodes/UsingDeconstruction.ts
+++ b/src/slang-nodes/UsingDeconstruction.ts
@@ -20,6 +20,6 @@ export class UsingDeconstruction extends SlangNode {
   }
 
   print(path: AstPath<UsingDeconstruction>, print: PrintFunction): Doc {
-    return ['{', path.call(print, 'symbols'), '}'];
+    return ['{', print('symbols'), '}'];
   }
 }

--- a/src/slang-nodes/UsingDeconstruction.ts
+++ b/src/slang-nodes/UsingDeconstruction.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { UsingDeconstructionSymbols } from './UsingDeconstructionSymbols.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class UsingDeconstruction extends SlangNode {
@@ -19,7 +19,7 @@ export class UsingDeconstruction extends SlangNode {
     this.updateMetadata(this.symbols);
   }
 
-  print(path: AstPath<UsingDeconstruction>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['{', print('symbols'), '}'];
   }
 }

--- a/src/slang-nodes/UsingDeconstructionSymbol.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbol.ts
@@ -4,7 +4,7 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { UsingAlias } from './UsingAlias.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class UsingDeconstructionSymbol extends SlangNode {
@@ -28,7 +28,7 @@ export class UsingDeconstructionSymbol extends SlangNode {
     this.updateMetadata(this.name, this.alias);
   }
 
-  print(path: AstPath<UsingDeconstructionSymbol>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('name'), print('alias')];
   }
 }

--- a/src/slang-nodes/UsingDeconstructionSymbol.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbol.ts
@@ -29,6 +29,6 @@ export class UsingDeconstructionSymbol extends SlangNode {
   }
 
   print(path: AstPath<UsingDeconstructionSymbol>, print: PrintFunction): Doc {
-    return [path.call(print, 'name'), path.call(print, 'alias')];
+    return [print('name'), print('alias')];
   }
 }

--- a/src/slang-nodes/UsingDeconstructionSymbols.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbols.ts
@@ -28,8 +28,8 @@ export class UsingDeconstructionSymbols extends SlangNode {
   }
 
   print(
-    path: AstPath<UsingDeconstructionSymbols>,
     print: PrintFunction,
+    path: AstPath<UsingDeconstructionSymbols>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return printSeparatedList(path.map(print, 'items'), {

--- a/src/slang-nodes/UsingDirective.ts
+++ b/src/slang-nodes/UsingDirective.ts
@@ -5,7 +5,7 @@ import { UsingClause } from './UsingClause.js';
 import { UsingTarget } from './UsingTarget.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class UsingDirective extends SlangNode {
     this.updateMetadata(this.clause, this.target);
   }
 
-  print(path: AstPath<UsingDirective>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'using ',
       print('clause'),

--- a/src/slang-nodes/UsingDirective.ts
+++ b/src/slang-nodes/UsingDirective.ts
@@ -37,9 +37,9 @@ export class UsingDirective extends SlangNode {
   print(path: AstPath<UsingDirective>, print: PrintFunction): Doc {
     return [
       'using ',
-      path.call(print, 'clause'),
+      print('clause'),
       ' for ',
-      path.call(print, 'target'),
+      print('target'),
       this.globalKeyword ? ' global;' : ';'
     ];
   }

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -9,7 +9,7 @@ import { TerminalNode } from './TerminalNode.js';
 import { VariableDeclarationValue } from './VariableDeclarationValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -50,10 +50,7 @@ export class VariableDeclarationStatement extends SlangNode {
     this.updateMetadata(this.variableType, this.storageLocation, this.value);
   }
 
-  print(
-    path: AstPath<VariableDeclarationStatement>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return printGroupAndIndentIfBreakPair(
       [
         print('variableType'),

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -56,14 +56,12 @@ export class VariableDeclarationStatement extends SlangNode {
   ): Doc {
     return printGroupAndIndentIfBreakPair(
       [
-        path.call(print, 'variableType'),
-        this.storageLocation
-          ? indent([line, path.call(print, 'storageLocation')])
-          : '',
+        print('variableType'),
+        this.storageLocation ? indent([line, print('storageLocation')]) : '',
         ' ',
-        path.call(print, 'name')
+        print('name')
       ],
-      [path.call(print, 'value'), ';']
+      [print('value'), ';']
     );
   }
 }

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -5,7 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -28,7 +28,7 @@ export class VariableDeclarationValue extends SlangNode {
     this.updateMetadata(this.expression);
   }
 
-  print(path: AstPath<VariableDeclarationValue>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       ' =',
       printAssignmentRightSide(print('expression'), this.expression)

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -31,7 +31,7 @@ export class VariableDeclarationValue extends SlangNode {
   print(path: AstPath<VariableDeclarationValue>, print: PrintFunction): Doc {
     return [
       ' =',
-      printAssignmentRightSide(path.call(print, 'expression'), this.expression)
+      printAssignmentRightSide(print('expression'), this.expression)
     ];
   }
 }

--- a/src/slang-nodes/VersionExpressionSet.ts
+++ b/src/slang-nodes/VersionExpressionSet.ts
@@ -23,7 +23,7 @@ export class VersionExpressionSet extends SlangNode {
     );
   }
 
-  print(path: AstPath<VersionExpressionSet>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<VersionExpressionSet>): Doc {
     return join(' ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/VersionExpressionSets.ts
+++ b/src/slang-nodes/VersionExpressionSets.ts
@@ -22,7 +22,7 @@ export class VersionExpressionSets extends SlangNode {
     );
   }
 
-  print(path: AstPath<VersionExpressionSets>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<VersionExpressionSets>): Doc {
     return join(' || ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/VersionPragma.ts
+++ b/src/slang-nodes/VersionPragma.ts
@@ -20,6 +20,6 @@ export class VersionPragma extends SlangNode {
   }
 
   print(path: AstPath<VersionPragma>, print: PrintFunction): Doc {
-    return ['solidity ', path.call(print, 'sets')];
+    return ['solidity ', print('sets')];
   }
 }

--- a/src/slang-nodes/VersionPragma.ts
+++ b/src/slang-nodes/VersionPragma.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { VersionExpressionSets } from './VersionExpressionSets.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class VersionPragma extends SlangNode {
@@ -19,7 +19,7 @@ export class VersionPragma extends SlangNode {
     this.updateMetadata(this.sets);
   }
 
-  print(path: AstPath<VersionPragma>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['solidity ', print('sets')];
   }
 }

--- a/src/slang-nodes/VersionRange.ts
+++ b/src/slang-nodes/VersionRange.ts
@@ -24,6 +24,6 @@ export class VersionRange extends SlangNode {
   }
 
   print(path: AstPath<VersionRange>, print: PrintFunction): Doc {
-    return [path.call(print, 'start'), ' - ', path.call(print, 'end')];
+    return [print('start'), ' - ', print('end')];
   }
 }

--- a/src/slang-nodes/VersionRange.ts
+++ b/src/slang-nodes/VersionRange.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { VersionLiteral } from './VersionLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class VersionRange extends SlangNode {
@@ -23,7 +23,7 @@ export class VersionRange extends SlangNode {
     this.updateMetadata(this.start, this.end);
   }
 
-  print(path: AstPath<VersionRange>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('start'), ' - ', print('end')];
   }
 }

--- a/src/slang-nodes/VersionTerm.ts
+++ b/src/slang-nodes/VersionTerm.ts
@@ -5,7 +5,7 @@ import { VersionOperator } from './VersionOperator.js';
 import { VersionLiteral } from './VersionLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class VersionTerm extends SlangNode {
@@ -26,7 +26,7 @@ export class VersionTerm extends SlangNode {
     this.updateMetadata(this.operator, this.literal);
   }
 
-  print(path: AstPath<VersionTerm>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('operator'), print('literal')];
   }
 }

--- a/src/slang-nodes/VersionTerm.ts
+++ b/src/slang-nodes/VersionTerm.ts
@@ -27,6 +27,6 @@ export class VersionTerm extends SlangNode {
   }
 
   print(path: AstPath<VersionTerm>, print: PrintFunction): Doc {
-    return [path.call(print, 'operator'), path.call(print, 'literal')];
+    return [print('operator'), print('literal')];
   }
 }

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -7,7 +7,7 @@ import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -33,7 +33,7 @@ export class WhileStatement extends SlangNode {
     this.updateMetadata(this.condition, this.body);
   }
 
-  print(path: AstPath<WhileStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'while (',
       printSeparatedItem(print('condition')),

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -36,10 +36,10 @@ export class WhileStatement extends SlangNode {
   print(path: AstPath<WhileStatement>, print: PrintFunction): Doc {
     return [
       'while (',
-      printSeparatedItem(path.call(print, 'condition')),
+      printSeparatedItem(print('condition')),
       ')',
       printIndentedGroupOrSpacedDocument(
-        path.call(print, 'body'),
+        print('body'),
         this.body.kind !== NonterminalKind.Block
       )
     ];

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -26,7 +26,7 @@ export class YulArguments extends SlangNode {
     );
   }
 
-  print(path: AstPath<YulArguments>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulArguments>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulBlock.ts
+++ b/src/slang-nodes/YulBlock.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { YulStatements } from './YulStatements.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class YulBlock extends SlangNode {
     this.updateMetadata(this.statements);
   }
 
-  print(path: AstPath<YulBlock>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['{', print('statements'), '}'];
   }
 }

--- a/src/slang-nodes/YulBlock.ts
+++ b/src/slang-nodes/YulBlock.ts
@@ -25,6 +25,6 @@ export class YulBlock extends SlangNode {
   }
 
   print(path: AstPath<YulBlock>, print: PrintFunction): Doc {
-    return ['{', path.call(print, 'statements'), '}'];
+    return ['{', print('statements'), '}'];
   }
 }

--- a/src/slang-nodes/YulDefaultCase.ts
+++ b/src/slang-nodes/YulDefaultCase.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -24,7 +24,7 @@ export class YulDefaultCase extends SlangNode {
     this.updateMetadata(this.body);
   }
 
-  print(path: AstPath<YulDefaultCase>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['default ', print('body')];
   }
 }

--- a/src/slang-nodes/YulDefaultCase.ts
+++ b/src/slang-nodes/YulDefaultCase.ts
@@ -25,6 +25,6 @@ export class YulDefaultCase extends SlangNode {
   }
 
   print(path: AstPath<YulDefaultCase>, print: PrintFunction): Doc {
-    return ['default ', path.call(print, 'body')];
+    return ['default ', print('body')];
   }
 }

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -6,7 +6,7 @@ import { YulBlock } from './YulBlock.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -45,7 +45,7 @@ export class YulForStatement extends SlangNode {
     );
   }
 
-  print(path: AstPath<YulForStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return join(' ', [
       'for',
       print('initialization'),

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -48,10 +48,10 @@ export class YulForStatement extends SlangNode {
   print(path: AstPath<YulForStatement>, print: PrintFunction): Doc {
     return join(' ', [
       'for',
-      path.call(print, 'initialization'),
-      path.call(print, 'condition'),
-      path.call(print, 'iterator'),
-      path.call(print, 'body')
+      print('initialization'),
+      print('condition'),
+      print('iterator'),
+      print('body')
     ]);
   }
 }

--- a/src/slang-nodes/YulFunctionCallExpression.ts
+++ b/src/slang-nodes/YulFunctionCallExpression.ts
@@ -5,7 +5,7 @@ import { YulExpression } from './YulExpression.js';
 import { YulArguments } from './YulArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class YulFunctionCallExpression extends SlangNode {
     this.updateMetadata(this.operand, this.arguments);
   }
 
-  print(path: AstPath<YulFunctionCallExpression>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('operand'), '(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/YulFunctionCallExpression.ts
+++ b/src/slang-nodes/YulFunctionCallExpression.ts
@@ -32,11 +32,6 @@ export class YulFunctionCallExpression extends SlangNode {
   }
 
   print(path: AstPath<YulFunctionCallExpression>, print: PrintFunction): Doc {
-    return [
-      path.call(print, 'operand'),
-      '(',
-      path.call(print, 'arguments'),
-      ')'
-    ];
+    return [print('operand'), '(', print('arguments'), ')'];
   }
 }

--- a/src/slang-nodes/YulFunctionDefinition.ts
+++ b/src/slang-nodes/YulFunctionDefinition.ts
@@ -6,7 +6,7 @@ import { YulReturnsDeclaration } from './YulReturnsDeclaration.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -38,7 +38,7 @@ export class YulFunctionDefinition extends SlangNode {
     this.updateMetadata(this.parameters, this.returns, this.body);
   }
 
-  print(path: AstPath<YulFunctionDefinition>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       'function ',
       print('name'),

--- a/src/slang-nodes/YulFunctionDefinition.ts
+++ b/src/slang-nodes/YulFunctionDefinition.ts
@@ -41,10 +41,10 @@ export class YulFunctionDefinition extends SlangNode {
   print(path: AstPath<YulFunctionDefinition>, print: PrintFunction): Doc {
     return [
       'function ',
-      path.call(print, 'name'),
-      path.call(print, 'parameters'),
-      path.call(print, 'returns') || ' ',
-      path.call(print, 'body')
+      print('name'),
+      print('parameters'),
+      print('returns') || ' ',
+      print('body')
     ];
   }
 }

--- a/src/slang-nodes/YulIfStatement.ts
+++ b/src/slang-nodes/YulIfStatement.ts
@@ -5,7 +5,7 @@ import { YulExpression } from './YulExpression.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -31,7 +31,7 @@ export class YulIfStatement extends SlangNode {
     this.updateMetadata(this.condition, this.body);
   }
 
-  print(path: AstPath<YulIfStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['if ', print('condition'), ' ', print('body')];
   }
 }

--- a/src/slang-nodes/YulIfStatement.ts
+++ b/src/slang-nodes/YulIfStatement.ts
@@ -32,11 +32,6 @@ export class YulIfStatement extends SlangNode {
   }
 
   print(path: AstPath<YulIfStatement>, print: PrintFunction): Doc {
-    return [
-      'if ',
-      path.call(print, 'condition'),
-      ' ',
-      path.call(print, 'body')
-    ];
+    return ['if ', print('condition'), ' ', print('body')];
   }
 }

--- a/src/slang-nodes/YulLabel.ts
+++ b/src/slang-nodes/YulLabel.ts
@@ -4,7 +4,7 @@ import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { dedent, line } = doc.builders;
@@ -20,7 +20,7 @@ export class YulLabel extends SlangNode {
     this.label = new TerminalNode(ast.label, collected);
   }
 
-  print(path: AstPath<YulLabel>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [dedent(line), print('label'), ':'];
   }
 }

--- a/src/slang-nodes/YulLabel.ts
+++ b/src/slang-nodes/YulLabel.ts
@@ -21,6 +21,6 @@ export class YulLabel extends SlangNode {
   }
 
   print(path: AstPath<YulLabel>, print: PrintFunction): Doc {
-    return [dedent(line), path.call(print, 'label'), ':'];
+    return [dedent(line), print('label'), ':'];
   }
 }

--- a/src/slang-nodes/YulParameters.ts
+++ b/src/slang-nodes/YulParameters.ts
@@ -18,7 +18,7 @@ export class YulParameters extends SlangNode {
     this.items = ast.items.map((item) => new TerminalNode(item, collected));
   }
 
-  print(path: AstPath<YulParameters>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulParameters>): Doc {
     return printSeparatedList(path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulParametersDeclaration.ts
+++ b/src/slang-nodes/YulParametersDeclaration.ts
@@ -20,6 +20,6 @@ export class YulParametersDeclaration extends SlangNode {
   }
 
   print(path: AstPath<YulParametersDeclaration>, print: PrintFunction): Doc {
-    return ['(', path.call(print, 'parameters'), ')'];
+    return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/YulParametersDeclaration.ts
+++ b/src/slang-nodes/YulParametersDeclaration.ts
@@ -3,7 +3,7 @@ import { SlangNode } from './SlangNode.js';
 import { YulParameters } from './YulParameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 export class YulParametersDeclaration extends SlangNode {
@@ -19,7 +19,7 @@ export class YulParametersDeclaration extends SlangNode {
     this.updateMetadata(this.parameters);
   }
 
-  print(path: AstPath<YulParametersDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['(', print('parameters'), ')'];
   }
 }

--- a/src/slang-nodes/YulPath.ts
+++ b/src/slang-nodes/YulPath.ts
@@ -20,7 +20,7 @@ export class YulPath extends SlangNode {
     this.items = ast.items.map((item) => new TerminalNode(item, collected));
   }
 
-  print(path: AstPath<YulPath>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulPath>): Doc {
     return join('.', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulPaths.ts
+++ b/src/slang-nodes/YulPaths.ts
@@ -20,7 +20,7 @@ export class YulPaths extends SlangNode {
     this.items = ast.items.map((item) => new YulPath(item, collected));
   }
 
-  print(path: AstPath<YulPaths>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulPaths>): Doc {
     return join(', ', path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulReturnsDeclaration.ts
+++ b/src/slang-nodes/YulReturnsDeclaration.ts
@@ -5,7 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { YulVariableNames } from './YulVariableNames.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
@@ -23,7 +23,7 @@ export class YulReturnsDeclaration extends SlangNode {
     this.updateMetadata(this.variables);
   }
 
-  print(path: AstPath<YulReturnsDeclaration>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return printSeparatedItem(['->', print('variables')], {
       firstSeparator: line
     });

--- a/src/slang-nodes/YulReturnsDeclaration.ts
+++ b/src/slang-nodes/YulReturnsDeclaration.ts
@@ -24,7 +24,7 @@ export class YulReturnsDeclaration extends SlangNode {
   }
 
   print(path: AstPath<YulReturnsDeclaration>, print: PrintFunction): Doc {
-    return printSeparatedItem(['->', path.call(print, 'variables')], {
+    return printSeparatedItem(['->', print('variables')], {
       firstSeparator: line
     });
   }

--- a/src/slang-nodes/YulStackAssignmentStatement.ts
+++ b/src/slang-nodes/YulStackAssignmentStatement.ts
@@ -7,7 +7,7 @@ import { YulStackAssignmentOperator } from './YulStackAssignmentOperator.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
@@ -33,7 +33,7 @@ export class YulStackAssignmentStatement extends SlangNode {
     this.updateMetadata(this.assignment);
   }
 
-  print(path: AstPath<YulStackAssignmentStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [
       print('assignment'),
       printSeparatedItem(print('variable'), {

--- a/src/slang-nodes/YulStackAssignmentStatement.ts
+++ b/src/slang-nodes/YulStackAssignmentStatement.ts
@@ -35,8 +35,8 @@ export class YulStackAssignmentStatement extends SlangNode {
 
   print(path: AstPath<YulStackAssignmentStatement>, print: PrintFunction): Doc {
     return [
-      path.call(print, 'assignment'),
-      printSeparatedItem(path.call(print, 'variable'), {
+      print('assignment'),
+      printSeparatedItem(print('variable'), {
         firstSeparator: line,
         lastSeparator: ''
       })

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -31,8 +31,8 @@ export class YulStatements extends SlangNode {
   }
 
   print(
-    path: AstPath<YulStatements>,
     print: PrintFunction,
+    path: AstPath<YulStatements>,
     options: ParserOptions<PrintableNode>
   ): Doc {
     return this.items.length > 0 || (this.comments?.length || 0) > 0

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -28,7 +28,7 @@ export class YulSwitchCases extends SlangNode {
     );
   }
 
-  print(path: AstPath<YulSwitchCases>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulSwitchCases>): Doc {
     return join(hardline, path.map(print, 'items'));
   }
 }

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -6,7 +6,7 @@ import { YulExpression } from './YulExpression.js';
 import { YulSwitchCases } from './YulSwitchCases.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -34,7 +34,7 @@ export class YulSwitchStatement extends SlangNode {
     this.updateMetadata(this.expression, this.cases);
   }
 
-  print(path: AstPath<YulSwitchStatement>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['switch ', print('expression'), hardline, print('cases')];
   }
 }

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -35,11 +35,6 @@ export class YulSwitchStatement extends SlangNode {
   }
 
   print(path: AstPath<YulSwitchStatement>, print: PrintFunction): Doc {
-    return [
-      'switch ',
-      path.call(print, 'expression'),
-      hardline,
-      path.call(print, 'cases')
-    ];
+    return ['switch ', print('expression'), hardline, print('cases')];
   }
 }

--- a/src/slang-nodes/YulValueCase.ts
+++ b/src/slang-nodes/YulValueCase.ts
@@ -30,6 +30,6 @@ export class YulValueCase extends SlangNode {
   }
 
   print(path: AstPath<YulValueCase>, print: PrintFunction): Doc {
-    return ['case ', path.call(print, 'value'), ' ', path.call(print, 'body')];
+    return ['case ', print('value'), ' ', print('body')];
   }
 }

--- a/src/slang-nodes/YulValueCase.ts
+++ b/src/slang-nodes/YulValueCase.ts
@@ -5,7 +5,7 @@ import { YulLiteral } from './YulLiteral.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -29,7 +29,7 @@ export class YulValueCase extends SlangNode {
     this.updateMetadata(this.value, this.body);
   }
 
-  print(path: AstPath<YulValueCase>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return ['case ', print('value'), ' ', print('body')];
   }
 }

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -7,7 +7,7 @@ import { YulAssignmentOperator } from './YulAssignmentOperator.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -40,10 +40,7 @@ export class YulVariableAssignmentStatement extends SlangNode {
     this.updateMetadata(this.variables, this.assignment, this.expression);
   }
 
-  print(
-    path: AstPath<YulVariableAssignmentStatement>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return join(' ', [
       print('variables'),
       print('assignment'),

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -45,9 +45,9 @@ export class YulVariableAssignmentStatement extends SlangNode {
     print: PrintFunction
   ): Doc {
     return join(' ', [
-      path.call(print, 'variables'),
-      path.call(print, 'assignment'),
-      path.call(print, 'expression')
+      print('variables'),
+      print('assignment'),
+      print('expression')
     ]);
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -5,7 +5,7 @@ import { YulVariableDeclarationValue } from './YulVariableDeclarationValue.js';
 import { YulVariableNames } from './YulVariableNames.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -35,10 +35,7 @@ export class YulVariableDeclarationStatement extends SlangNode {
     this.updateMetadata(this.value);
   }
 
-  print(
-    path: AstPath<YulVariableDeclarationStatement>,
-    print: PrintFunction
-  ): Doc {
+  print(print: PrintFunction): Doc {
     return joinExisting(' ', [['let', print('variables')], print('value')]);
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -39,9 +39,6 @@ export class YulVariableDeclarationStatement extends SlangNode {
     path: AstPath<YulVariableDeclarationStatement>,
     print: PrintFunction
   ): Doc {
-    return joinExisting(' ', [
-      ['let', path.call(print, 'variables')],
-      path.call(print, 'value')
-    ]);
+    return joinExisting(' ', [['let', print('variables')], print('value')]);
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationValue.ts
+++ b/src/slang-nodes/YulVariableDeclarationValue.ts
@@ -34,10 +34,6 @@ export class YulVariableDeclarationValue extends SlangNode {
   }
 
   print(path: AstPath<YulVariableDeclarationValue>, print: PrintFunction): Doc {
-    return [
-      path.call(print, 'assignment'),
-      ' ',
-      path.call(print, 'expression')
-    ];
+    return [print('assignment'), ' ', print('expression')];
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationValue.ts
+++ b/src/slang-nodes/YulVariableDeclarationValue.ts
@@ -5,7 +5,7 @@ import { YulAssignmentOperator } from './YulAssignmentOperator.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
@@ -33,7 +33,7 @@ export class YulVariableDeclarationValue extends SlangNode {
     this.updateMetadata(this.assignment, this.expression);
   }
 
-  print(path: AstPath<YulVariableDeclarationValue>, print: PrintFunction): Doc {
+  print(print: PrintFunction): Doc {
     return [print('assignment'), ' ', print('expression')];
   }
 }

--- a/src/slang-nodes/YulVariableNames.ts
+++ b/src/slang-nodes/YulVariableNames.ts
@@ -21,7 +21,7 @@ export class YulVariableNames extends SlangNode {
     this.items = ast.items.map((item) => new TerminalNode(item, collected));
   }
 
-  print(path: AstPath<YulVariableNames>, print: PrintFunction): Doc {
+  print(print: PrintFunction, path: AstPath<YulVariableNames>): Doc {
     return printSeparatedList(path.map(print, 'items'), {
       firstSeparator: line,
       lastSeparator: ''

--- a/src/slang-printers/create-binary-operation-printer.ts
+++ b/src/slang-printers/create-binary-operation-printer.ts
@@ -14,7 +14,7 @@ function rightOperandPrint(
   print: PrintFunction,
   options: ParserOptions<PrintableNode>
 ): Doc {
-  const rightOperand = path.call(print, 'rightOperand');
+  const rightOperand = print('rightOperand');
   const rightOperandDoc =
     options.experimentalOperatorPosition === 'end'
       ? [` ${operator}`, line, rightOperand]
@@ -49,7 +49,7 @@ export const createBinaryOperationPrinter =
     const indentRules = indentRulesBuilder(node, path);
 
     return groupRules([
-      path.call(print, 'leftOperand'),
+      print('leftOperand'),
       indentRules(rightOperandPrint(node, path, print, options))
     ]);
   };

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -18,13 +18,10 @@ export function printFunction(
 
   return group([
     functionName,
-    path.call(print, 'parameters'),
+    print('parameters'),
     indent(
       group([
-        joinExisting(line, [
-          path.call(print, 'attributes'),
-          path.call(print, 'returns')
-        ]),
+        joinExisting(line, [print('attributes'), print('returns')]),
         body && body.kind === NonterminalKind.Block ? dedent(line) : ''
       ])
     )
@@ -37,8 +34,5 @@ export function printFunctionWithBody(
   path: AstPath<FunctionWithBody>,
   print: PrintFunction
 ): Doc {
-  return [
-    printFunction(functionName, node, path, print),
-    path.call(print, 'body')
-  ];
+  return [printFunction(functionName, node, path, print), print('body')];
 }

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -13,15 +13,15 @@ export function printFunction(
   node: FunctionLike,
   print: PrintFunction
 ): Doc {
-  const body = (node as FunctionWithBody).body;
-
   return group([
     functionName,
     print('parameters'),
     indent(
       group([
         joinExisting(line, [print('attributes'), print('returns')]),
-        body && body.kind === NonterminalKind.Block ? dedent(line) : ''
+        (node as FunctionWithBody).body?.kind === NonterminalKind.Block
+          ? dedent(line)
+          : ''
       ])
     )
   ]);

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { joinExisting } from '../slang-utils/join-existing.js';
 
-import type { AstPath, Doc } from 'prettier';
+import type { Doc } from 'prettier';
 import type { FunctionLike, FunctionWithBody } from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
 
@@ -11,7 +11,6 @@ const { dedent, group, indent, line } = doc.builders;
 export function printFunction(
   functionName: Doc,
   node: FunctionLike,
-  path: AstPath<FunctionLike>,
   print: PrintFunction
 ): Doc {
   const body = (node as FunctionWithBody).body;
@@ -31,8 +30,7 @@ export function printFunction(
 export function printFunctionWithBody(
   functionName: Doc,
   node: FunctionLike,
-  path: AstPath<FunctionWithBody>,
   print: PrintFunction
 ): Doc {
-  return [printFunction(functionName, node, path, print), print('body')];
+  return [printFunction(functionName, node, print), print('body')];
 }

--- a/src/slang-printers/print-preserving-empty-lines.ts
+++ b/src/slang-printers/print-preserving-empty-lines.ts
@@ -24,7 +24,7 @@ export function printPreservingEmptyLines(
           node.kind !== NonterminalKind.YulLabel
             ? hardline
             : '',
-          print(path),
+          print(),
           // Only attempt to append an empty line if `node` is not the last item
           !isLast &&
           // Append an empty line if the original text already had an one after the

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -12,7 +12,7 @@ function genericPrint(
   // Since each node has a print function with a specific AstPath, the union of
   // all nodes in PrintableNode creates a print function with an AstPath of the
   // intersection of all nodes. This forces us to cast this with a never type.
-  return path.node.print(path as AstPath<never>, print, options);
+  return path.node.print(print, path as AstPath<never>, options);
 }
 
 export default genericPrint;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,7 +24,13 @@ interface AstLocation extends Location {
   outerEnd: number;
 }
 
-type PrintFunction = (path: AstPath<PrintableNode | undefined>) => Doc;
+type PrintFunction = (
+  selector?:
+    | string
+    | number
+    | (string | number)[]
+    | AstPath<PrintableNode | undefined>
+) => Doc;
 
 // This the union of all the types in the namespace `ast`.
 type TypeOfAst = typeof ast;


### PR DESCRIPTION
Since Prettier 2.3.0 the `print` argument for the `print` function has a new [signature](https://prettier.io/docs/plugins#print) and since it was backwards compatible, we never noticed 😅, however we can now take advantage of this and have a way less polluted environment and smaller build.


```TypeScript
function print(
  // Path to the AST node to print
  path: AstPath,
  options: object,
  // Recursively print a child node
  print: (selector?: string | number | Array<string | number> | AstPath) => Doc,
): Doc;
```

This opens the possibility to shorten the call `path.call(print, 'selector')` to `print('selector')` making our code much cleaner.

This PR has 2 steps:

1. Change all instances of `path.call(print, 'selector')` to `print('selector')`
2. Remove all unused references to `path` that are no longer needed

For the second step, was necessary to change the signature of the `print` function of each node so the `path` parameter would come after the `print` parameter and therefore removable when not used.

```TypeScript
  // Before
  print(
    path: AstPath<AdditiveExpression>,
    print: PrintFunction,
    options: ParserOptions<AstNode>
  ): Doc {
    return printAdditiveExpression(this, path, print, options);
  }

  print(path: AstPath<ArrayExpression>, print: PrintFunction): Doc {
    return ['[', path.call(print, 'items'), ']'];
  }

  // After
  print(
    print: PrintFunction,
    path: AstPath<AdditiveExpression>,
    options: ParserOptions<AstNode>
  ): Doc {
    return printAdditiveExpression(this, path, print, options);
  }
  
  print(print: PrintFunction): Doc {
    return ['[', print('items'), ']'];
  }
```

I tested these changes with prettier 3.0.0 and it was supported back then.

Caveats:
The prettier team hasn't updated their TypeScript declarations for this function so at one point I had to cast it to the old signature that they provide. [I made a PR to their project.](https://github.com/prettier/prettier/pull/19014)

There is a loss of type checking as `path.call(print, 'name')` checks that the current node has a node called `name` and that the `print` function is equiped to receive said node to be printed.
However after having seen @fisker comment, prettier checks just before printing that the node exist on runtime (**only when we are using prettier's on development**).