### PR TITLE
delegating printing nodes with `prettier-ignore` to prettier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import slangParse from './slangSolidityParser.js';
 import slangPrint from './slangPrinter.js';
 import { isBlockComment, isComment } from './slang-utils/is-comment.js';
 import { locEnd, locStart } from './slang-utils/loc.js';
+import { hasPrettierIgnore } from './slang-utils/has-prettier-ignore.js';
 
 import type {
   Parser,
@@ -78,6 +79,7 @@ const slangPrinter: Printer<AstNode> = {
   isBlockComment,
   massageAstNode,
   print: slangPrint,
+  hasPrettierIgnore,
   printComment
 };
 

--- a/src/slang-utils/has-prettier-ignore.ts
+++ b/src/slang-utils/has-prettier-ignore.ts
@@ -1,0 +1,20 @@
+import { isBlockComment, isComment } from './is-comment.js';
+
+import type { AstPath } from 'prettier';
+import type { AstNode } from '../slang-nodes/types.js';
+
+export function hasPrettierIgnore({ node }: AstPath<AstNode>): boolean {
+  if (typeof node === 'string' || node === undefined || isComment(node))
+    return false;
+
+  // Prettier sets SourceUnit's comments to undefined after assigning comments
+  // to each node.
+  return Boolean(
+    node.comments?.some(
+      (comment) =>
+        comment.value
+          .slice(2, isBlockComment(comment) ? -2 : undefined)
+          .trim() === 'prettier-ignore'
+    )
+  );
+}

--- a/src/slangPrinter.ts
+++ b/src/slangPrinter.ts
@@ -1,6 +1,3 @@
-import { isBlockComment } from './slang-utils/is-comment.js';
-import { locEnd, locStart } from './slang-utils/loc.js';
-
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type {
   AstNode,
@@ -9,53 +6,6 @@ import type {
 } from './slang-nodes/types.d.ts';
 import type { PrintFunction } from './types.d.ts';
 
-function hasNodeIgnoreComment({ comments }: StrictAstNode): boolean {
-  // Prettier sets SourceUnit's comments to undefined after assigning comments
-  // to each node.
-  return Boolean(
-    comments?.some(
-      (comment) =>
-        comment.value
-          .slice(2, isBlockComment(comment) ? -2 : undefined)
-          .trim() === 'prettier-ignore'
-    )
-  );
-}
-
-function ignoreComments(path: AstPath<StrictAstNode>): void {
-  const node = path.node;
-  // We ignore anything that is not an object
-  if (node === null || typeof node !== 'object') return;
-
-  let key: keyof StrictAstNode;
-  for (key in node) {
-    switch (key) {
-      // We ignore `kind` and `loc` since these are added by the parser.
-      // `updateMetadata` is an internal function.
-      case 'kind':
-      case 'loc':
-      case 'updateMetadata':
-        break;
-      // The key `comments` will contain every comment for this node.
-      case 'comments':
-        if (node.comments !== undefined) {
-          path.each(({ node }) => (node.printed = true), key);
-        }
-        break;
-      default:
-        // If the value for that key is an Array or an Object we go deeper.
-        const childNode = node[key];
-        if (typeof childNode === 'object') {
-          if (Array.isArray(childNode)) {
-            path.each(ignoreComments, key);
-            break;
-          }
-          path.call(ignoreComments, key);
-        }
-    }
-  }
-}
-
 // Nodes take care of undefined and string properties so we can restrict path
 // to AstPath<StrictAstNode>
 function genericPrint(
@@ -63,18 +13,10 @@ function genericPrint(
   options: ParserOptions<AstNode>,
   print: PrintFunction
 ): Doc {
-  const node = path.node;
-
-  if (hasNodeIgnoreComment(node)) {
-    ignoreComments(path);
-
-    return options.originalText.slice(locStart(node), locEnd(node));
-  }
-
   // Since each node has a print function with a specific AstPath, the union of
   // all nodes into AstNode creates a print function with an AstPath of the
   // intersection of all nodes. This forces us to cast this with a never type.
-  return node.print(path as AstPath<never>, print, options);
+  return path.node.print(path as AstPath<never>, print, options);
 }
 
 export default genericPrint;


### PR DESCRIPTION
`hasPrettierIgnore` has been documented since prettier 3.7.0 but has been in the `types` and in the code since at least prettier 3.0.0

this way we won't need to maintain `ignoreComments`.

I tested this with prettier 3.0.0 and it was supported back then.