### PR TITLE
Removing joinExisting

### DIFF
--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -41,8 +41,8 @@ export class AssemblyStatement extends SlangNode {
     const flagsDoc = print('flags');
     return [
       'assembly ',
-      labelDoc ? [labelDoc, ' '] : '',
-      flagsDoc ? [flagsDoc, ' '] : '',
+      labelDoc ? [labelDoc, ' '] : labelDoc,
+      flagsDoc ? [flagsDoc, ' '] : flagsDoc,
       print('body')
     ];
   }

--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
 import { AssemblyFlagsDeclaration } from './AssemblyFlagsDeclaration.js';
@@ -38,11 +37,13 @@ export class AssemblyStatement extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [
-      'assembly',
-      print('label'),
-      print('flags'),
+    const labelDoc = print('label');
+    const flagsDoc = print('flags');
+    return [
+      'assembly ',
+      labelDoc ? [labelDoc, ' '] : '',
+      flagsDoc ? [flagsDoc, ' '] : '',
       print('body')
-    ]);
+    ];
   }
 }

--- a/src/slang-nodes/ConstructorDefinition.ts
+++ b/src/slang-nodes/ConstructorDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 import { ConstructorAttributes } from './ConstructorAttributes.js';
@@ -42,6 +42,6 @@ export class ConstructorDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody('constructor', this, print);
+    return printFunction('constructor', this, print);
   }
 }

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -60,9 +60,8 @@ export class ContractDefinition extends SlangNode {
 
   print(print: PrintFunction): Doc {
     return [
+      `${this.abstractKeyword ? 'abstract ' : ''}contract `,
       group([
-        this.abstractKeyword ? 'abstract ' : '',
-        'contract ',
         print('name'),
         print('specifiers'),
         this.specifiers.items.length > 0 ? '' : line,

--- a/src/slang-nodes/DecimalNumberExpression.ts
+++ b/src/slang-nodes/DecimalNumberExpression.ts
@@ -26,6 +26,6 @@ export class DecimalNumberExpression extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const unitDoc = print('unit');
-    return [this.literal, unitDoc ? [' ', unitDoc] : ''];
+    return [this.literal, unitDoc ? [' ', unitDoc] : unitDoc];
   }
 }

--- a/src/slang-nodes/DecimalNumberExpression.ts
+++ b/src/slang-nodes/DecimalNumberExpression.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { SlangNode } from './SlangNode.js';
 import { NumberUnit } from './NumberUnit.js';
 
@@ -26,6 +25,7 @@ export class DecimalNumberExpression extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [this.literal, print('unit')]);
+    const unitDoc = print('unit');
+    return [this.literal, unitDoc ? [' ', unitDoc] : ''];
   }
 }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -35,6 +34,7 @@ export class ErrorParameter extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [print('typeName'), print('name')]);
+    const nameDoc = print('name');
+    return [print('typeName'), nameDoc ? [' ', nameDoc] : ''];
   }
 }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -35,6 +35,6 @@ export class ErrorParameter extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const nameDoc = print('name');
-    return [print('typeName'), nameDoc ? [' ', nameDoc] : ''];
+    return [print('typeName'), nameDoc ? [' ', nameDoc] : nameDoc];
   }
 }

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -38,10 +37,11 @@ export class EventParameter extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [
+    const nameDoc = print('name');
+    return [
       print('typeName'),
-      this.indexedKeyword,
-      print('name')
-    ]);
+      this.indexedKeyword ? ` ${this.indexedKeyword}` : '',
+      nameDoc ? [' ', nameDoc] : ''
+    ];
   }
 }

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -40,8 +40,8 @@ export class EventParameter extends SlangNode {
     const nameDoc = print('name');
     return [
       print('typeName'),
-      this.indexedKeyword ? ` ${this.indexedKeyword}` : '',
-      nameDoc ? [' ', nameDoc] : ''
+      this.indexedKeyword ? ' indexed' : '',
+      nameDoc ? [' ', nameDoc] : nameDoc
     ];
   }
 }

--- a/src/slang-nodes/FallbackFunctionDefinition.ts
+++ b/src/slang-nodes/FallbackFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -60,6 +60,6 @@ export class FallbackFunctionDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody('fallback', this, print);
+    return printFunction('fallback', this, print);
   }
 }

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { satisfies } from 'semver';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { FunctionName } from './FunctionName.js';
@@ -76,6 +76,6 @@ export class FunctionDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody(['function ', print('name')], this, print);
+    return printFunction(['function ', print('name')], this, print);
   }
 }

--- a/src/slang-nodes/HexNumberExpression.ts
+++ b/src/slang-nodes/HexNumberExpression.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { SlangNode } from './SlangNode.js';
 import { NumberUnit } from './NumberUnit.js';
 
@@ -26,6 +25,7 @@ export class HexNumberExpression extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [this.literal, print('unit')]);
+    const unitDoc = print('unit');
+    return [this.literal, unitDoc ? [' ', unitDoc] : ''];
   }
 }

--- a/src/slang-nodes/HexNumberExpression.ts
+++ b/src/slang-nodes/HexNumberExpression.ts
@@ -26,6 +26,6 @@ export class HexNumberExpression extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const unitDoc = print('unit');
-    return [this.literal, unitDoc ? [' ', unitDoc] : ''];
+    return [this.literal, unitDoc ? [' ', unitDoc] : unitDoc];
   }
 }

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -43,8 +43,8 @@ export class InterfaceDefinition extends SlangNode {
 
   print(print: PrintFunction): Doc {
     return [
+      'interface ',
       group([
-        'interface ',
         print('name'),
         this.inheritance ? [' ', print('inheritance')] : line,
         '{'

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -46,7 +46,8 @@ export class LibraryDefinition extends SlangNode {
 
   print(print: PrintFunction): Doc {
     return [
-      group(['library ', print('name'), line, '{']),
+      'library ',
+      group([print('name'), line, '{']),
       print('members'),
       '}'
     ];

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -28,6 +28,6 @@ export class MappingKey extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const nameDoc = print('name');
-    return [print('keyType'), nameDoc ? [' ', nameDoc] : ''];
+    return [print('keyType'), nameDoc ? [' ', nameDoc] : nameDoc];
   }
 }

--- a/src/slang-nodes/MappingKey.ts
+++ b/src/slang-nodes/MappingKey.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { MappingKeyType } from './MappingKeyType.js';
@@ -28,6 +27,7 @@ export class MappingKey extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [print('keyType'), print('name')]);
+    const nameDoc = print('name');
+    return [print('keyType'), nameDoc ? [' ', nameDoc] : ''];
   }
 }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -35,6 +35,6 @@ export class MappingValue extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const nameDoc = print('name');
-    return [print('typeName'), nameDoc ? [' ', nameDoc] : ''];
+    return [print('typeName'), nameDoc ? [' ', nameDoc] : nameDoc];
   }
 }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -35,6 +34,7 @@ export class MappingValue extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [print('typeName'), print('name')]);
+    const nameDoc = print('name');
+    return [print('typeName'), nameDoc ? [' ', nameDoc] : ''];
   }
 }

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -78,6 +78,6 @@ export class ModifierDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody(['modifier ', print('name')], this, print);
+    return printFunction(['modifier ', print('name')], this, print);
   }
 }

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -1,6 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -47,12 +46,12 @@ export class Parameter extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return group(
-      joinExisting(' ', [
-        print('typeName'),
-        print('storageLocation'),
-        print('name')
-      ])
-    );
+    const storageLocationDoc = print('storageLocation');
+    const nameDoc = print('name');
+    return group([
+      print('typeName'),
+      storageLocationDoc ? [' ', storageLocationDoc] : '',
+      nameDoc ? [' ', nameDoc] : ''
+    ]);
   }
 }

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -50,8 +50,8 @@ export class Parameter extends SlangNode {
     const nameDoc = print('name');
     return group([
       print('typeName'),
-      storageLocationDoc ? [' ', storageLocationDoc] : '',
-      nameDoc ? [' ', nameDoc] : ''
+      storageLocationDoc ? [' ', storageLocationDoc] : storageLocationDoc,
+      nameDoc ? [' ', nameDoc] : nameDoc
     ]);
   }
 }

--- a/src/slang-nodes/ReceiveFunctionDefinition.ts
+++ b/src/slang-nodes/ReceiveFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -49,6 +49,6 @@ export class ReceiveFunctionDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody('receive', this, print);
+    return printFunction('receive', this, print);
   }
 }

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -58,7 +58,7 @@ export class TryStatement extends SlangNode {
         firstSeparator: line
       }),
       [
-        returnsDoc ? [returnsDoc, ' '] : '',
+        returnsDoc ? [returnsDoc, ' '] : returnsDoc,
         print('body'),
         ' ',
         print('catchClauses')

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
@@ -52,16 +51,18 @@ export class TryStatement extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
+    const returnsDoc = print('returns');
     return [
       'try',
       printSeparatedItem(print('expression'), {
         firstSeparator: line
       }),
-      joinExisting(' ', [
-        print('returns'),
+      [
+        returnsDoc ? [returnsDoc, ' '] : '',
         print('body'),
+        ' ',
         print('catchClauses')
-      ])
+      ]
     ];
   }
 }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -42,10 +41,12 @@ export class TypedTupleMember extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [
+    const storageLocationDoc = print('storageLocation');
+    return [
       print('typeName'),
-      print('storageLocation'),
+      storageLocationDoc ? [' ', storageLocationDoc] : '',
+      ' ',
       print('name')
-    ]);
+    ];
   }
 }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -44,7 +44,7 @@ export class TypedTupleMember extends SlangNode {
     const storageLocationDoc = print('storageLocation');
     return [
       print('typeName'),
-      storageLocationDoc ? [' ', storageLocationDoc] : '',
+      storageLocationDoc ? [' ', storageLocationDoc] : storageLocationDoc,
       ' ',
       print('name')
     ];

--- a/src/slang-nodes/UnnamedFunctionDefinition.ts
+++ b/src/slang-nodes/UnnamedFunctionDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { printFunctionWithBody } from '../slang-printers/print-function.js';
+import { printFunction } from '../slang-printers/print-function.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -49,6 +49,6 @@ export class UnnamedFunctionDefinition extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return printFunctionWithBody('function', this, print);
+    return printFunction('function', this, print);
   }
 }

--- a/src/slang-nodes/UntypedTupleMember.ts
+++ b/src/slang-nodes/UntypedTupleMember.ts
@@ -30,6 +30,9 @@ export class UntypedTupleMember extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const storageLocationDoc = print('storageLocation');
-    return [storageLocationDoc ? [storageLocationDoc, ' '] : '', print('name')];
+    return [
+      storageLocationDoc ? [storageLocationDoc, ' '] : storageLocationDoc,
+      print('name')
+    ];
   }
 }

--- a/src/slang-nodes/UntypedTupleMember.ts
+++ b/src/slang-nodes/UntypedTupleMember.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { SlangNode } from './SlangNode.js';
 import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -30,6 +29,7 @@ export class UntypedTupleMember extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [print('storageLocation'), print('name')]);
+    const storageLocationDoc = print('storageLocation');
+    return [storageLocationDoc ? [storageLocationDoc, ' '] : '', print('name')];
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -36,6 +36,6 @@ export class YulVariableDeclarationStatement extends SlangNode {
 
   print(print: PrintFunction): Doc {
     const valueDoc = print('value');
-    return ['let', print('variables'), valueDoc ? [' ', valueDoc] : ''];
+    return ['let', print('variables'), valueDoc ? [' ', valueDoc] : valueDoc];
   }
 }

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -1,5 +1,4 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { SlangNode } from './SlangNode.js';
 import { YulVariableDeclarationValue } from './YulVariableDeclarationValue.js';
 import { YulVariableNames } from './YulVariableNames.js';
@@ -36,6 +35,7 @@ export class YulVariableDeclarationStatement extends SlangNode {
   }
 
   print(print: PrintFunction): Doc {
-    return joinExisting(' ', [['let', print('variables')], print('value')]);
+    const valueDoc = print('value');
+    return ['let', print('variables'), valueDoc ? [' ', valueDoc] : ''];
   }
 }

--- a/src/slang-printers/print-comments.ts
+++ b/src/slang-printers/print-comments.ts
@@ -1,12 +1,11 @@
 import { doc, util } from 'prettier';
 import { printComment } from '../slang-comments/printer.js';
-import { joinExisting } from '../slang-utils/join-existing.js';
 import { locEnd } from '../slang-utils/loc.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from '../slang-nodes/types.d.ts';
 
-const { hardline, line } = doc.builders;
+const { hardline } = doc.builders;
 
 function isPrintable(comment: Comment): boolean {
   return !comment.trailing && !comment.leading && !comment.printed;
@@ -21,20 +20,21 @@ export function printComments(
   if (lastPrintableIndex === -1) {
     return [];
   }
-  return joinExisting(
-    line,
-    path.map(({ node: comment }, index) => {
-      if (!isPrintable(comment)) {
-        return '';
-      }
-      comment.printed = true;
-      return [
-        printComment(path),
-        index !== lastPrintableIndex &&
-        util.isNextLineEmpty(options.originalText, locEnd(comment))
-          ? hardline
-          : ''
-      ];
-    }, 'comments')
-  );
+  return path.map(({ node: comment }, index) => {
+    if (!isPrintable(comment)) {
+      return '';
+    }
+    comment.printed = true;
+    return [
+      printComment(path),
+      index !== lastPrintableIndex
+        ? [
+            hardline,
+            util.isNextLineEmpty(options.originalText, locEnd(comment))
+              ? hardline
+              : ''
+          ]
+        : ''
+    ];
+  }, 'comments');
 }

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -20,7 +20,7 @@ export function printFunction(
       indent(
         group([
           print('attributes'),
-          returnsDoc ? [line, returnsDoc] : '',
+          returnsDoc ? [line, returnsDoc] : returnsDoc,
           (node as FunctionWithBody).body?.kind === NonterminalKind.Block
             ? dedent(line)
             : ''

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -1,6 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { joinExisting } from '../slang-utils/join-existing.js';
 
 import type { Doc } from 'prettier';
 import type { FunctionLike, FunctionWithBody } from '../slang-nodes/types.d.ts';
@@ -13,24 +12,21 @@ export function printFunction(
   node: FunctionLike,
   print: PrintFunction
 ): Doc {
-  return group([
-    functionName,
-    print('parameters'),
-    indent(
-      group([
-        joinExisting(line, [print('attributes'), print('returns')]),
-        (node as FunctionWithBody).body?.kind === NonterminalKind.Block
-          ? dedent(line)
-          : ''
-      ])
-    )
-  ]);
-}
-
-export function printFunctionWithBody(
-  functionName: Doc,
-  node: FunctionLike,
-  print: PrintFunction
-): Doc {
-  return [printFunction(functionName, node, print), print('body')];
+  const returnsDoc = print('returns');
+  return [
+    group([
+      functionName,
+      print('parameters'),
+      indent(
+        group([
+          print('attributes'),
+          returnsDoc ? [line, returnsDoc] : '',
+          (node as FunctionWithBody).body?.kind === NonterminalKind.Block
+            ? dedent(line)
+            : ''
+        ])
+      )
+    ]),
+    print('body')
+  ];
 }

--- a/src/slang-utils/join-existing.ts
+++ b/src/slang-utils/join-existing.ts
@@ -1,9 +1,0 @@
-import { doc } from 'prettier';
-
-import type { Doc } from 'prettier';
-
-const { join } = doc.builders;
-
-export function joinExisting(sep: Doc, docs: (Doc | undefined)[]): Doc[] {
-  return join(sep, docs.filter(Boolean) as Doc[]);
-}


### PR DESCRIPTION
`joinExisting` iterates over each array twice, filtering for truthy values and joining filtered items.
It also adds extra file size when importing.

Storing the printed value in a variable and make use of the falsy value of an empty string `''`, allows us to have only iterate once per item and we save some file size as well.