### PR TITLE
parser options should be a part of collected metadata

### DIFF
--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -35,19 +35,15 @@ export class AdditiveExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.AdditiveExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AdditiveExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/AndExpression.ts
+++ b/src/slang-nodes/AndExpression.ts
@@ -18,19 +18,15 @@ export class AndExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.AndExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AndExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -5,9 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { PositionalArgumentsDeclaration } from './PositionalArgumentsDeclaration.js';
 import { NamedArgumentsDeclaration } from './NamedArgumentsDeclaration.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ArgumentsDeclaration,
@@ -22,14 +20,10 @@ export class ArgumentsDeclaration extends SlangNode {
 
   variant: PositionalArgumentsDeclaration | NamedArgumentsDeclaration;
 
-  constructor(
-    ast: ast.ArgumentsDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ArgumentsDeclaration, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ArrayExpression.ts
+++ b/src/slang-nodes/ArrayExpression.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { ArrayValues } from './ArrayValues.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ArrayExpression extends SlangNode {
   readonly kind = NonterminalKind.ArrayExpression;
 
   items: ArrayValues;
 
-  constructor(
-    ast: ast.ArrayExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ArrayExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.items = new ArrayValues(ast.items, collected, options);
+    this.items = new ArrayValues(ast.items, collected);
 
     this.updateMetadata(this.items);
   }

--- a/src/slang-nodes/ArrayTypeName.ts
+++ b/src/slang-nodes/ArrayTypeName.ts
@@ -5,9 +5,8 @@ import { TypeName } from './TypeName.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ArrayTypeName extends SlangNode {
   readonly kind = NonterminalKind.ArrayTypeName;
@@ -16,20 +15,12 @@ export class ArrayTypeName extends SlangNode {
 
   index?: Expression['variant'];
 
-  constructor(
-    ast: ast.ArrayTypeName,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ArrayTypeName, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new TypeName(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new TypeName(ast.operand, collected));
     if (ast.index) {
-      this.index = extractVariant(
-        new Expression(ast.index, collected, options)
-      );
+      this.index = extractVariant(new Expression(ast.index, collected));
     }
 
     this.updateMetadata(this.operand, this.index);

--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -5,24 +5,19 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ArrayValues extends SlangNode {
   readonly kind = NonterminalKind.ArrayValues;
 
   items: Expression['variant'][];
 
-  constructor(
-    ast: ast.ArrayValues,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ArrayValues, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new Expression(item, collected, options))
+      extractVariant(new Expression(item, collected))
     );
   }
 

--- a/src/slang-nodes/AssemblyFlags.ts
+++ b/src/slang-nodes/AssemblyFlags.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class AssemblyFlags extends SlangNode {
   readonly kind = NonterminalKind.AssemblyFlags;
 
   items: StringLiteral[];
 
-  constructor(
-    ast: ast.AssemblyFlags,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AssemblyFlags, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new StringLiteral(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new StringLiteral(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<AssemblyFlags>): Doc {

--- a/src/slang-nodes/AssemblyFlagsDeclaration.ts
+++ b/src/slang-nodes/AssemblyFlagsDeclaration.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { AssemblyFlags } from './AssemblyFlags.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class AssemblyFlagsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.AssemblyFlagsDeclaration;
 
   flags: AssemblyFlags;
 
-  constructor(
-    ast: ast.AssemblyFlagsDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AssemblyFlagsDeclaration, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.flags = new AssemblyFlags(ast.flags, collected, options);
+    this.flags = new AssemblyFlags(ast.flags, collected);
 
     this.updateMetadata(this.flags);
   }

--- a/src/slang-nodes/AssemblyStatement.ts
+++ b/src/slang-nodes/AssemblyStatement.ts
@@ -5,9 +5,8 @@ import { AssemblyFlagsDeclaration } from './AssemblyFlagsDeclaration.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class AssemblyStatement extends SlangNode {
   readonly kind = NonterminalKind.AssemblyStatement;
@@ -18,20 +17,16 @@ export class AssemblyStatement extends SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.AssemblyStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AssemblyStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.label) {
-      this.label = new StringLiteral(ast.label, collected, options);
+      this.label = new StringLiteral(ast.label, collected);
     }
     if (ast.flags) {
-      this.flags = new AssemblyFlagsDeclaration(ast.flags, collected, options);
+      this.flags = new AssemblyFlagsDeclaration(ast.flags, collected);
     }
-    this.body = new YulBlock(ast.body, collected, options);
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(this.label, this.flags, this.body);
   }

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class AssignmentExpression extends SlangNode {
   readonly kind = NonterminalKind.AssignmentExpression;
@@ -18,19 +17,15 @@ export class AssignmentExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.AssignmentExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.AssignmentExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -31,19 +31,15 @@ export class BitwiseAndExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.BitwiseAndExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.BitwiseAndExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -41,19 +41,15 @@ export class BitwiseOrExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.BitwiseOrExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.BitwiseOrExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -31,19 +31,15 @@ export class BitwiseXorExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.BitwiseXorExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.BitwiseXorExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/Block.ts
+++ b/src/slang-nodes/Block.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { Statements } from './Statements.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class Block extends SlangNode {
   readonly kind = NonterminalKind.Block;
 
   statements: Statements;
 
-  constructor(
-    ast: ast.Block,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Block, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.statements = new Statements(ast.statements, collected, options);
+    this.statements = new Statements(ast.statements, collected);
 
     this.updateMetadata(this.statements);
   }

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -16,16 +16,10 @@ export class CallOptions extends SlangNode {
 
   items: NamedArgument[];
 
-  constructor(
-    ast: ast.CallOptions,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.CallOptions, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new NamedArgument(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new NamedArgument(item, collected));
   }
 
   print(

--- a/src/slang-nodes/CallOptionsExpression.ts
+++ b/src/slang-nodes/CallOptionsExpression.ts
@@ -5,9 +5,8 @@ import { Expression } from './Expression.js';
 import { CallOptions } from './CallOptions.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class CallOptionsExpression extends SlangNode {
   readonly kind = NonterminalKind.CallOptionsExpression;
@@ -16,17 +15,11 @@ export class CallOptionsExpression extends SlangNode {
 
   options: CallOptions;
 
-  constructor(
-    ast: ast.CallOptionsExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.CallOptionsExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
-    this.options = new CallOptions(ast.options, collected, options);
+    this.operand = extractVariant(new Expression(ast.operand, collected));
+    this.options = new CallOptions(ast.options, collected);
 
     this.updateMetadata(this.operand, this.options);
   }

--- a/src/slang-nodes/CatchClause.ts
+++ b/src/slang-nodes/CatchClause.ts
@@ -4,9 +4,8 @@ import { CatchClauseError } from './CatchClauseError.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class CatchClause extends SlangNode {
   readonly kind = NonterminalKind.CatchClause;
@@ -15,17 +14,13 @@ export class CatchClause extends SlangNode {
 
   body: Block;
 
-  constructor(
-    ast: ast.CatchClause,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.CatchClause, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.error) {
-      this.error = new CatchClauseError(ast.error, collected, options);
+      this.error = new CatchClauseError(ast.error, collected);
     }
-    this.body = new Block(ast.body, collected, options);
+    this.body = new Block(ast.body, collected);
 
     this.updateMetadata(this.error, this.body);
   }

--- a/src/slang-nodes/CatchClauseError.ts
+++ b/src/slang-nodes/CatchClauseError.ts
@@ -5,9 +5,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group } = doc.builders;
 
@@ -18,21 +17,13 @@ export class CatchClauseError extends SlangNode {
 
   parameters: ParametersDeclaration;
 
-  constructor(
-    ast: ast.CatchClauseError,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.CatchClauseError, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.name) {
       this.name = new TerminalNode(ast.name, collected);
     }
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
 
     this.updateMetadata(this.parameters);
   }

--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { CatchClause } from './CatchClause.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join } = doc.builders;
 
@@ -15,16 +14,10 @@ export class CatchClauses extends SlangNode {
 
   items: CatchClause[];
 
-  constructor(
-    ast: ast.CatchClauses,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.CatchClauses, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new CatchClause(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new CatchClause(item, collected));
 
     this.updateMetadata(...this.items);
   }

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -114,21 +114,15 @@ export class ConditionalExpression extends SlangNode {
 
   falseExpression: Expression['variant'];
 
-  constructor(
-    ast: ast.ConditionalExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ConditionalExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
     this.trueExpression = extractVariant(
-      new Expression(ast.trueExpression, collected, options)
+      new Expression(ast.trueExpression, collected)
     );
     this.falseExpression = extractVariant(
-      new Expression(ast.falseExpression, collected, options)
+      new Expression(ast.falseExpression, collected)
     );
 
     this.updateMetadata(
@@ -137,7 +131,7 @@ export class ConditionalExpression extends SlangNode {
       this.falseExpression
     );
 
-    if (options.experimentalTernaries) {
+    if (collected.options.experimentalTernaries) {
       // We can remove parentheses only because we are sure that the
       // `condition` must be a single `bool` value.
       const operandLoc = this.operand.loc;

--- a/src/slang-nodes/ConstantDefinition.ts
+++ b/src/slang-nodes/ConstantDefinition.ts
@@ -7,9 +7,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ConstantDefinition extends SlangNode {
   readonly kind = NonterminalKind.ConstantDefinition;
@@ -20,18 +19,12 @@ export class ConstantDefinition extends SlangNode {
 
   value: Expression['variant'];
 
-  constructor(
-    ast: ast.ConstantDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ConstantDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     this.name = new TerminalNode(ast.name, collected);
-    this.value = extractVariant(new Expression(ast.value, collected, options));
+    this.value = extractVariant(new Expression(ast.value, collected));
 
     this.updateMetadata(this.typeName, this.value);
   }

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -7,20 +7,14 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ConstructorAttribute extends SlangNode {
   readonly kind = NonterminalKind.ConstructorAttribute;
 
   variant: ModifierInvocation | TerminalNode;
 
-  constructor(
-    ast: ast.ConstructorAttribute,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ConstructorAttribute, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -28,7 +22,7 @@ export class ConstructorAttribute extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = new ModifierInvocation(variant, collected, options);
+    this.variant = new ModifierInvocation(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { ConstructorAttribute } from './ConstructorAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -17,15 +16,11 @@ export class ConstructorAttributes extends SlangNode {
 
   items: ConstructorAttribute['variant'][];
 
-  constructor(
-    ast: ast.ConstructorAttributes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ConstructorAttributes, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ConstructorAttribute(item, collected, options))
+      extractVariant(new ConstructorAttribute(item, collected))
     );
 
     this.items.sort(sortFunctionAttributes);

--- a/src/slang-nodes/ConstructorDefinition.ts
+++ b/src/slang-nodes/ConstructorDefinition.ts
@@ -6,9 +6,8 @@ import { ConstructorAttributes } from './ConstructorAttributes.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ConstructorDefinition extends SlangNode {
   readonly kind = NonterminalKind.ConstructorDefinition;
@@ -19,24 +18,12 @@ export class ConstructorDefinition extends SlangNode {
 
   body: Block;
 
-  constructor(
-    ast: ast.ConstructorDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ConstructorDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
-    this.attributes = new ConstructorAttributes(
-      ast.attributes,
-      collected,
-      options
-    );
-    this.body = new Block(ast.body, collected, options);
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
+    this.attributes = new ConstructorAttributes(ast.attributes, collected);
+    this.body = new Block(ast.body, collected);
 
     this.updateMetadata(this.parameters, this.attributes, this.body);
   }

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -7,9 +7,8 @@ import { ContractSpecifiers } from './ContractSpecifiers.js';
 import { ContractMembers } from './ContractMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group, line } = doc.builders;
 
@@ -24,21 +23,13 @@ export class ContractDefinition extends SlangNode {
 
   members: ContractMembers;
 
-  constructor(
-    ast: ast.ContractDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ContractDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.abstractKeyword = ast.abstractKeyword?.unparse();
     this.name = new TerminalNode(ast.name, collected);
-    this.specifiers = new ContractSpecifiers(
-      ast.specifiers,
-      collected,
-      options
-    );
-    this.members = new ContractMembers(ast.members, collected, options);
+    this.specifiers = new ContractSpecifiers(ast.specifiers, collected);
+    this.members = new ContractMembers(ast.members, collected);
 
     this.updateMetadata(this.specifiers, this.members);
 
@@ -46,7 +37,7 @@ export class ContractDefinition extends SlangNode {
     // the same name as the contract.
     // So we delegate to the parents the responsibility of cleaning the
     // arguments of modifier invocations.
-    if (!satisfies(options.compiler, '>=0.5.0')) {
+    if (!satisfies(collected.options.compiler, '>=0.5.0')) {
       for (const member of this.members.items) {
         if (
           member.kind === NonterminalKind.FunctionDefinition &&

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -16,9 +16,7 @@ import { StateVariableDefinition } from './StateVariableDefinition.js';
 import { ErrorDefinition } from './ErrorDefinition.js';
 import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ContractMember,
@@ -57,14 +55,10 @@ export class ContractMember extends SlangNode {
     | ErrorDefinition
     | UserDefinedValueTypeDefinition;
 
-  constructor(
-    ast: ast.ContractMember,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ContractMember, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -14,15 +14,11 @@ export class ContractMembers extends SlangNode {
 
   items: ContractMember['variant'][];
 
-  constructor(
-    ast: ast.ContractMembers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ContractMembers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected, options))
+      extractVariant(new ContractMember(item, collected))
     );
   }
 

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -5,9 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { StorageLayoutSpecifier } from './StorageLayoutSpecifier.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ContractSpecifier,
@@ -22,14 +20,10 @@ export class ContractSpecifier extends SlangNode {
 
   variant: InheritanceSpecifier | StorageLayoutSpecifier;
 
-  constructor(
-    ast: ast.ContractSpecifier,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ContractSpecifier, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ContractSpecifiers.ts
+++ b/src/slang-nodes/ContractSpecifiers.ts
@@ -7,9 +7,8 @@ import { SlangNode } from './SlangNode.js';
 import { ContractSpecifier } from './ContractSpecifier.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group, ifBreak, line, softline } = doc.builders;
 
@@ -18,15 +17,11 @@ export class ContractSpecifiers extends SlangNode {
 
   items: ContractSpecifier['variant'][];
 
-  constructor(
-    ast: ast.ContractSpecifiers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ContractSpecifiers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ContractSpecifier(item, collected, options))
+      extractVariant(new ContractSpecifier(item, collected))
     );
 
     this.items.sort(sortContractSpecifiers);

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -7,9 +7,8 @@ import { Statement } from './Statement.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -20,17 +19,11 @@ export class DoWhileStatement extends SlangNode {
 
   condition: Expression['variant'];
 
-  constructor(
-    ast: ast.DoWhileStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.DoWhileStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.body = extractVariant(new Statement(ast.body, collected, options));
-    this.condition = extractVariant(
-      new Expression(ast.condition, collected, options)
-    );
+    this.body = extractVariant(new Statement(ast.body, collected));
+    this.condition = extractVariant(new Expression(ast.condition, collected));
 
     this.updateMetadata(this.body, this.condition);
   }

--- a/src/slang-nodes/ElseBranch.ts
+++ b/src/slang-nodes/ElseBranch.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const isIfStatementOrBlock = createKindCheckFunction([
   NonterminalKind.Block,
@@ -20,14 +19,10 @@ export class ElseBranch extends SlangNode {
 
   body: Statement['variant'];
 
-  constructor(
-    ast: ast.ElseBranch,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ElseBranch, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.body = extractVariant(new Statement(ast.body, collected, options));
+    this.body = extractVariant(new Statement(ast.body, collected));
 
     this.updateMetadata(this.body);
   }

--- a/src/slang-nodes/EmitStatement.ts
+++ b/src/slang-nodes/EmitStatement.ts
@@ -5,9 +5,8 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class EmitStatement extends SlangNode {
   readonly kind = NonterminalKind.EmitStatement;
@@ -16,16 +15,12 @@ export class EmitStatement extends SlangNode {
 
   arguments: ArgumentsDeclaration['variant'];
 
-  constructor(
-    ast: ast.EmitStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.EmitStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.event = new IdentifierPath(ast.event, collected);
     this.arguments = extractVariant(
-      new ArgumentsDeclaration(ast.arguments, collected, options)
+      new ArgumentsDeclaration(ast.arguments, collected)
     );
 
     this.updateMetadata(this.event, this.arguments);

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -29,19 +29,15 @@ export class EqualityExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.EqualityExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.EqualityExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/ErrorDefinition.ts
+++ b/src/slang-nodes/ErrorDefinition.ts
@@ -4,9 +4,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { ErrorParametersDeclaration } from './ErrorParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ErrorDefinition extends SlangNode {
   readonly kind = NonterminalKind.ErrorDefinition;
@@ -15,19 +14,11 @@ export class ErrorDefinition extends SlangNode {
 
   members: ErrorParametersDeclaration;
 
-  constructor(
-    ast: ast.ErrorDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ErrorDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
-    this.members = new ErrorParametersDeclaration(
-      ast.members,
-      collected,
-      options
-    );
+    this.members = new ErrorParametersDeclaration(ast.members, collected);
 
     this.updateMetadata(this.members);
   }

--- a/src/slang-nodes/ErrorParameter.ts
+++ b/src/slang-nodes/ErrorParameter.ts
@@ -5,9 +5,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ErrorParameter extends SlangNode {
   readonly kind = NonterminalKind.ErrorParameter;
@@ -16,16 +15,10 @@ export class ErrorParameter extends SlangNode {
 
   name?: TerminalNode;
 
-  constructor(
-    ast: ast.ErrorParameter,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ErrorParameter, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     if (ast.name) {
       this.name = new TerminalNode(ast.name, collected);
     }

--- a/src/slang-nodes/ErrorParameters.ts
+++ b/src/slang-nodes/ErrorParameters.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { ErrorParameter } from './ErrorParameter.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ErrorParameters extends SlangNode {
   readonly kind = NonterminalKind.ErrorParameters;
 
   items: ErrorParameter[];
 
-  constructor(
-    ast: ast.ErrorParameters,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ErrorParameters, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new ErrorParameter(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new ErrorParameter(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<ErrorParameters>): Doc {

--- a/src/slang-nodes/ErrorParametersDeclaration.ts
+++ b/src/slang-nodes/ErrorParametersDeclaration.ts
@@ -3,9 +3,8 @@ import { SlangNode } from './SlangNode.js';
 import { ErrorParameters } from './ErrorParameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ErrorParametersDeclaration extends SlangNode {
   readonly kind = NonterminalKind.ErrorParametersDeclaration;
@@ -14,12 +13,11 @@ export class ErrorParametersDeclaration extends SlangNode {
 
   constructor(
     ast: ast.ErrorParametersDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.parameters = new ErrorParameters(ast.parameters, collected, options);
+    this.parameters = new ErrorParameters(ast.parameters, collected);
 
     this.updateMetadata(this.parameters);
   }

--- a/src/slang-nodes/EventDefinition.ts
+++ b/src/slang-nodes/EventDefinition.ts
@@ -4,9 +4,8 @@ import { EventParametersDeclaration } from './EventParametersDeclaration.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class EventDefinition extends SlangNode {
   readonly kind = NonterminalKind.EventDefinition;
@@ -17,19 +16,11 @@ export class EventDefinition extends SlangNode {
 
   anonymousKeyword?: string;
 
-  constructor(
-    ast: ast.EventDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.EventDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
-    this.parameters = new EventParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
+    this.parameters = new EventParametersDeclaration(ast.parameters, collected);
     this.anonymousKeyword = ast.anonymousKeyword?.unparse();
 
     this.updateMetadata(this.parameters);

--- a/src/slang-nodes/EventParameter.ts
+++ b/src/slang-nodes/EventParameter.ts
@@ -5,9 +5,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class EventParameter extends SlangNode {
   readonly kind = NonterminalKind.EventParameter;
@@ -18,16 +17,10 @@ export class EventParameter extends SlangNode {
 
   name?: TerminalNode;
 
-  constructor(
-    ast: ast.EventParameter,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.EventParameter, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     this.indexedKeyword = ast.indexedKeyword?.unparse();
     if (ast.name) {
       this.name = new TerminalNode(ast.name, collected);

--- a/src/slang-nodes/EventParameters.ts
+++ b/src/slang-nodes/EventParameters.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { EventParameter } from './EventParameter.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class EventParameters extends SlangNode {
   readonly kind = NonterminalKind.EventParameters;
 
   items: EventParameter[];
 
-  constructor(
-    ast: ast.EventParameters,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.EventParameters, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new EventParameter(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new EventParameter(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<EventParameters>): Doc {

--- a/src/slang-nodes/EventParametersDeclaration.ts
+++ b/src/slang-nodes/EventParametersDeclaration.ts
@@ -3,9 +3,8 @@ import { SlangNode } from './SlangNode.js';
 import { EventParameters } from './EventParameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class EventParametersDeclaration extends SlangNode {
   readonly kind = NonterminalKind.EventParametersDeclaration;
@@ -14,12 +13,11 @@ export class EventParametersDeclaration extends SlangNode {
 
   constructor(
     ast: ast.EventParametersDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.parameters = new EventParameters(ast.parameters, collected, options);
+    this.parameters = new EventParameters(ast.parameters, collected);
 
     this.updateMetadata(this.parameters);
   }

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -7,20 +7,14 @@ import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ExperimentalFeature extends SlangNode {
   readonly kind = NonterminalKind.ExperimentalFeature;
 
   variant: StringLiteral | TerminalNode;
 
-  constructor(
-    ast: ast.ExperimentalFeature,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ExperimentalFeature, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -28,7 +22,7 @@ export class ExperimentalFeature extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = new StringLiteral(variant, collected, options);
+    this.variant = new StringLiteral(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ExperimentalPragma.ts
+++ b/src/slang-nodes/ExperimentalPragma.ts
@@ -4,24 +4,19 @@ import { SlangNode } from './SlangNode.js';
 import { ExperimentalFeature } from './ExperimentalFeature.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ExperimentalPragma extends SlangNode {
   readonly kind = NonterminalKind.ExperimentalPragma;
 
   feature: ExperimentalFeature['variant'];
 
-  constructor(
-    ast: ast.ExperimentalPragma,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ExperimentalPragma, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.feature = extractVariant(
-      new ExperimentalFeature(ast.feature, collected, options)
+      new ExperimentalFeature(ast.feature, collected)
     );
 
     this.updateMetadata(this.feature);

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -46,19 +46,15 @@ export class ExponentiationExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.ExponentiationExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ExponentiationExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -34,9 +34,7 @@ import { StringExpression } from './StringExpression.js';
 import { ElementaryType } from './ElementaryType.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantCreator<
   ast.Expression,
@@ -108,11 +106,7 @@ export class Expression extends SlangNode {
     | ElementaryType['variant']
     | TerminalNode;
 
-  constructor(
-    ast: ast.Expression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Expression, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -120,7 +114,7 @@ export class Expression extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ExpressionStatement.ts
+++ b/src/slang-nodes/ExpressionStatement.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ExpressionStatement extends SlangNode {
   readonly kind = NonterminalKind.ExpressionStatement;
 
   expression: Expression['variant'];
 
-  constructor(
-    ast: ast.ExpressionStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ExpressionStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.expression = extractVariant(
-      new Expression(ast.expression, collected, options)
-    );
+    this.expression = extractVariant(new Expression(ast.expression, collected));
 
     this.updateMetadata(this.expression);
   }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -9,9 +9,7 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.FallbackFunctionAttribute,
@@ -28,8 +26,7 @@ export class FallbackFunctionAttribute extends SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionAttribute,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
@@ -38,7 +35,7 @@ export class FallbackFunctionAttribute extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { FallbackFunctionAttribute } from './FallbackFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -19,13 +18,12 @@ export class FallbackFunctionAttributes extends SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionAttributes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new FallbackFunctionAttribute(item, collected, options))
+      extractVariant(new FallbackFunctionAttribute(item, collected))
     );
 
     this.items.sort(sortFunctionAttributes);

--- a/src/slang-nodes/FallbackFunctionDefinition.ts
+++ b/src/slang-nodes/FallbackFunctionDefinition.ts
@@ -8,9 +8,8 @@ import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class FallbackFunctionDefinition extends SlangNode {
   readonly kind = NonterminalKind.FallbackFunctionDefinition;
@@ -25,25 +24,16 @@ export class FallbackFunctionDefinition extends SlangNode {
 
   constructor(
     ast: ast.FallbackFunctionDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
-    this.attributes = new FallbackFunctionAttributes(
-      ast.attributes,
-      collected,
-      options
-    );
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
+    this.attributes = new FallbackFunctionAttributes(ast.attributes, collected);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, collected, options);
+      this.returns = new ReturnsDeclaration(ast.returns, collected);
     }
-    this.body = extractVariant(new FunctionBody(ast.body, collected, options));
+    this.body = extractVariant(new FunctionBody(ast.body, collected));
 
     this.updateMetadata(
       this.parameters,

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -10,9 +10,8 @@ import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -27,25 +26,19 @@ export class ForStatement extends SlangNode {
 
   body: Statement['variant'];
 
-  constructor(
-    ast: ast.ForStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ForStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.initialization = extractVariant(
-      new ForStatementInitialization(ast.initialization, collected, options)
+      new ForStatementInitialization(ast.initialization, collected)
     );
     this.condition = extractVariant(
-      new ForStatementCondition(ast.condition, collected, options)
+      new ForStatementCondition(ast.condition, collected)
     );
     if (ast.iterator) {
-      this.iterator = extractVariant(
-        new Expression(ast.iterator, collected, options)
-      );
+      this.iterator = extractVariant(new Expression(ast.iterator, collected));
     }
-    this.body = extractVariant(new Statement(ast.body, collected, options));
+    this.body = extractVariant(new Statement(ast.body, collected));
 
     this.updateMetadata(
       this.initialization,

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -7,20 +7,14 @@ import { ExpressionStatement } from './ExpressionStatement.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ForStatementCondition extends SlangNode {
   readonly kind = NonterminalKind.ForStatementCondition;
 
   variant: ExpressionStatement | TerminalNode;
 
-  constructor(
-    ast: ast.ForStatementCondition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ForStatementCondition, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -28,7 +22,7 @@ export class ForStatementCondition extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = new ExpressionStatement(variant, collected, options);
+    this.variant = new ExpressionStatement(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -10,9 +10,7 @@ import { VariableDeclarationStatement } from './VariableDeclarationStatement.js'
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ForStatementInitialization,
@@ -34,8 +32,7 @@ export class ForStatementInitialization extends SlangNode {
 
   constructor(
     ast: ast.ForStatementInitialization,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
@@ -44,7 +41,7 @@ export class ForStatementInitialization extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -9,9 +9,7 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.FunctionAttribute,
@@ -26,11 +24,7 @@ export class FunctionAttribute extends SlangNode {
 
   variant: ModifierInvocation | OverrideSpecifier | TerminalNode;
 
-  constructor(
-    ast: ast.FunctionAttribute,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionAttribute, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -38,7 +32,7 @@ export class FunctionAttribute extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { FunctionAttribute } from './FunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -17,15 +16,11 @@ export class FunctionAttributes extends SlangNode {
 
   items: FunctionAttribute['variant'][];
 
-  constructor(
-    ast: ast.FunctionAttributes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionAttributes, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new FunctionAttribute(item, collected, options))
+      extractVariant(new FunctionAttribute(item, collected))
     );
 
     this.items.sort(sortFunctionAttributes);

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -7,20 +7,14 @@ import { Block } from './Block.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class FunctionBody extends SlangNode {
   readonly kind = NonterminalKind.FunctionBody;
 
   variant: Block | TerminalNode;
 
-  constructor(
-    ast: ast.FunctionBody,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionBody, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -28,7 +22,7 @@ export class FunctionBody extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = new Block(variant, collected, options);
+    this.variant = new Block(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/FunctionCallExpression.ts
+++ b/src/slang-nodes/FunctionCallExpression.ts
@@ -6,9 +6,8 @@ import { Expression } from './Expression.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class FunctionCallExpression extends SlangNode {
   readonly kind = NonterminalKind.FunctionCallExpression;
@@ -17,18 +16,12 @@ export class FunctionCallExpression extends SlangNode {
 
   arguments: ArgumentsDeclaration['variant'];
 
-  constructor(
-    ast: ast.FunctionCallExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionCallExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
     this.arguments = extractVariant(
-      new ArgumentsDeclaration(ast.arguments, collected, options)
+      new ArgumentsDeclaration(ast.arguments, collected)
     );
 
     this.updateMetadata(this.operand, this.arguments);

--- a/src/slang-nodes/FunctionDefinition.ts
+++ b/src/slang-nodes/FunctionDefinition.ts
@@ -10,9 +10,8 @@ import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class FunctionDefinition extends SlangNode {
   readonly kind = NonterminalKind.FunctionDefinition;
@@ -27,28 +26,16 @@ export class FunctionDefinition extends SlangNode {
 
   body: FunctionBody['variant'];
 
-  constructor(
-    ast: ast.FunctionDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = extractVariant(new FunctionName(ast.name, collected));
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
-    this.attributes = new FunctionAttributes(
-      ast.attributes,
-      collected,
-      options
-    );
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
+    this.attributes = new FunctionAttributes(ast.attributes, collected);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, collected, options);
+      this.returns = new ReturnsDeclaration(ast.returns, collected);
     }
-    this.body = extractVariant(new FunctionBody(ast.body, collected, options));
+    this.body = extractVariant(new FunctionBody(ast.body, collected));
 
     this.updateMetadata(
       this.name,
@@ -62,7 +49,7 @@ export class FunctionDefinition extends SlangNode {
     // the same name as the contract.
     // So we delegate to the parents the responsibility of cleaning the
     // arguments of modifier invocations.
-    if (satisfies(options.compiler, '>=0.5.0')) {
+    if (satisfies(collected.options.compiler, '>=0.5.0')) {
       this.cleanModifierInvocationArguments();
     }
   }

--- a/src/slang-nodes/FunctionType.ts
+++ b/src/slang-nodes/FunctionType.ts
@@ -6,9 +6,8 @@ import { FunctionTypeAttributes } from './FunctionTypeAttributes.js';
 import { ReturnsDeclaration } from './ReturnsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class FunctionType extends SlangNode {
   readonly kind = NonterminalKind.FunctionType;
@@ -19,21 +18,13 @@ export class FunctionType extends SlangNode {
 
   returns?: ReturnsDeclaration;
 
-  constructor(
-    ast: ast.FunctionType,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.FunctionType, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
     this.attributes = new FunctionTypeAttributes(ast.attributes, collected);
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, collected, options);
+      this.returns = new ReturnsDeclaration(ast.returns, collected);
     }
 
     this.updateMetadata(this.parameters, this.attributes, this.returns);

--- a/src/slang-nodes/HexStringLiteral.ts
+++ b/src/slang-nodes/HexStringLiteral.ts
@@ -3,25 +3,20 @@ import { printString } from '../slang-printers/print-string.js';
 import { SlangNode } from './SlangNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class HexStringLiteral extends SlangNode {
   readonly kind = NonterminalKind.HexStringLiteral;
 
   variant: string;
 
-  constructor(
-    ast: ast.HexStringLiteral,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.HexStringLiteral, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.variant = ast.variant.unparse();
 
-    this.variant = `hex${printString(this.variant.slice(4, -1), options)}`;
+    this.variant = `hex${printString(this.variant.slice(4, -1), collected.options)}`;
   }
 
   print(): Doc {

--- a/src/slang-nodes/HexStringLiterals.ts
+++ b/src/slang-nodes/HexStringLiterals.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join, hardline } = doc.builders;
 
@@ -15,16 +14,10 @@ export class HexStringLiterals extends SlangNode {
 
   items: HexStringLiteral[];
 
-  constructor(
-    ast: ast.HexStringLiterals,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.HexStringLiterals, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new HexStringLiteral(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new HexStringLiteral(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<HexStringLiterals>): Doc {

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -10,9 +10,8 @@ import { Statement } from './Statement.js';
 import { ElseBranch } from './ElseBranch.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { hardline } = doc.builders;
 
@@ -25,19 +24,13 @@ export class IfStatement extends SlangNode {
 
   elseBranch?: ElseBranch;
 
-  constructor(
-    ast: ast.IfStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.IfStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.condition = extractVariant(
-      new Expression(ast.condition, collected, options)
-    );
-    this.body = extractVariant(new Statement(ast.body, collected, options));
+    this.condition = extractVariant(new Expression(ast.condition, collected));
+    this.body = extractVariant(new Statement(ast.body, collected));
     if (ast.elseBranch) {
-      this.elseBranch = new ElseBranch(ast.elseBranch, collected, options);
+      this.elseBranch = new ElseBranch(ast.elseBranch, collected);
     }
 
     this.updateMetadata(this.condition, this.body, this.elseBranch);

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -6,9 +6,7 @@ import { PathImport } from './PathImport.js';
 import { NamedImport } from './NamedImport.js';
 import { ImportDeconstruction } from './ImportDeconstruction.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ImportClause,
@@ -24,14 +22,10 @@ export class ImportClause extends SlangNode {
 
   variant: PathImport | NamedImport | ImportDeconstruction;
 
-  constructor(
-    ast: ast.ImportClause,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ImportClause, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ImportDeconstruction.ts
+++ b/src/slang-nodes/ImportDeconstruction.ts
@@ -4,9 +4,8 @@ import { ImportDeconstructionSymbols } from './ImportDeconstructionSymbols.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ImportDeconstruction extends SlangNode {
   readonly kind = NonterminalKind.ImportDeconstruction;
@@ -15,15 +14,11 @@ export class ImportDeconstruction extends SlangNode {
 
   path: StringLiteral;
 
-  constructor(
-    ast: ast.ImportDeconstruction,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ImportDeconstruction, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.symbols = new ImportDeconstructionSymbols(ast.symbols, collected);
-    this.path = new StringLiteral(ast.path, collected, options);
+    this.path = new StringLiteral(ast.path, collected);
 
     this.updateMetadata(this.symbols, this.path);
   }

--- a/src/slang-nodes/ImportDirective.ts
+++ b/src/slang-nodes/ImportDirective.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { ImportClause } from './ImportClause.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ImportDirective extends SlangNode {
   readonly kind = NonterminalKind.ImportDirective;
 
   clause: ImportClause['variant'];
 
-  constructor(
-    ast: ast.ImportDirective,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ImportDirective, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.clause = extractVariant(
-      new ImportClause(ast.clause, collected, options)
-    );
+    this.clause = extractVariant(new ImportClause(ast.clause, collected));
 
     this.updateMetadata(this.clause);
   }

--- a/src/slang-nodes/IndexAccessEnd.ts
+++ b/src/slang-nodes/IndexAccessEnd.ts
@@ -4,24 +4,19 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class IndexAccessEnd extends SlangNode {
   readonly kind = NonterminalKind.IndexAccessEnd;
 
   end?: Expression['variant'];
 
-  constructor(
-    ast: ast.IndexAccessEnd,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.IndexAccessEnd, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.end) {
-      this.end = extractVariant(new Expression(ast.end, collected, options));
+      this.end = extractVariant(new Expression(ast.end, collected));
     }
 
     this.updateMetadata(this.end);

--- a/src/slang-nodes/IndexAccessExpression.ts
+++ b/src/slang-nodes/IndexAccessExpression.ts
@@ -7,9 +7,8 @@ import { Expression } from './Expression.js';
 import { IndexAccessEnd } from './IndexAccessEnd.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class IndexAccessExpression extends SlangNode {
   readonly kind = NonterminalKind.IndexAccessExpression;
@@ -20,23 +19,15 @@ export class IndexAccessExpression extends SlangNode {
 
   end?: IndexAccessEnd;
 
-  constructor(
-    ast: ast.IndexAccessExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.IndexAccessExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
     if (ast.start) {
-      this.start = extractVariant(
-        new Expression(ast.start, collected, options)
-      );
+      this.start = extractVariant(new Expression(ast.start, collected));
     }
     if (ast.end) {
-      this.end = new IndexAccessEnd(ast.end, collected, options);
+      this.end = new IndexAccessEnd(ast.end, collected);
     }
 
     this.updateMetadata(this.operand, this.start, this.end);

--- a/src/slang-nodes/InequalityExpression.ts
+++ b/src/slang-nodes/InequalityExpression.ts
@@ -27,19 +27,15 @@ export class InequalityExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.InequalityExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InequalityExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/InheritanceSpecifier.ts
+++ b/src/slang-nodes/InheritanceSpecifier.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { InheritanceTypes } from './InheritanceTypes.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class InheritanceSpecifier extends SlangNode {
   readonly kind = NonterminalKind.InheritanceSpecifier;
 
   types: InheritanceTypes;
 
-  constructor(
-    ast: ast.InheritanceSpecifier,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InheritanceSpecifier, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.types = new InheritanceTypes(ast.types, collected, options);
+    this.types = new InheritanceTypes(ast.types, collected);
 
     this.updateMetadata(this.types);
   }

--- a/src/slang-nodes/InheritanceType.ts
+++ b/src/slang-nodes/InheritanceType.ts
@@ -5,9 +5,8 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class InheritanceType extends SlangNode {
   readonly kind = NonterminalKind.InheritanceType;
@@ -16,17 +15,13 @@ export class InheritanceType extends SlangNode {
 
   arguments?: ArgumentsDeclaration['variant'];
 
-  constructor(
-    ast: ast.InheritanceType,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InheritanceType, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.typeName = new IdentifierPath(ast.typeName, collected);
     if (ast.arguments) {
       this.arguments = extractVariant(
-        new ArgumentsDeclaration(ast.arguments, collected, options)
+        new ArgumentsDeclaration(ast.arguments, collected)
       );
     }
 

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { InheritanceType } from './InheritanceType.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -16,16 +15,10 @@ export class InheritanceTypes extends SlangNode {
 
   items: InheritanceType[];
 
-  constructor(
-    ast: ast.InheritanceTypes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InheritanceTypes, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new InheritanceType(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new InheritanceType(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<InheritanceTypes>): Doc {

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -6,9 +6,8 @@ import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { InterfaceMembers } from './InterfaceMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group, line } = doc.builders;
 
@@ -21,22 +20,14 @@ export class InterfaceDefinition extends SlangNode {
 
   members: InterfaceMembers;
 
-  constructor(
-    ast: ast.InterfaceDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InterfaceDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
     if (ast.inheritance) {
-      this.inheritance = new InheritanceSpecifier(
-        ast.inheritance,
-        collected,
-        options
-      );
+      this.inheritance = new InheritanceSpecifier(ast.inheritance, collected);
     }
-    this.members = new InterfaceMembers(ast.members, collected, options);
+    this.members = new InterfaceMembers(ast.members, collected);
 
     this.updateMetadata(this.inheritance, this.members);
   }

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -14,15 +14,11 @@ export class InterfaceMembers extends SlangNode {
 
   items: ContractMember['variant'][];
 
-  constructor(
-    ast: ast.InterfaceMembers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.InterfaceMembers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected, options))
+      extractVariant(new ContractMember(item, collected))
     );
   }
 

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -6,9 +6,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { LibraryMembers } from './LibraryMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group, line } = doc.builders;
 
@@ -19,15 +18,11 @@ export class LibraryDefinition extends SlangNode {
 
   members: LibraryMembers;
 
-  constructor(
-    ast: ast.LibraryDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.LibraryDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
-    this.members = new LibraryMembers(ast.members, collected, options);
+    this.members = new LibraryMembers(ast.members, collected);
 
     this.updateMetadata(this.members);
 
@@ -35,7 +30,7 @@ export class LibraryDefinition extends SlangNode {
     // the same name as the contract.
     // So we delegate to the parents the responsibility of cleaning the
     // arguments of modifier invocations.
-    if (!satisfies(options.compiler, '>=0.5.0')) {
+    if (!satisfies(collected.options.compiler, '>=0.5.0')) {
       for (const member of this.members.items) {
         if (member.kind === NonterminalKind.FunctionDefinition) {
           member.cleanModifierInvocationArguments();

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -14,15 +14,11 @@ export class LibraryMembers extends SlangNode {
 
   items: ContractMember['variant'][];
 
-  constructor(
-    ast: ast.LibraryMembers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.LibraryMembers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected, options))
+      extractVariant(new ContractMember(item, collected))
     );
   }
 

--- a/src/slang-nodes/MappingType.ts
+++ b/src/slang-nodes/MappingType.ts
@@ -4,9 +4,8 @@ import { MappingKey } from './MappingKey.js';
 import { MappingValue } from './MappingValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class MappingType extends SlangNode {
   readonly kind = NonterminalKind.MappingType;
@@ -15,15 +14,11 @@ export class MappingType extends SlangNode {
 
   valueType: MappingValue;
 
-  constructor(
-    ast: ast.MappingType,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.MappingType, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.keyType = new MappingKey(ast.keyType, collected);
-    this.valueType = new MappingValue(ast.valueType, collected, options);
+    this.valueType = new MappingValue(ast.valueType, collected);
 
     this.updateMetadata(this.keyType, this.valueType);
   }

--- a/src/slang-nodes/MappingValue.ts
+++ b/src/slang-nodes/MappingValue.ts
@@ -5,9 +5,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class MappingValue extends SlangNode {
   readonly kind = NonterminalKind.MappingValue;
@@ -16,16 +15,10 @@ export class MappingValue extends SlangNode {
 
   name?: TerminalNode;
 
-  constructor(
-    ast: ast.MappingValue,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.MappingValue, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     if (ast.name) {
       this.name = new TerminalNode(ast.name, collected);
     }

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -9,7 +9,7 @@ import { Expression } from './Expression.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { ChainableExpression, PrintableNode } from './types.d.ts';
 
@@ -115,16 +115,10 @@ export class MemberAccessExpression extends SlangNode {
 
   member: TerminalNode;
 
-  constructor(
-    ast: ast.MemberAccessExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.MemberAccessExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
     this.member = new TerminalNode(ast.member, collected);
 
     this.updateMetadata(this.operand);

--- a/src/slang-nodes/ModifierDefinition.ts
+++ b/src/slang-nodes/ModifierDefinition.ts
@@ -9,13 +9,12 @@ import { ModifierAttributes } from './ModifierAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type {
   AstLocation,
   CollectedMetadata,
   PrintFunction
 } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ModifierDefinition extends SlangNode {
   readonly kind = NonterminalKind.ModifierDefinition;
@@ -28,23 +27,15 @@ export class ModifierDefinition extends SlangNode {
 
   body: FunctionBody['variant'];
 
-  constructor(
-    ast: ast.ModifierDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ModifierDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
     if (ast.parameters) {
-      this.parameters = new ParametersDeclaration(
-        ast.parameters,
-        collected,
-        options
-      );
+      this.parameters = new ParametersDeclaration(ast.parameters, collected);
     }
     this.attributes = new ModifierAttributes(ast.attributes, collected);
-    this.body = extractVariant(new FunctionBody(ast.body, collected, options));
+    this.body = extractVariant(new FunctionBody(ast.body, collected));
 
     this.updateMetadata(this.parameters, this.attributes, this.body);
 

--- a/src/slang-nodes/ModifierInvocation.ts
+++ b/src/slang-nodes/ModifierInvocation.ts
@@ -5,9 +5,8 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ModifierInvocation extends SlangNode {
   readonly kind = NonterminalKind.ModifierInvocation;
@@ -16,17 +15,13 @@ export class ModifierInvocation extends SlangNode {
 
   arguments?: ArgumentsDeclaration['variant'];
 
-  constructor(
-    ast: ast.ModifierInvocation,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ModifierInvocation, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new IdentifierPath(ast.name, collected);
     if (ast.arguments) {
       this.arguments = extractVariant(
-        new ArgumentsDeclaration(ast.arguments, collected, options)
+        new ArgumentsDeclaration(ast.arguments, collected)
       );
     }
 

--- a/src/slang-nodes/MultiplicativeExpression.ts
+++ b/src/slang-nodes/MultiplicativeExpression.ts
@@ -40,19 +40,15 @@ export class MultiplicativeExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.MultiplicativeExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.MultiplicativeExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/NamedArgument.ts
+++ b/src/slang-nodes/NamedArgument.ts
@@ -5,9 +5,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class NamedArgument extends SlangNode {
   readonly kind = NonterminalKind.NamedArgument;
@@ -16,15 +15,11 @@ export class NamedArgument extends SlangNode {
 
   value: Expression['variant'];
 
-  constructor(
-    ast: ast.NamedArgument,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.NamedArgument, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
-    this.value = extractVariant(new Expression(ast.value, collected, options));
+    this.value = extractVariant(new Expression(ast.value, collected));
 
     this.updateMetadata(this.value);
   }

--- a/src/slang-nodes/NamedArgumentGroup.ts
+++ b/src/slang-nodes/NamedArgumentGroup.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { NamedArguments } from './NamedArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class NamedArgumentGroup extends SlangNode {
   readonly kind = NonterminalKind.NamedArgumentGroup;
 
   arguments: NamedArguments;
 
-  constructor(
-    ast: ast.NamedArgumentGroup,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.NamedArgumentGroup, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.arguments = new NamedArguments(ast.arguments, collected, options);
+    this.arguments = new NamedArguments(ast.arguments, collected);
 
     this.updateMetadata(this.arguments);
   }

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -16,16 +16,10 @@ export class NamedArguments extends SlangNode {
 
   items: NamedArgument[];
 
-  constructor(
-    ast: ast.NamedArguments,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.NamedArguments, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new NamedArgument(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new NamedArgument(item, collected));
   }
 
   print(

--- a/src/slang-nodes/NamedArgumentsDeclaration.ts
+++ b/src/slang-nodes/NamedArgumentsDeclaration.ts
@@ -3,9 +3,8 @@ import { SlangNode } from './SlangNode.js';
 import { NamedArgumentGroup } from './NamedArgumentGroup.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class NamedArgumentsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.NamedArgumentsDeclaration;
@@ -14,17 +13,12 @@ export class NamedArgumentsDeclaration extends SlangNode {
 
   constructor(
     ast: ast.NamedArgumentsDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
     if (ast.arguments) {
-      this.arguments = new NamedArgumentGroup(
-        ast.arguments,
-        collected,
-        options
-      );
+      this.arguments = new NamedArgumentGroup(ast.arguments, collected);
     }
 
     this.updateMetadata(this.arguments);

--- a/src/slang-nodes/NamedImport.ts
+++ b/src/slang-nodes/NamedImport.ts
@@ -4,9 +4,8 @@ import { ImportAlias } from './ImportAlias.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class NamedImport extends SlangNode {
   readonly kind = NonterminalKind.NamedImport;
@@ -15,15 +14,11 @@ export class NamedImport extends SlangNode {
 
   path: StringLiteral;
 
-  constructor(
-    ast: ast.NamedImport,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.NamedImport, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.alias = new ImportAlias(ast.alias, collected);
-    this.path = new StringLiteral(ast.path, collected, options);
+    this.path = new StringLiteral(ast.path, collected);
 
     this.updateMetadata(this.alias, this.path);
   }

--- a/src/slang-nodes/NewExpression.ts
+++ b/src/slang-nodes/NewExpression.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class NewExpression extends SlangNode {
   readonly kind = NonterminalKind.NewExpression;
 
   typeName: TypeName['variant'];
 
-  constructor(
-    ast: ast.NewExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.NewExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
 
     this.updateMetadata(this.typeName);
   }

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -21,19 +21,15 @@ export class OrExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.OrExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.OrExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -7,9 +7,8 @@ import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group } = doc.builders;
 
@@ -22,16 +21,10 @@ export class Parameter extends SlangNode {
 
   name?: TerminalNode;
 
-  constructor(
-    ast: ast.Parameter,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Parameter, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     if (ast.storageLocation) {
       this.storageLocation = new StorageLocation(
         ast.storageLocation,

--- a/src/slang-nodes/Parameters.ts
+++ b/src/slang-nodes/Parameters.ts
@@ -15,16 +15,10 @@ export class Parameters extends SlangNode {
 
   items: Parameter[];
 
-  constructor(
-    ast: ast.Parameters,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Parameters, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new Parameter(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new Parameter(item, collected));
   }
 
   print(

--- a/src/slang-nodes/ParametersDeclaration.ts
+++ b/src/slang-nodes/ParametersDeclaration.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { Parameters } from './Parameters.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ParametersDeclaration extends SlangNode {
   readonly kind = NonterminalKind.ParametersDeclaration;
 
   parameters: Parameters;
 
-  constructor(
-    ast: ast.ParametersDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ParametersDeclaration, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.parameters = new Parameters(ast.parameters, collected, options);
+    this.parameters = new Parameters(ast.parameters, collected);
 
     this.updateMetadata(this.parameters);
   }

--- a/src/slang-nodes/PathImport.ts
+++ b/src/slang-nodes/PathImport.ts
@@ -4,9 +4,8 @@ import { StringLiteral } from './StringLiteral.js';
 import { ImportAlias } from './ImportAlias.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class PathImport extends SlangNode {
   readonly kind = NonterminalKind.PathImport;
@@ -15,14 +14,10 @@ export class PathImport extends SlangNode {
 
   alias?: ImportAlias;
 
-  constructor(
-    ast: ast.PathImport,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.PathImport, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.path = new StringLiteral(ast.path, collected, options);
+    this.path = new StringLiteral(ast.path, collected);
     if (ast.alias) {
       this.alias = new ImportAlias(ast.alias, collected);
     }

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -16,15 +16,11 @@ export class PositionalArguments extends SlangNode {
 
   items: Expression['variant'][];
 
-  constructor(
-    ast: ast.PositionalArguments,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.PositionalArguments, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new Expression(item, collected, options))
+      extractVariant(new Expression(item, collected))
     );
   }
 

--- a/src/slang-nodes/PositionalArgumentsDeclaration.ts
+++ b/src/slang-nodes/PositionalArgumentsDeclaration.ts
@@ -4,25 +4,23 @@ import { SlangNode } from './SlangNode.js';
 import { PositionalArguments } from './PositionalArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class PositionalArgumentsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.PositionalArgumentsDeclaration;
 
-  isEmpty;
+  readonly isEmpty;
 
   arguments: PositionalArguments;
 
   constructor(
     ast: ast.PositionalArgumentsDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.arguments = new PositionalArguments(ast.arguments, collected, options);
+    this.arguments = new PositionalArguments(ast.arguments, collected);
 
     this.updateMetadata(this.arguments);
 

--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class PostfixExpression extends SlangNode {
   readonly kind = NonterminalKind.PostfixExpression;
@@ -15,16 +14,10 @@ export class PostfixExpression extends SlangNode {
 
   operator: string;
 
-  constructor(
-    ast: ast.PostfixExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.PostfixExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
     this.operator = ast.operator.unparse();
 
     this.updateMetadata(this.operand);

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -6,9 +6,7 @@ import { AbicoderPragma } from './AbicoderPragma.js';
 import { ExperimentalPragma } from './ExperimentalPragma.js';
 import { VersionPragma } from './VersionPragma.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.Pragma,
@@ -24,14 +22,10 @@ export class Pragma extends SlangNode {
 
   variant: AbicoderPragma | ExperimentalPragma | VersionPragma;
 
-  constructor(
-    ast: ast.Pragma,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Pragma, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/PragmaDirective.ts
+++ b/src/slang-nodes/PragmaDirective.ts
@@ -4,23 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { Pragma } from './Pragma.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class PragmaDirective extends SlangNode {
   readonly kind = NonterminalKind.PragmaDirective;
 
   pragma: Pragma['variant'];
 
-  constructor(
-    ast: ast.PragmaDirective,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.PragmaDirective, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.pragma = extractVariant(new Pragma(ast.pragma, collected, options));
+    this.pragma = extractVariant(new Pragma(ast.pragma, collected));
 
     this.updateMetadata(this.pragma);
   }

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class PrefixExpression extends SlangNode {
   readonly kind = NonterminalKind.PrefixExpression;
@@ -15,17 +14,11 @@ export class PrefixExpression extends SlangNode {
 
   operand: Expression['variant'];
 
-  constructor(
-    ast: ast.PrefixExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.PrefixExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.operator = ast.operator.unparse();
-    this.operand = extractVariant(
-      new Expression(ast.operand, collected, options)
-    );
+    this.operand = extractVariant(new Expression(ast.operand, collected));
 
     this.updateMetadata(this.operand);
 

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -9,9 +9,7 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ReceiveFunctionAttribute,
@@ -26,11 +24,7 @@ export class ReceiveFunctionAttribute extends SlangNode {
 
   variant: ModifierInvocation | OverrideSpecifier | TerminalNode;
 
-  constructor(
-    ast: ast.ReceiveFunctionAttribute,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ReceiveFunctionAttribute, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -38,7 +32,7 @@ export class ReceiveFunctionAttribute extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { ReceiveFunctionAttribute } from './ReceiveFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -19,13 +18,12 @@ export class ReceiveFunctionAttributes extends SlangNode {
 
   constructor(
     ast: ast.ReceiveFunctionAttributes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new ReceiveFunctionAttribute(item, collected, options))
+      extractVariant(new ReceiveFunctionAttribute(item, collected))
     );
 
     this.items.sort(sortFunctionAttributes);

--- a/src/slang-nodes/ReceiveFunctionDefinition.ts
+++ b/src/slang-nodes/ReceiveFunctionDefinition.ts
@@ -7,9 +7,8 @@ import { ReceiveFunctionAttributes } from './ReceiveFunctionAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class ReceiveFunctionDefinition extends SlangNode {
   readonly kind = NonterminalKind.ReceiveFunctionDefinition;
@@ -22,22 +21,13 @@ export class ReceiveFunctionDefinition extends SlangNode {
 
   constructor(
     ast: ast.ReceiveFunctionDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
-    this.attributes = new ReceiveFunctionAttributes(
-      ast.attributes,
-      collected,
-      options
-    );
-    this.body = extractVariant(new FunctionBody(ast.body, collected, options));
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
+    this.attributes = new ReceiveFunctionAttributes(ast.attributes, collected);
+    this.body = extractVariant(new FunctionBody(ast.body, collected));
 
     this.updateMetadata(this.parameters, this.attributes, this.body);
 

--- a/src/slang-nodes/ReturnStatement.ts
+++ b/src/slang-nodes/ReturnStatement.ts
@@ -14,16 +14,12 @@ export class ReturnStatement extends SlangNode {
 
   expression?: Expression['variant'];
 
-  constructor(
-    ast: ast.ReturnStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ReturnStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.expression) {
       this.expression = extractVariant(
-        new Expression(ast.expression, collected, options)
+        new Expression(ast.expression, collected)
       );
     }
 

--- a/src/slang-nodes/ReturnsDeclaration.ts
+++ b/src/slang-nodes/ReturnsDeclaration.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { group } = doc.builders;
 
@@ -15,18 +14,10 @@ export class ReturnsDeclaration extends SlangNode {
 
   variables: ParametersDeclaration;
 
-  constructor(
-    ast: ast.ReturnsDeclaration,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ReturnsDeclaration, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variables = new ParametersDeclaration(
-      ast.variables,
-      collected,
-      options
-    );
+    this.variables = new ParametersDeclaration(ast.variables, collected);
 
     this.updateMetadata(this.variables);
   }

--- a/src/slang-nodes/RevertStatement.ts
+++ b/src/slang-nodes/RevertStatement.ts
@@ -5,9 +5,8 @@ import { IdentifierPath } from './IdentifierPath.js';
 import { ArgumentsDeclaration } from './ArgumentsDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class RevertStatement extends SlangNode {
   readonly kind = NonterminalKind.RevertStatement;
@@ -16,16 +15,12 @@ export class RevertStatement extends SlangNode {
 
   arguments: ArgumentsDeclaration['variant'];
 
-  constructor(
-    ast: ast.RevertStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.RevertStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.error = new IdentifierPath(ast.error, collected);
     this.arguments = extractVariant(
-      new ArgumentsDeclaration(ast.arguments, collected, options)
+      new ArgumentsDeclaration(ast.arguments, collected)
     );
 
     this.updateMetadata(this.error, this.arguments);

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -43,19 +43,15 @@ export class ShiftExpression extends SlangNode {
 
   rightOperand: Expression['variant'];
 
-  constructor(
-    ast: ast.ShiftExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.ShiftExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected, options)
+      new Expression(ast.leftOperand, collected)
     );
     this.operator = ast.operator.unparse();
     this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected, options)
+      new Expression(ast.rightOperand, collected)
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -15,14 +15,10 @@ export class SourceUnit extends SlangNode {
 
   members: SourceUnitMembers;
 
-  constructor(
-    ast: ast.SourceUnit,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.SourceUnit, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.members = new SourceUnitMembers(ast.members, collected, options);
+    this.members = new SourceUnitMembers(ast.members, collected);
 
     this.updateMetadata(this.members);
   }

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -16,9 +16,7 @@ import { UserDefinedValueTypeDefinition } from './UserDefinedValueTypeDefinition
 import { UsingDirective } from './UsingDirective.js';
 import { EventDefinition } from './EventDefinition.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.SourceUnitMember,
@@ -57,14 +55,10 @@ export class SourceUnitMember extends SlangNode {
     | UsingDirective
     | EventDefinition;
 
-  constructor(
-    ast: ast.SourceUnitMember,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.SourceUnitMember, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/SourceUnitMembers.ts
+++ b/src/slang-nodes/SourceUnitMembers.ts
@@ -14,15 +14,11 @@ export class SourceUnitMembers extends SlangNode {
 
   items: SourceUnitMember['variant'][];
 
-  constructor(
-    ast: ast.SourceUnitMembers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.SourceUnitMembers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new SourceUnitMember(item, collected, options))
+      extractVariant(new SourceUnitMember(item, collected))
     );
   }
 

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -9,9 +9,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { StateVariableDefinitionValue } from './StateVariableDefinitionValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { indent } = doc.builders;
 
@@ -26,24 +25,14 @@ export class StateVariableDefinition extends SlangNode {
 
   value?: StateVariableDefinitionValue;
 
-  constructor(
-    ast: ast.StateVariableDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StateVariableDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     this.attributes = new StateVariableAttributes(ast.attributes, collected);
     this.name = new TerminalNode(ast.name, collected);
     if (ast.value) {
-      this.value = new StateVariableDefinitionValue(
-        ast.value,
-        collected,
-        options
-      );
+      this.value = new StateVariableDefinitionValue(ast.value, collected);
     }
 
     this.updateMetadata(this.typeName, this.attributes, this.value);

--- a/src/slang-nodes/StateVariableDefinitionValue.ts
+++ b/src/slang-nodes/StateVariableDefinitionValue.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class StateVariableDefinitionValue extends SlangNode {
   readonly kind = NonterminalKind.StateVariableDefinitionValue;
@@ -16,12 +15,11 @@ export class StateVariableDefinitionValue extends SlangNode {
 
   constructor(
     ast: ast.StateVariableDefinitionValue,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.value = extractVariant(new Expression(ast.value, collected, options));
+    this.value = extractVariant(new Expression(ast.value, collected));
 
     this.updateMetadata(this.value);
   }

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -20,9 +20,7 @@ import { AssemblyStatement } from './AssemblyStatement.js';
 import { Block } from './Block.js';
 import { UncheckedBlock } from './UncheckedBlock.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   slangAst.Statement,
@@ -68,18 +66,14 @@ export class Statement extends SlangNode {
     | Block
     | UncheckedBlock;
 
-  constructor(
-    ast: slangAst.Statement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: slangAst.Statement, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
     this.variant =
       variant instanceof slangAst.Block
-        ? new Block(variant, collected, options)
-        : createNonterminalVariant(variant, collected, options);
+        ? new Block(variant, collected)
+        : createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -14,15 +14,11 @@ export class Statements extends SlangNode {
 
   items: Statement['variant'][];
 
-  constructor(
-    ast: ast.Statements,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.Statements, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new Statement(item, collected, options))
+      extractVariant(new Statement(item, collected))
     );
   }
 

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -17,16 +16,10 @@ export class StorageLayoutSpecifier extends SlangNode {
 
   expression: Expression['variant'];
 
-  constructor(
-    ast: ast.StorageLayoutSpecifier,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StorageLayoutSpecifier, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.expression = extractVariant(
-      new Expression(ast.expression, collected, options)
-    );
+    this.expression = extractVariant(new Expression(ast.expression, collected));
 
     this.updateMetadata(this.expression);
   }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -8,9 +8,7 @@ import { HexStringLiteral } from './HexStringLiteral.js';
 import { HexStringLiterals } from './HexStringLiterals.js';
 import { UnicodeStringLiterals } from './UnicodeStringLiterals.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.StringExpression,
@@ -33,14 +31,10 @@ export class StringExpression extends SlangNode {
     | HexStringLiterals
     | UnicodeStringLiterals;
 
-  constructor(
-    ast: ast.StringExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StringExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/StringLiteral.ts
+++ b/src/slang-nodes/StringLiteral.ts
@@ -3,25 +3,20 @@ import { printString } from '../slang-printers/print-string.js';
 import { SlangNode } from './SlangNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class StringLiteral extends SlangNode {
   readonly kind = NonterminalKind.StringLiteral;
 
   variant: string;
 
-  constructor(
-    ast: ast.StringLiteral,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StringLiteral, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.variant = ast.variant.unparse();
 
-    this.variant = printString(this.variant.slice(1, -1), options);
+    this.variant = printString(this.variant.slice(1, -1), collected.options);
   }
 
   print(): Doc {

--- a/src/slang-nodes/StringLiterals.ts
+++ b/src/slang-nodes/StringLiterals.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join, hardline } = doc.builders;
 
@@ -15,16 +14,10 @@ export class StringLiterals extends SlangNode {
 
   items: StringLiteral[];
 
-  constructor(
-    ast: ast.StringLiterals,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StringLiterals, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new StringLiteral(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new StringLiteral(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<StringLiterals>): Doc {

--- a/src/slang-nodes/StructDefinition.ts
+++ b/src/slang-nodes/StructDefinition.ts
@@ -4,9 +4,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { StructMembers } from './StructMembers.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class StructDefinition extends SlangNode {
   readonly kind = NonterminalKind.StructDefinition;
@@ -15,15 +14,11 @@ export class StructDefinition extends SlangNode {
 
   members: StructMembers;
 
-  constructor(
-    ast: ast.StructDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StructDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
-    this.members = new StructMembers(ast.members, collected, options);
+    this.members = new StructMembers(ast.members, collected);
 
     this.updateMetadata(this.members);
   }

--- a/src/slang-nodes/StructMember.ts
+++ b/src/slang-nodes/StructMember.ts
@@ -5,9 +5,8 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class StructMember extends SlangNode {
   readonly kind = NonterminalKind.StructMember;
@@ -16,16 +15,10 @@ export class StructMember extends SlangNode {
 
   name: TerminalNode;
 
-  constructor(
-    ast: ast.StructMember,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StructMember, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     this.name = new TerminalNode(ast.name, collected);
 
     this.updateMetadata(this.typeName);

--- a/src/slang-nodes/StructMembers.ts
+++ b/src/slang-nodes/StructMembers.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { StructMember } from './StructMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { hardline } = doc.builders;
 
@@ -16,16 +15,10 @@ export class StructMembers extends SlangNode {
 
   items: StructMember[];
 
-  constructor(
-    ast: ast.StructMembers,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.StructMembers, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new StructMember(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new StructMember(item, collected));
   }
 
   print(print: PrintFunction, path: AstPath<StructMembers>): Doc {

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -9,9 +9,8 @@ import { Block } from './Block.js';
 import { CatchClauses } from './CatchClauses.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -26,21 +25,15 @@ export class TryStatement extends SlangNode {
 
   catchClauses: CatchClauses;
 
-  constructor(
-    ast: ast.TryStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TryStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.expression = extractVariant(
-      new Expression(ast.expression, collected, options)
-    );
+    this.expression = extractVariant(new Expression(ast.expression, collected));
     if (ast.returns) {
-      this.returns = new ReturnsDeclaration(ast.returns, collected, options);
+      this.returns = new ReturnsDeclaration(ast.returns, collected);
     }
-    this.body = new Block(ast.body, collected, options);
-    this.catchClauses = new CatchClauses(ast.catchClauses, collected, options);
+    this.body = new Block(ast.body, collected);
+    this.catchClauses = new CatchClauses(ast.catchClauses, collected);
 
     this.updateMetadata(
       this.expression,

--- a/src/slang-nodes/TupleDeconstructionElement.ts
+++ b/src/slang-nodes/TupleDeconstructionElement.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { TupleMember } from './TupleMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TupleDeconstructionElement extends SlangNode {
   readonly kind = NonterminalKind.TupleDeconstructionElement;
@@ -15,15 +14,12 @@ export class TupleDeconstructionElement extends SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionElement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
     if (ast.member) {
-      this.member = extractVariant(
-        new TupleMember(ast.member, collected, options)
-      );
+      this.member = extractVariant(new TupleMember(ast.member, collected));
     }
 
     this.updateMetadata(this.member);

--- a/src/slang-nodes/TupleDeconstructionElements.ts
+++ b/src/slang-nodes/TupleDeconstructionElements.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { TupleDeconstructionElement } from './TupleDeconstructionElement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TupleDeconstructionElements extends SlangNode {
   readonly kind = NonterminalKind.TupleDeconstructionElements;
@@ -15,13 +14,12 @@ export class TupleDeconstructionElements extends SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionElements,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected, true);
 
     this.items = ast.items.map(
-      (item) => new TupleDeconstructionElement(item, collected, options)
+      (item) => new TupleDeconstructionElement(item, collected)
     );
   }
 

--- a/src/slang-nodes/TupleDeconstructionStatement.ts
+++ b/src/slang-nodes/TupleDeconstructionStatement.ts
@@ -6,9 +6,8 @@ import { TupleDeconstructionElements } from './TupleDeconstructionElements.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TupleDeconstructionStatement extends SlangNode {
   readonly kind = NonterminalKind.TupleDeconstructionStatement;
@@ -21,20 +20,13 @@ export class TupleDeconstructionStatement extends SlangNode {
 
   constructor(
     ast: ast.TupleDeconstructionStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
     this.varKeyword = ast.varKeyword?.unparse();
-    this.elements = new TupleDeconstructionElements(
-      ast.elements,
-      collected,
-      options
-    );
-    this.expression = extractVariant(
-      new Expression(ast.expression, collected, options)
-    );
+    this.elements = new TupleDeconstructionElements(ast.elements, collected);
+    this.expression = extractVariant(new Expression(ast.expression, collected));
 
     this.updateMetadata(this.elements, this.expression);
   }

--- a/src/slang-nodes/TupleExpression.ts
+++ b/src/slang-nodes/TupleExpression.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { TupleValues } from './TupleValues.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TupleExpression extends SlangNode {
   readonly kind = NonterminalKind.TupleExpression;
 
   items: TupleValues;
 
-  constructor(
-    ast: ast.TupleExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TupleExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.items = new TupleValues(ast.items, collected, options);
+    this.items = new TupleValues(ast.items, collected);
 
     this.updateMetadata(this.items);
   }

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -5,9 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { TypedTupleMember } from './TypedTupleMember.js';
 import { UntypedTupleMember } from './UntypedTupleMember.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.TupleMember,
@@ -22,14 +20,10 @@ export class TupleMember extends SlangNode {
 
   variant: TypedTupleMember | UntypedTupleMember;
 
-  constructor(
-    ast: ast.TupleMember,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TupleMember, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/TupleValue.ts
+++ b/src/slang-nodes/TupleValue.ts
@@ -4,25 +4,20 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TupleValue extends SlangNode {
   readonly kind = NonterminalKind.TupleValue;
 
   expression?: Expression['variant'];
 
-  constructor(
-    ast: ast.TupleValue,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TupleValue, collected: CollectedMetadata) {
     super(ast, collected);
 
     if (ast.expression) {
       this.expression = extractVariant(
-        new Expression(ast.expression, collected, options)
+        new Expression(ast.expression, collected)
       );
     }
 

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { TupleValue } from './TupleValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 import type { Expression } from './Expression.ts';
 
 export class TupleValues extends SlangNode {
@@ -15,16 +14,10 @@ export class TupleValues extends SlangNode {
 
   items: TupleValue[];
 
-  constructor(
-    ast: ast.TupleValues,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TupleValues, collected: CollectedMetadata) {
     super(ast, collected, true);
 
-    this.items = ast.items.map(
-      (item) => new TupleValue(item, collected, options)
-    );
+    this.items = ast.items.map((item) => new TupleValue(item, collected));
   }
 
   getSingleExpression(): Expression['variant'] | undefined {

--- a/src/slang-nodes/TypeExpression.ts
+++ b/src/slang-nodes/TypeExpression.ts
@@ -4,25 +4,18 @@ import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TypeExpression extends SlangNode {
   readonly kind = NonterminalKind.TypeExpression;
 
   typeName: TypeName['variant'];
 
-  constructor(
-    ast: ast.TypeExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TypeExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
 
     this.updateMetadata(this.typeName);
   }

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -8,9 +8,7 @@ import { MappingType } from './MappingType.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantCreator<
   ast.TypeName,
@@ -35,14 +33,10 @@ export class TypeName extends SlangNode {
     | ElementaryType['variant']
     | IdentifierPath;
 
-  constructor(
-    ast: ast.TypeName,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TypeName, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/TypedTupleMember.ts
+++ b/src/slang-nodes/TypedTupleMember.ts
@@ -6,9 +6,8 @@ import { StorageLocation } from './StorageLocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class TypedTupleMember extends SlangNode {
   readonly kind = NonterminalKind.TypedTupleMember;
@@ -19,16 +18,10 @@ export class TypedTupleMember extends SlangNode {
 
   name: TerminalNode;
 
-  constructor(
-    ast: ast.TypedTupleMember,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.TypedTupleMember, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.typeName = extractVariant(
-      new TypeName(ast.typeName, collected, options)
-    );
+    this.typeName = extractVariant(new TypeName(ast.typeName, collected));
     if (ast.storageLocation) {
       this.storageLocation = new StorageLocation(
         ast.storageLocation,

--- a/src/slang-nodes/UncheckedBlock.ts
+++ b/src/slang-nodes/UncheckedBlock.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { Block } from './Block.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UncheckedBlock extends SlangNode {
   readonly kind = NonterminalKind.UncheckedBlock;
 
   block: Block;
 
-  constructor(
-    ast: ast.UncheckedBlock,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UncheckedBlock, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.block = new Block(ast.block, collected, options);
+    this.block = new Block(ast.block, collected);
 
     this.updateMetadata(this.block);
   }

--- a/src/slang-nodes/UnicodeStringLiteral.ts
+++ b/src/slang-nodes/UnicodeStringLiteral.ts
@@ -3,25 +3,20 @@ import { printString } from '../slang-printers/print-string.js';
 import { SlangNode } from './SlangNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UnicodeStringLiteral extends SlangNode {
   readonly kind = NonterminalKind.UnicodeStringLiteral;
 
   variant: string;
 
-  constructor(
-    ast: ast.UnicodeStringLiteral,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UnicodeStringLiteral, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.variant = ast.variant.unparse();
 
-    this.variant = `unicode${printString(this.variant.slice(8, -1), options)}`;
+    this.variant = `unicode${printString(this.variant.slice(8, -1), collected.options)}`;
   }
 
   print(): Doc {

--- a/src/slang-nodes/UnicodeStringLiterals.ts
+++ b/src/slang-nodes/UnicodeStringLiterals.ts
@@ -4,9 +4,8 @@ import { SlangNode } from './SlangNode.js';
 import { UnicodeStringLiteral } from './UnicodeStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join, hardline } = doc.builders;
 
@@ -15,15 +14,11 @@ export class UnicodeStringLiterals extends SlangNode {
 
   items: UnicodeStringLiteral[];
 
-  constructor(
-    ast: ast.UnicodeStringLiterals,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UnicodeStringLiterals, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map(
-      (item) => new UnicodeStringLiteral(item, collected, options)
+      (item) => new UnicodeStringLiteral(item, collected)
     );
   }
 

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -7,20 +7,14 @@ import { ModifierInvocation } from './ModifierInvocation.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UnnamedFunctionAttribute extends SlangNode {
   readonly kind = NonterminalKind.UnnamedFunctionAttribute;
 
   variant: ModifierInvocation | TerminalNode;
 
-  constructor(
-    ast: ast.UnnamedFunctionAttribute,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UnnamedFunctionAttribute, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -28,7 +22,7 @@ export class UnnamedFunctionAttribute extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = new ModifierInvocation(variant, collected, options);
+    this.variant = new ModifierInvocation(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -6,9 +6,8 @@ import { SlangNode } from './SlangNode.js';
 import { UnnamedFunctionAttribute } from './UnnamedFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { line } = doc.builders;
 
@@ -19,13 +18,12 @@ export class UnnamedFunctionAttributes extends SlangNode {
 
   constructor(
     ast: ast.UnnamedFunctionAttributes,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new UnnamedFunctionAttribute(item, collected, options))
+      extractVariant(new UnnamedFunctionAttribute(item, collected))
     );
 
     this.items.sort(sortFunctionAttributes);

--- a/src/slang-nodes/UnnamedFunctionDefinition.ts
+++ b/src/slang-nodes/UnnamedFunctionDefinition.ts
@@ -7,9 +7,8 @@ import { UnnamedFunctionAttributes } from './UnnamedFunctionAttributes.js';
 import { FunctionBody } from './FunctionBody.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UnnamedFunctionDefinition extends SlangNode {
   readonly kind = NonterminalKind.UnnamedFunctionDefinition;
@@ -22,22 +21,13 @@ export class UnnamedFunctionDefinition extends SlangNode {
 
   constructor(
     ast: ast.UnnamedFunctionDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.parameters = new ParametersDeclaration(
-      ast.parameters,
-      collected,
-      options
-    );
-    this.attributes = new UnnamedFunctionAttributes(
-      ast.attributes,
-      collected,
-      options
-    );
-    this.body = extractVariant(new FunctionBody(ast.body, collected, options));
+    this.parameters = new ParametersDeclaration(ast.parameters, collected);
+    this.attributes = new UnnamedFunctionAttributes(ast.attributes, collected);
+    this.body = extractVariant(new FunctionBody(ast.body, collected));
 
     this.updateMetadata(this.parameters, this.attributes, this.body);
 

--- a/src/slang-nodes/UsingDirective.ts
+++ b/src/slang-nodes/UsingDirective.ts
@@ -5,9 +5,8 @@ import { UsingClause } from './UsingClause.js';
 import { UsingTarget } from './UsingTarget.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UsingDirective extends SlangNode {
   readonly kind = NonterminalKind.UsingDirective;
@@ -18,17 +17,11 @@ export class UsingDirective extends SlangNode {
 
   globalKeyword?: string;
 
-  constructor(
-    ast: ast.UsingDirective,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UsingDirective, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.clause = extractVariant(new UsingClause(ast.clause, collected));
-    this.target = extractVariant(
-      new UsingTarget(ast.target, collected, options)
-    );
+    this.target = extractVariant(new UsingTarget(ast.target, collected));
     this.globalKeyword = ast.globalKeyword?.unparse();
 
     this.updateMetadata(this.clause, this.target);

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -8,20 +8,14 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class UsingTarget extends SlangNode {
   readonly kind = NonterminalKind.UsingTarget;
 
   variant: TypeName['variant'] | TerminalNode;
 
-  constructor(
-    ast: ast.UsingTarget,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.UsingTarget, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -29,7 +23,7 @@ export class UsingTarget extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = extractVariant(new TypeName(variant, collected, options));
+    this.variant = extractVariant(new TypeName(variant, collected));
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -9,9 +9,8 @@ import { TerminalNode } from './TerminalNode.js';
 import { VariableDeclarationValue } from './VariableDeclarationValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { indent, line } = doc.builders;
 
@@ -28,13 +27,12 @@ export class VariableDeclarationStatement extends SlangNode {
 
   constructor(
     ast: ast.VariableDeclarationStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
     this.variableType = extractVariant(
-      new VariableDeclarationType(ast.variableType, collected, options)
+      new VariableDeclarationType(ast.variableType, collected)
     );
     if (ast.storageLocation) {
       this.storageLocation = new StorageLocation(
@@ -44,7 +42,7 @@ export class VariableDeclarationStatement extends SlangNode {
     }
     this.name = new TerminalNode(ast.name, collected);
     if (ast.value) {
-      this.value = new VariableDeclarationValue(ast.value, collected, options);
+      this.value = new VariableDeclarationValue(ast.value, collected);
     }
 
     this.updateMetadata(this.variableType, this.storageLocation, this.value);

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -8,20 +8,14 @@ import { TypeName } from './TypeName.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class VariableDeclarationType extends SlangNode {
   readonly kind = NonterminalKind.VariableDeclarationType;
 
   variant: TypeName['variant'] | TerminalNode;
 
-  constructor(
-    ast: ast.VariableDeclarationType,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.VariableDeclarationType, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -29,7 +23,7 @@ export class VariableDeclarationType extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = extractVariant(new TypeName(variant, collected, options));
+    this.variant = extractVariant(new TypeName(variant, collected));
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/VariableDeclarationValue.ts
+++ b/src/slang-nodes/VariableDeclarationValue.ts
@@ -5,25 +5,18 @@ import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class VariableDeclarationValue extends SlangNode {
   readonly kind = NonterminalKind.VariableDeclarationValue;
 
   expression: Expression['variant'];
 
-  constructor(
-    ast: ast.VariableDeclarationValue,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.VariableDeclarationValue, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.expression = extractVariant(
-      new Expression(ast.expression, collected, options)
-    );
+    this.expression = extractVariant(new Expression(ast.expression, collected));
 
     this.updateMetadata(this.expression);
   }

--- a/src/slang-nodes/WhileStatement.ts
+++ b/src/slang-nodes/WhileStatement.ts
@@ -7,9 +7,8 @@ import { Expression } from './Expression.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class WhileStatement extends SlangNode {
   readonly kind = NonterminalKind.WhileStatement;
@@ -18,17 +17,11 @@ export class WhileStatement extends SlangNode {
 
   body: Statement['variant'];
 
-  constructor(
-    ast: ast.WhileStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.WhileStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.condition = extractVariant(
-      new Expression(ast.condition, collected, options)
-    );
-    this.body = extractVariant(new Statement(ast.body, collected, options));
+    this.condition = extractVariant(new Expression(ast.condition, collected));
+    this.body = extractVariant(new Statement(ast.body, collected));
 
     this.updateMetadata(this.condition, this.body);
   }

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -5,24 +5,19 @@ import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulArguments extends SlangNode {
   readonly kind = NonterminalKind.YulArguments;
 
   items: YulExpression['variant'][];
 
-  constructor(
-    ast: ast.YulArguments,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulArguments, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new YulExpression(item, collected, options))
+      extractVariant(new YulExpression(item, collected))
     );
   }
 

--- a/src/slang-nodes/YulBlock.ts
+++ b/src/slang-nodes/YulBlock.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { YulStatements } from './YulStatements.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulBlock extends SlangNode {
   readonly kind = NonterminalKind.YulBlock;
 
   statements: YulStatements;
 
-  constructor(
-    ast: ast.YulBlock,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulBlock, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.statements = new YulStatements(ast.statements, collected, options);
+    this.statements = new YulStatements(ast.statements, collected);
 
     this.updateMetadata(this.statements);
   }

--- a/src/slang-nodes/YulDefaultCase.ts
+++ b/src/slang-nodes/YulDefaultCase.ts
@@ -3,23 +3,18 @@ import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulDefaultCase extends SlangNode {
   readonly kind = NonterminalKind.YulDefaultCase;
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulDefaultCase,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulDefaultCase, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.body = new YulBlock(ast.body, collected, options);
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(this.body);
   }

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -6,9 +6,7 @@ import { YulFunctionCallExpression } from './YulFunctionCallExpression.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulPath } from './YulPath.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantCreator<
   ast.YulExpression,
@@ -26,14 +24,10 @@ export class YulExpression extends SlangNode {
 
   variant: YulFunctionCallExpression | YulLiteral['variant'] | YulPath;
 
-  constructor(
-    ast: ast.YulExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulExpression, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -6,9 +6,8 @@ import { YulBlock } from './YulBlock.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join } = doc.builders;
 
@@ -23,19 +22,15 @@ export class YulForStatement extends SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulForStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulForStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.initialization = new YulBlock(ast.initialization, collected, options);
+    this.initialization = new YulBlock(ast.initialization, collected);
     this.condition = extractVariant(
-      new YulExpression(ast.condition, collected, options)
+      new YulExpression(ast.condition, collected)
     );
-    this.iterator = new YulBlock(ast.iterator, collected, options);
-    this.body = new YulBlock(ast.body, collected, options);
+    this.iterator = new YulBlock(ast.iterator, collected);
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(
       this.initialization,

--- a/src/slang-nodes/YulFunctionCallExpression.ts
+++ b/src/slang-nodes/YulFunctionCallExpression.ts
@@ -5,9 +5,8 @@ import { YulExpression } from './YulExpression.js';
 import { YulArguments } from './YulArguments.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulFunctionCallExpression extends SlangNode {
   readonly kind = NonterminalKind.YulFunctionCallExpression;
@@ -18,15 +17,12 @@ export class YulFunctionCallExpression extends SlangNode {
 
   constructor(
     ast: ast.YulFunctionCallExpression,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
-    this.operand = extractVariant(
-      new YulExpression(ast.operand, collected, options)
-    );
-    this.arguments = new YulArguments(ast.arguments, collected, options);
+    this.operand = extractVariant(new YulExpression(ast.operand, collected));
+    this.arguments = new YulArguments(ast.arguments, collected);
 
     this.updateMetadata(this.operand, this.arguments);
   }

--- a/src/slang-nodes/YulFunctionDefinition.ts
+++ b/src/slang-nodes/YulFunctionDefinition.ts
@@ -6,9 +6,8 @@ import { YulReturnsDeclaration } from './YulReturnsDeclaration.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulFunctionDefinition extends SlangNode {
   readonly kind = NonterminalKind.YulFunctionDefinition;
@@ -21,11 +20,7 @@ export class YulFunctionDefinition extends SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulFunctionDefinition,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulFunctionDefinition, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.name = new TerminalNode(ast.name, collected);
@@ -33,7 +28,7 @@ export class YulFunctionDefinition extends SlangNode {
     if (ast.returns) {
       this.returns = new YulReturnsDeclaration(ast.returns, collected);
     }
-    this.body = new YulBlock(ast.body, collected, options);
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(this.parameters, this.returns, this.body);
   }

--- a/src/slang-nodes/YulIfStatement.ts
+++ b/src/slang-nodes/YulIfStatement.ts
@@ -5,9 +5,8 @@ import { YulExpression } from './YulExpression.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulIfStatement extends SlangNode {
   readonly kind = NonterminalKind.YulIfStatement;
@@ -16,17 +15,13 @@ export class YulIfStatement extends SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulIfStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulIfStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.condition = extractVariant(
-      new YulExpression(ast.condition, collected, options)
+      new YulExpression(ast.condition, collected)
     );
-    this.body = new YulBlock(ast.body, collected, options);
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(this.condition, this.body);
   }

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -9,9 +9,7 @@ import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
 import { TerminalNode } from './TerminalNode.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.YulLiteral,
@@ -26,11 +24,7 @@ export class YulLiteral extends SlangNode {
 
   variant: HexStringLiteral | StringLiteral | TerminalNode;
 
-  constructor(
-    ast: ast.YulLiteral,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulLiteral, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
@@ -38,7 +32,7 @@ export class YulLiteral extends SlangNode {
       this.variant = new TerminalNode(variant, collected);
       return;
     }
-    this.variant = createNonterminalVariant(variant, collected, options);
+    this.variant = createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -16,9 +16,7 @@ import { YulContinueStatement } from './YulContinueStatement.js';
 import { YulLabel } from './YulLabel.js';
 import { YulExpression } from './YulExpression.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantCreator<
   slangAst.YulStatement,
@@ -58,18 +56,14 @@ export class YulStatement extends SlangNode {
     | YulLabel
     | YulExpression['variant'];
 
-  constructor(
-    ast: slangAst.YulStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: slangAst.YulStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     const variant = ast.variant;
     this.variant =
       variant instanceof slangAst.YulBlock
-        ? new YulBlock(variant, collected, options)
-        : createNonterminalVariant(variant, collected, options);
+        ? new YulBlock(variant, collected)
+        : createNonterminalVariant(variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -14,15 +14,11 @@ export class YulStatements extends SlangNode {
 
   items: YulStatement['variant'][];
 
-  constructor(
-    ast: ast.YulStatements,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulStatements, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new YulStatement(item, collected, options))
+      extractVariant(new YulStatement(item, collected))
     );
   }
 

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -5,9 +5,7 @@ import { SlangNode } from './SlangNode.js';
 import { YulDefaultCase } from './YulDefaultCase.js';
 import { YulValueCase } from './YulValueCase.js';
 
-import type { ParserOptions } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.YulSwitchCase,
@@ -22,14 +20,10 @@ export class YulSwitchCase extends SlangNode {
 
   variant: YulDefaultCase | YulValueCase;
 
-  constructor(
-    ast: ast.YulSwitchCase,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulSwitchCase, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.variant = createNonterminalVariant(ast.variant, collected, options);
+    this.variant = createNonterminalVariant(ast.variant, collected);
 
     this.updateMetadata(this.variant);
   }

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -5,9 +5,8 @@ import { SlangNode } from './SlangNode.js';
 import { YulSwitchCase } from './YulSwitchCase.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc, ParserOptions } from 'prettier';
+import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { hardline, join } = doc.builders;
 
@@ -16,15 +15,11 @@ export class YulSwitchCases extends SlangNode {
 
   items: YulSwitchCase['variant'][];
 
-  constructor(
-    ast: ast.YulSwitchCases,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulSwitchCases, collected: CollectedMetadata) {
     super(ast, collected, true);
 
     this.items = ast.items.map((item) =>
-      extractVariant(new YulSwitchCase(item, collected, options))
+      extractVariant(new YulSwitchCase(item, collected))
     );
   }
 

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -6,9 +6,8 @@ import { YulExpression } from './YulExpression.js';
 import { YulSwitchCases } from './YulSwitchCases.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { hardline } = doc.builders;
 
@@ -19,17 +18,13 @@ export class YulSwitchStatement extends SlangNode {
 
   cases: YulSwitchCases;
 
-  constructor(
-    ast: ast.YulSwitchStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulSwitchStatement, collected: CollectedMetadata) {
     super(ast, collected);
 
     this.expression = extractVariant(
-      new YulExpression(ast.expression, collected, options)
+      new YulExpression(ast.expression, collected)
     );
-    this.cases = new YulSwitchCases(ast.cases, collected, options);
+    this.cases = new YulSwitchCases(ast.cases, collected);
 
     this.updateMetadata(this.expression, this.cases);
   }

--- a/src/slang-nodes/YulValueCase.ts
+++ b/src/slang-nodes/YulValueCase.ts
@@ -5,9 +5,8 @@ import { YulLiteral } from './YulLiteral.js';
 import { YulBlock } from './YulBlock.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulValueCase extends SlangNode {
   readonly kind = NonterminalKind.YulValueCase;
@@ -16,15 +15,11 @@ export class YulValueCase extends SlangNode {
 
   body: YulBlock;
 
-  constructor(
-    ast: ast.YulValueCase,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
-  ) {
+  constructor(ast: ast.YulValueCase, collected: CollectedMetadata) {
     super(ast, collected);
 
-    this.value = extractVariant(new YulLiteral(ast.value, collected, options));
-    this.body = new YulBlock(ast.body, collected, options);
+    this.value = extractVariant(new YulLiteral(ast.value, collected));
+    this.body = new YulBlock(ast.body, collected);
 
     this.updateMetadata(this.value, this.body);
   }

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -7,9 +7,8 @@ import { YulAssignmentOperator } from './YulAssignmentOperator.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 const { join } = doc.builders;
 
@@ -24,8 +23,7 @@ export class YulVariableAssignmentStatement extends SlangNode {
 
   constructor(
     ast: ast.YulVariableAssignmentStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
@@ -34,7 +32,7 @@ export class YulVariableAssignmentStatement extends SlangNode {
       new YulAssignmentOperator(ast.assignment, collected)
     );
     this.expression = extractVariant(
-      new YulExpression(ast.expression, collected, options)
+      new YulExpression(ast.expression, collected)
     );
 
     this.updateMetadata(this.variables, this.assignment, this.expression);

--- a/src/slang-nodes/YulVariableDeclarationStatement.ts
+++ b/src/slang-nodes/YulVariableDeclarationStatement.ts
@@ -4,9 +4,8 @@ import { YulVariableDeclarationValue } from './YulVariableDeclarationValue.js';
 import { YulVariableNames } from './YulVariableNames.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulVariableDeclarationStatement extends SlangNode {
   readonly kind = NonterminalKind.YulVariableDeclarationStatement;
@@ -17,18 +16,13 @@ export class YulVariableDeclarationStatement extends SlangNode {
 
   constructor(
     ast: ast.YulVariableDeclarationStatement,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
     this.variables = new YulVariableNames(ast.variables, collected);
     if (ast.value) {
-      this.value = new YulVariableDeclarationValue(
-        ast.value,
-        collected,
-        options
-      );
+      this.value = new YulVariableDeclarationValue(ast.value, collected);
     }
 
     this.updateMetadata(this.value);

--- a/src/slang-nodes/YulVariableDeclarationValue.ts
+++ b/src/slang-nodes/YulVariableDeclarationValue.ts
@@ -5,9 +5,8 @@ import { YulAssignmentOperator } from './YulAssignmentOperator.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc, ParserOptions } from 'prettier';
+import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-import type { PrintableNode } from './types.d.ts';
 
 export class YulVariableDeclarationValue extends SlangNode {
   readonly kind = NonterminalKind.YulVariableDeclarationValue;
@@ -18,8 +17,7 @@ export class YulVariableDeclarationValue extends SlangNode {
 
   constructor(
     ast: ast.YulVariableDeclarationValue,
-    collected: CollectedMetadata,
-    options: ParserOptions<PrintableNode>
+    collected: CollectedMetadata
   ) {
     super(ast, collected);
 
@@ -27,7 +25,7 @@ export class YulVariableDeclarationValue extends SlangNode {
       new YulAssignmentOperator(ast.assignment, collected)
     );
     this.expression = extractVariant(
-      new YulExpression(ast.expression, collected, options)
+      new YulExpression(ast.expression, collected)
     );
 
     this.updateMetadata(this.assignment, this.expression);

--- a/src/slang-utils/create-nonterminal-variant-creator.ts
+++ b/src/slang-utils/create-nonterminal-variant-creator.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { extractVariant } from './extract-variant.js';
 
-import type { ParserOptions } from 'prettier';
-import type {
-  PrintableNode,
-  StrictPolymorphicNode
-} from '../slang-nodes/types.d.ts';
+import type { StrictPolymorphicNode } from '../slang-nodes/types.d.ts';
 import type {
   CollectedMetadata,
   SlangAstNode,
@@ -18,11 +14,7 @@ type SlangPolymorphicNode = Extract<SlangAstNode, { variant: unknown }>;
 type NonterminalVariantFactory<
   U extends SlangPolymorphicNode,
   T extends StrictPolymorphicNode
-> = (
-  variant: U['variant'],
-  collected: CollectedMetadata,
-  options?: ParserOptions<PrintableNode>
-) => T['variant'];
+> = (variant: U['variant'], collected: CollectedMetadata) => T['variant'];
 
 export function createNonterminalVariantSimpleCreator<
   U extends SlangPolymorphicNode,

--- a/src/slang-utils/create-nonterminal-variant-creator.ts
+++ b/src/slang-utils/create-nonterminal-variant-creator.ts
@@ -12,7 +12,7 @@ import type {
   SlangAstNodeClass
 } from '../types.d.ts';
 
-type Constructor<T> = new (...args: any) => T;
+type Constructor<T> = new (ast: any, collected: CollectedMetadata) => T;
 type ConstructorsFromInstances<U> = U extends any ? Constructor<U> : never;
 type SlangPolymorphicNode = Extract<SlangAstNode, { variant: unknown }>;
 
@@ -31,10 +31,10 @@ export function createNonterminalVariantSimpleCreator<
 >(
   constructors: [SlangAstNodeClass, ConstructorsFromInstances<T['variant']>][]
 ): NonterminalVariantFactory<U, T> {
-  return (variant, collected, options?) => {
+  return (variant, collected) => {
     for (const [slangAstClass, constructor] of constructors) {
       if (variant instanceof slangAstClass)
-        return new constructor(variant, collected, options);
+        return new constructor(variant, collected);
     }
 
     throw new Error(`Unexpected variant: ${JSON.stringify(variant)}`);
@@ -55,12 +55,12 @@ export function createNonterminalVariantCreator<
     constructors
   );
 
-  return (variant, collected, options?) => {
+  return (variant, collected) => {
     for (const [slangAstClass, constructor] of extractVariantConstructors) {
       if (variant instanceof slangAstClass)
-        return extractVariant(new constructor(variant, collected, options));
+        return extractVariant(new constructor(variant, collected));
     }
 
-    return simpleCreator(variant, collected, options);
+    return simpleCreator(variant, collected);
   };
 }

--- a/src/slang-utils/create-nonterminal-variant-creator.ts
+++ b/src/slang-utils/create-nonterminal-variant-creator.ts
@@ -12,8 +12,7 @@ import type {
   SlangAstNodeClass
 } from '../types.d.ts';
 
-type Constructor<T> = new (ast: any, collected: CollectedMetadata) => T;
-type ConstructorsFromInstances<U> = U extends any ? Constructor<U> : never;
+type NodeConstructor<T> = new (ast: any, collected: CollectedMetadata) => T;
 type SlangPolymorphicNode = Extract<SlangAstNode, { variant: unknown }>;
 
 type NonterminalVariantFactory<
@@ -29,7 +28,7 @@ export function createNonterminalVariantSimpleCreator<
   U extends SlangPolymorphicNode,
   T extends StrictPolymorphicNode
 >(
-  constructors: [SlangAstNodeClass, ConstructorsFromInstances<T['variant']>][]
+  constructors: [SlangAstNodeClass, NodeConstructor<T['variant']>][]
 ): NonterminalVariantFactory<U, T> {
   return (variant, collected) => {
     for (const [slangAstClass, constructor] of constructors) {
@@ -45,10 +44,10 @@ export function createNonterminalVariantCreator<
   U extends SlangPolymorphicNode,
   T extends StrictPolymorphicNode
 >(
-  constructors: [SlangAstNodeClass, ConstructorsFromInstances<T['variant']>][],
+  constructors: [SlangAstNodeClass, NodeConstructor<T['variant']>][],
   extractVariantConstructors: [
     SlangAstNodeClass,
-    ConstructorsFromInstances<StrictPolymorphicNode>
+    NodeConstructor<StrictPolymorphicNode>
   ][]
 ): NonterminalVariantFactory<U, T> {
   const simpleCreator = createNonterminalVariantSimpleCreator<U, T>(

--- a/src/slangSolidityParser.ts
+++ b/src/slangSolidityParser.ts
@@ -18,8 +18,7 @@ export default function parse(
   const comments: Comment[] = [];
   const parsed = new SourceUnit(
     new SlangSourceUnit(parseOutput.tree.asNonterminalNode()),
-    { offsets: new Map<number, number>(), comments },
-    options
+    { offsets: new Map<number, number>(), comments, options }
   );
 
   // Comments are extracted in nested order; sort them by location.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { AstPath, Doc } from 'prettier';
+import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from './slang-nodes/types.d.ts';
 
 // Adding our own options to prettier's `ParserOptions` interface.
@@ -12,6 +12,7 @@ declare module 'prettier' {
 interface CollectedMetadata {
   offsets: Map<number, number>;
   comments: Comment[];
+  options: ParserOptions<PrintableNode>;
 }
 
 interface Location {


### PR DESCRIPTION
This way we can standardise all constructor signatures and depollute the class instantiations.

The changes are very repetitive:

- removing `type` imports and `options` from constructors across `slang-nodes`.
- replacing `options` with `collected.options` whenever we actually need to access this info (only 7 times) **In the constructors only.**
- cleaned up the `createNonterminalVariantCreator` function and types associated to reflect the constructor calls.
- updated `slangSolidityParser` initial creation of `SourceUnit` to reflect the change.
- updated the `CollectedMetadata` interface.