### PR TITLE
Collection base classes

### DIFF
--- a/src/slang-nodes/ArrayValues.ts
+++ b/src/slang-nodes/ArrayValues.ts
@@ -1,24 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class ArrayValues extends SlangNode {
+export class ArrayValues extends VariantCollection<
+  ast.ArrayValues,
+  Expression
+> {
   readonly kind = NonterminalKind.ArrayValues;
 
-  items: Expression['variant'][];
-
   constructor(ast: ast.ArrayValues, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new Expression(item, collected))
-    );
+    super(ast, collected, Expression);
   }
 
   print(print: PrintFunction, path: AstPath<ArrayValues>): Doc {

--- a/src/slang-nodes/AssemblyFlags.ts
+++ b/src/slang-nodes/AssemblyFlags.ts
@@ -1,21 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class AssemblyFlags extends SlangNode {
+export class AssemblyFlags extends NodeCollection<
+  ast.AssemblyFlags,
+  StringLiteral
+> {
   readonly kind = NonterminalKind.AssemblyFlags;
 
-  items: StringLiteral[];
-
   constructor(ast: ast.AssemblyFlags, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new StringLiteral(item, collected));
+    super(ast, collected, StringLiteral);
   }
 
   print(print: PrintFunction, path: AstPath<AssemblyFlags>): Doc {

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { NamedArgument } from './NamedArgument.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,15 +11,14 @@ import type { PrintableNode } from './types.d.ts';
 
 const { line, softline } = doc.builders;
 
-export class CallOptions extends SlangNode {
+export class CallOptions extends NodeCollection<
+  ast.CallOptions,
+  NamedArgument
+> {
   readonly kind = NonterminalKind.CallOptions;
 
-  items: NamedArgument[];
-
   constructor(ast: ast.CallOptions, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new NamedArgument(item, collected));
+    super(ast, collected, NamedArgument);
   }
 
   print(

--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { CatchClause } from './CatchClause.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class CatchClauses extends SlangNode {
+export class CatchClauses extends NodeCollection<
+  ast.CatchClauses,
+  CatchClause
+> {
   readonly kind = NonterminalKind.CatchClauses;
 
-  items: CatchClause[];
-
   constructor(ast: ast.CatchClauses, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new CatchClause(item, collected));
+    super(ast, collected, CatchClause);
 
     this.updateMetadata(...this.items);
   }

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ConstructorAttribute } from './ConstructorAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class ConstructorAttributes extends SlangNode {
+export class ConstructorAttributes extends VariantCollection<
+  ast.ConstructorAttributes,
+  ConstructorAttribute
+> {
   readonly kind = NonterminalKind.ConstructorAttributes;
 
-  items: ConstructorAttribute['variant'][];
-
   constructor(ast: ast.ConstructorAttributes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ConstructorAttribute(item, collected))
-    );
+    super(ast, collected, ConstructorAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/ContractMembers.ts
+++ b/src/slang-nodes/ContractMembers.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ContractMember } from './ContractMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class ContractMembers extends SlangNode {
+export class ContractMembers extends VariantCollection<
+  ast.ContractMembers,
+  ContractMember
+> {
   readonly kind = NonterminalKind.ContractMembers;
 
-  items: ContractMember['variant'][];
-
   constructor(ast: ast.ContractMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected))
-    );
+    super(ast, collected, ContractMember);
   }
 
   print(

--- a/src/slang-nodes/ContractSpecifiers.ts
+++ b/src/slang-nodes/ContractSpecifiers.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ContractSpecifier } from './ContractSpecifier.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -30,17 +29,14 @@ function sortContractSpecifiers(
   return 0;
 }
 
-export class ContractSpecifiers extends SlangNode {
+export class ContractSpecifiers extends VariantCollection<
+  ast.ContractSpecifiers,
+  ContractSpecifier
+> {
   readonly kind = NonterminalKind.ContractSpecifiers;
 
-  items: ContractSpecifier['variant'][];
-
   constructor(ast: ast.ContractSpecifiers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ContractSpecifier(item, collected))
-    );
+    super(ast, collected, ContractSpecifier);
 
     this.items.sort(sortContractSpecifiers);
   }

--- a/src/slang-nodes/EnumMembers.ts
+++ b/src/slang-nodes/EnumMembers.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,15 +10,11 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { hardline } = doc.builders;
 
-export class EnumMembers extends SlangNode {
+export class EnumMembers extends NodeCollection<ast.EnumMembers, TerminalNode> {
   readonly kind = NonterminalKind.EnumMembers;
 
-  items: TerminalNode[];
-
   constructor(ast: ast.EnumMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new TerminalNode(item, collected));
+    super(ast, collected, TerminalNode);
   }
 
   print(print: PrintFunction, path: AstPath<EnumMembers>): Doc {

--- a/src/slang-nodes/ErrorParameters.ts
+++ b/src/slang-nodes/ErrorParameters.ts
@@ -1,21 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { ErrorParameter } from './ErrorParameter.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class ErrorParameters extends SlangNode {
+export class ErrorParameters extends NodeCollection<
+  ast.ErrorParameters,
+  ErrorParameter
+> {
   readonly kind = NonterminalKind.ErrorParameters;
 
-  items: ErrorParameter[];
-
   constructor(ast: ast.ErrorParameters, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new ErrorParameter(item, collected));
+    super(ast, collected, ErrorParameter);
   }
 
   print(print: PrintFunction, path: AstPath<ErrorParameters>): Doc {

--- a/src/slang-nodes/EventParameters.ts
+++ b/src/slang-nodes/EventParameters.ts
@@ -1,21 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { EventParameter } from './EventParameter.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class EventParameters extends SlangNode {
+export class EventParameters extends NodeCollection<
+  ast.EventParameters,
+  EventParameter
+> {
   readonly kind = NonterminalKind.EventParameters;
 
-  items: EventParameter[];
-
   constructor(ast: ast.EventParameters, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new EventParameter(item, collected));
+    super(ast, collected, EventParameter);
   }
 
   print(print: PrintFunction, path: AstPath<EventParameters>): Doc {

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { FallbackFunctionAttribute } from './FallbackFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,20 +10,17 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class FallbackFunctionAttributes extends SlangNode {
+export class FallbackFunctionAttributes extends VariantCollection<
+  ast.FallbackFunctionAttributes,
+  FallbackFunctionAttribute
+> {
   readonly kind = NonterminalKind.FallbackFunctionAttributes;
-
-  items: FallbackFunctionAttribute['variant'][];
 
   constructor(
     ast: ast.FallbackFunctionAttributes,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new FallbackFunctionAttribute(item, collected))
-    );
+    super(ast, collected, FallbackFunctionAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { FunctionAttribute } from './FunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class FunctionAttributes extends SlangNode {
+export class FunctionAttributes extends VariantCollection<
+  ast.FunctionAttributes,
+  FunctionAttribute
+> {
   readonly kind = NonterminalKind.FunctionAttributes;
 
-  items: FunctionAttribute['variant'][];
-
   constructor(ast: ast.FunctionAttributes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new FunctionAttribute(item, collected))
-    );
+    super(ast, collected, FunctionAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { FunctionTypeAttribute } from './FunctionTypeAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class FunctionTypeAttributes extends SlangNode {
+export class FunctionTypeAttributes extends VariantCollection<
+  ast.FunctionTypeAttributes,
+  FunctionTypeAttribute
+> {
   readonly kind = NonterminalKind.FunctionTypeAttributes;
 
-  items: FunctionTypeAttribute['variant'][];
-
   constructor(ast: ast.FunctionTypeAttributes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new FunctionTypeAttribute(item, collected))
-    );
+    super(ast, collected, FunctionTypeAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/HexStringLiterals.ts
+++ b/src/slang-nodes/HexStringLiterals.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join, hardline } = doc.builders;
 
-export class HexStringLiterals extends SlangNode {
+export class HexStringLiterals extends NodeCollection<
+  ast.HexStringLiterals,
+  HexStringLiteral
+> {
   readonly kind = NonterminalKind.HexStringLiterals;
 
-  items: HexStringLiteral[];
-
   constructor(ast: ast.HexStringLiterals, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new HexStringLiteral(item, collected));
+    super(ast, collected, HexStringLiteral);
   }
 
   print(print: PrintFunction, path: AstPath<HexStringLiterals>): Doc {

--- a/src/slang-nodes/IdentifierPath.ts
+++ b/src/slang-nodes/IdentifierPath.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class IdentifierPath extends SlangNode {
+export class IdentifierPath extends NodeCollection<
+  ast.IdentifierPath,
+  TerminalNode
+> {
   readonly kind = NonterminalKind.IdentifierPath;
 
-  items: TerminalNode[];
-
   constructor(ast: ast.IdentifierPath, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.items = ast.items.map((item) => new TerminalNode(item, collected));
+    super(ast, collected, TerminalNode, false);
   }
 
   print(print: PrintFunction, path: AstPath<IdentifierPath>): Doc {

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { satisfies } from 'semver';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { ImportDeconstructionSymbol } from './ImportDeconstructionSymbol.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -12,20 +12,17 @@ import type { PrintableNode } from './types.d.ts';
 
 const { line, softline } = doc.builders;
 
-export class ImportDeconstructionSymbols extends SlangNode {
+export class ImportDeconstructionSymbols extends NodeCollection<
+  ast.ImportDeconstructionSymbols,
+  ImportDeconstructionSymbol
+> {
   readonly kind = NonterminalKind.ImportDeconstructionSymbols;
-
-  items: ImportDeconstructionSymbol[];
 
   constructor(
     ast: ast.ImportDeconstructionSymbols,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map(
-      (item) => new ImportDeconstructionSymbol(item, collected)
-    );
+    super(ast, collected, ImportDeconstructionSymbol);
   }
 
   print(

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { InheritanceType } from './InheritanceType.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,15 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class InheritanceTypes extends SlangNode {
+export class InheritanceTypes extends NodeCollection<
+  ast.InheritanceTypes,
+  InheritanceType
+> {
   readonly kind = NonterminalKind.InheritanceTypes;
 
-  items: InheritanceType[];
-
   constructor(ast: ast.InheritanceTypes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new InheritanceType(item, collected));
+    super(ast, collected, InheritanceType);
   }
 
   print(print: PrintFunction, path: AstPath<InheritanceTypes>): Doc {

--- a/src/slang-nodes/InterfaceMembers.ts
+++ b/src/slang-nodes/InterfaceMembers.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ContractMember } from './ContractMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class InterfaceMembers extends SlangNode {
+export class InterfaceMembers extends VariantCollection<
+  ast.InterfaceMembers,
+  ContractMember
+> {
   readonly kind = NonterminalKind.InterfaceMembers;
 
-  items: ContractMember['variant'][];
-
   constructor(ast: ast.InterfaceMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected))
-    );
+    super(ast, collected, ContractMember);
   }
 
   print(

--- a/src/slang-nodes/LibraryMembers.ts
+++ b/src/slang-nodes/LibraryMembers.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ContractMember } from './ContractMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class LibraryMembers extends SlangNode {
+export class LibraryMembers extends VariantCollection<
+  ast.LibraryMembers,
+  ContractMember
+> {
   readonly kind = NonterminalKind.LibraryMembers;
 
-  items: ContractMember['variant'][];
-
   constructor(ast: ast.LibraryMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ContractMember(item, collected))
-    );
+    super(ast, collected, ContractMember);
   }
 
   print(

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ModifierAttribute } from './ModifierAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class ModifierAttributes extends SlangNode {
+export class ModifierAttributes extends VariantCollection<
+  ast.ModifierAttributes,
+  ModifierAttribute
+> {
   readonly kind = NonterminalKind.ModifierAttributes;
 
-  items: ModifierAttribute['variant'][];
-
   constructor(ast: ast.ModifierAttributes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ModifierAttribute(item, collected))
-    );
+    super(ast, collected, ModifierAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { NamedArgument } from './NamedArgument.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,15 +11,14 @@ import type { PrintableNode } from './types.d.ts';
 
 const { line, softline } = doc.builders;
 
-export class NamedArguments extends SlangNode {
+export class NamedArguments extends NodeCollection<
+  ast.NamedArguments,
+  NamedArgument
+> {
   readonly kind = NonterminalKind.NamedArguments;
 
-  items: NamedArgument[];
-
   constructor(ast: ast.NamedArguments, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new NamedArgument(item, collected));
+    super(ast, collected, NamedArgument);
   }
 
   print(

--- a/src/slang-nodes/NodeCollection.ts
+++ b/src/slang-nodes/NodeCollection.ts
@@ -1,0 +1,25 @@
+import { SlangNode } from './SlangNode.js';
+
+import type { CollectedMetadata, SlangCollectionNode } from '../types.d.ts';
+import type { PrintableNode } from './types.d.ts';
+
+export abstract class NodeCollection<
+  A extends SlangCollectionNode,
+  I extends PrintableNode
+> extends SlangNode {
+  items: I[];
+
+  protected constructor(
+    ast: A,
+    collected: CollectedMetadata,
+    constructor: new (
+      ast: A['items'][number],
+      collected: CollectedMetadata
+    ) => I,
+    enclosePeripheralComments = true
+  ) {
+    super(ast, collected, enclosePeripheralComments);
+
+    this.items = ast.items.map((item) => new constructor(item, collected));
+  }
+}

--- a/src/slang-nodes/OverridePaths.ts
+++ b/src/slang-nodes/OverridePaths.ts
@@ -1,21 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class OverridePaths extends SlangNode {
+export class OverridePaths extends NodeCollection<
+  ast.OverridePaths,
+  IdentifierPath
+> {
   readonly kind = NonterminalKind.OverridePaths;
 
-  items: IdentifierPath[];
-
   constructor(ast: ast.OverridePaths, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new IdentifierPath(item, collected));
+    super(ast, collected, IdentifierPath);
   }
 
   print(print: PrintFunction, path: AstPath<OverridePaths>): Doc {

--- a/src/slang-nodes/Parameters.ts
+++ b/src/slang-nodes/Parameters.ts
@@ -2,7 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printComments } from '../slang-printers/print-comments.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { Parameter } from './Parameter.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,15 +10,11 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class Parameters extends SlangNode {
+export class Parameters extends NodeCollection<ast.Parameters, Parameter> {
   readonly kind = NonterminalKind.Parameters;
 
-  items: Parameter[];
-
   constructor(ast: ast.Parameters, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new Parameter(item, collected));
+    super(ast, collected, Parameter);
   }
 
   print(

--- a/src/slang-nodes/PositionalArguments.ts
+++ b/src/slang-nodes/PositionalArguments.ts
@@ -2,8 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printComments } from '../slang-printers/print-comments.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { Expression } from './Expression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class PositionalArguments extends SlangNode {
+export class PositionalArguments extends VariantCollection<
+  ast.PositionalArguments,
+  Expression
+> {
   readonly kind = NonterminalKind.PositionalArguments;
 
-  items: Expression['variant'][];
-
   constructor(ast: ast.PositionalArguments, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new Expression(item, collected))
-    );
+    super(ast, collected, Expression);
   }
 
   print(

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { ReceiveFunctionAttribute } from './ReceiveFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,20 +10,17 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class ReceiveFunctionAttributes extends SlangNode {
+export class ReceiveFunctionAttributes extends VariantCollection<
+  ast.ReceiveFunctionAttributes,
+  ReceiveFunctionAttribute
+> {
   readonly kind = NonterminalKind.ReceiveFunctionAttributes;
-
-  items: ReceiveFunctionAttribute['variant'][];
 
   constructor(
     ast: ast.ReceiveFunctionAttributes,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new ReceiveFunctionAttribute(item, collected))
-    );
+    super(ast, collected, ReceiveFunctionAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/SourceUnitMembers.ts
+++ b/src/slang-nodes/SourceUnitMembers.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { SourceUnitMember } from './SourceUnitMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class SourceUnitMembers extends SlangNode {
+export class SourceUnitMembers extends VariantCollection<
+  ast.SourceUnitMembers,
+  SourceUnitMember
+> {
   readonly kind = NonterminalKind.SourceUnitMembers;
 
-  items: SourceUnitMember['variant'][];
-
   constructor(ast: ast.SourceUnitMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new SourceUnitMember(item, collected))
-    );
+    super(ast, collected, SourceUnitMember);
   }
 
   print(

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { StateVariableAttribute } from './StateVariableAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,17 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class StateVariableAttributes extends SlangNode {
+export class StateVariableAttributes extends VariantCollection<
+  ast.StateVariableAttributes,
+  StateVariableAttribute
+> {
   readonly kind = NonterminalKind.StateVariableAttributes;
 
-  items: StateVariableAttribute['variant'][];
-
   constructor(ast: ast.StateVariableAttributes, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new StateVariableAttribute(item, collected))
-    );
+    super(ast, collected, StateVariableAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/Statements.ts
+++ b/src/slang-nodes/Statements.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { Statement } from './Statement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,11 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class Statements extends SlangNode {
+export class Statements extends VariantCollection<ast.Statements, Statement> {
   readonly kind = NonterminalKind.Statements;
 
-  items: Statement['variant'][];
-
   constructor(ast: ast.Statements, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new Statement(item, collected))
-    );
+    super(ast, collected, Statement);
   }
 
   print(

--- a/src/slang-nodes/StringLiterals.ts
+++ b/src/slang-nodes/StringLiterals.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join, hardline } = doc.builders;
 
-export class StringLiterals extends SlangNode {
+export class StringLiterals extends NodeCollection<
+  ast.StringLiterals,
+  StringLiteral
+> {
   readonly kind = NonterminalKind.StringLiterals;
 
-  items: StringLiteral[];
-
   constructor(ast: ast.StringLiterals, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new StringLiteral(item, collected));
+    super(ast, collected, StringLiteral);
   }
 
   print(print: PrintFunction, path: AstPath<StringLiterals>): Doc {

--- a/src/slang-nodes/StructMembers.ts
+++ b/src/slang-nodes/StructMembers.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { StructMember } from './StructMember.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,15 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { hardline } = doc.builders;
 
-export class StructMembers extends SlangNode {
+export class StructMembers extends NodeCollection<
+  ast.StructMembers,
+  StructMember
+> {
   readonly kind = NonterminalKind.StructMembers;
 
-  items: StructMember[];
-
   constructor(ast: ast.StructMembers, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new StructMember(item, collected));
+    super(ast, collected, StructMember);
   }
 
   print(print: PrintFunction, path: AstPath<StructMembers>): Doc {

--- a/src/slang-nodes/TupleDeconstructionElements.ts
+++ b/src/slang-nodes/TupleDeconstructionElements.ts
@@ -1,26 +1,23 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TupleDeconstructionElement } from './TupleDeconstructionElement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class TupleDeconstructionElements extends SlangNode {
+export class TupleDeconstructionElements extends NodeCollection<
+  ast.TupleDeconstructionElements,
+  TupleDeconstructionElement
+> {
   readonly kind = NonterminalKind.TupleDeconstructionElements;
-
-  items: TupleDeconstructionElement[];
 
   constructor(
     ast: ast.TupleDeconstructionElements,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map(
-      (item) => new TupleDeconstructionElement(item, collected)
-    );
+    super(ast, collected, TupleDeconstructionElement);
   }
 
   print(print: PrintFunction, path: AstPath<TupleDeconstructionElements>): Doc {

--- a/src/slang-nodes/TupleValues.ts
+++ b/src/slang-nodes/TupleValues.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TupleValue } from './TupleValue.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,11 @@ import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { Expression } from './Expression.ts';
 
-export class TupleValues extends SlangNode {
+export class TupleValues extends NodeCollection<ast.TupleValues, TupleValue> {
   readonly kind = NonterminalKind.TupleValues;
 
-  items: TupleValue[];
-
   constructor(ast: ast.TupleValues, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new TupleValue(item, collected));
+    super(ast, collected, TupleValue);
   }
 
   getSingleExpression(): Expression['variant'] | undefined {

--- a/src/slang-nodes/UnicodeStringLiterals.ts
+++ b/src/slang-nodes/UnicodeStringLiterals.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { UnicodeStringLiteral } from './UnicodeStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join, hardline } = doc.builders;
 
-export class UnicodeStringLiterals extends SlangNode {
+export class UnicodeStringLiterals extends NodeCollection<
+  ast.UnicodeStringLiterals,
+  UnicodeStringLiteral
+> {
   readonly kind = NonterminalKind.UnicodeStringLiterals;
 
-  items: UnicodeStringLiteral[];
-
   constructor(ast: ast.UnicodeStringLiterals, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map(
-      (item) => new UnicodeStringLiteral(item, collected)
-    );
+    super(ast, collected, UnicodeStringLiteral);
   }
 
   print(print: PrintFunction, path: AstPath<UnicodeStringLiterals>): Doc {

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -1,8 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { UnnamedFunctionAttribute } from './UnnamedFunctionAttribute.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,20 +10,17 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class UnnamedFunctionAttributes extends SlangNode {
+export class UnnamedFunctionAttributes extends VariantCollection<
+  ast.UnnamedFunctionAttributes,
+  UnnamedFunctionAttribute
+> {
   readonly kind = NonterminalKind.UnnamedFunctionAttributes;
-
-  items: UnnamedFunctionAttribute['variant'][];
 
   constructor(
     ast: ast.UnnamedFunctionAttributes,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new UnnamedFunctionAttribute(item, collected))
-    );
+    super(ast, collected, UnnamedFunctionAttribute);
 
     this.items.sort(sortFunctionAttributes);
   }

--- a/src/slang-nodes/UsingDeconstructionSymbols.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbols.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { UsingDeconstructionSymbol } from './UsingDeconstructionSymbol.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -11,20 +11,17 @@ import type { PrintableNode } from './types.d.ts';
 
 const { line, softline } = doc.builders;
 
-export class UsingDeconstructionSymbols extends SlangNode {
+export class UsingDeconstructionSymbols extends NodeCollection<
+  ast.UsingDeconstructionSymbols,
+  UsingDeconstructionSymbol
+> {
   readonly kind = NonterminalKind.UsingDeconstructionSymbols;
-
-  items: UsingDeconstructionSymbol[];
 
   constructor(
     ast: ast.UsingDeconstructionSymbols,
     collected: CollectedMetadata
   ) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map(
-      (item) => new UsingDeconstructionSymbol(item, collected)
-    );
+    super(ast, collected, UsingDeconstructionSymbol);
   }
 
   print(

--- a/src/slang-nodes/VariantCollection.ts
+++ b/src/slang-nodes/VariantCollection.ts
@@ -1,0 +1,27 @@
+import { extractVariant } from '../slang-utils/extract-variant.js';
+import { SlangNode } from './SlangNode.js';
+
+import type { CollectedMetadata, SlangVariantCollection } from '../types.d.ts';
+import type { StrictPolymorphicNode } from './types.d.ts';
+
+export abstract class VariantCollection<
+  A extends SlangVariantCollection,
+  I extends StrictPolymorphicNode
+> extends SlangNode {
+  items: I['variant'][];
+
+  protected constructor(
+    ast: A,
+    collected: CollectedMetadata,
+    constructor: new (
+      ast: A['items'][number],
+      collected: CollectedMetadata
+    ) => I
+  ) {
+    super(ast, collected, true);
+
+    this.items = ast.items.map((item) =>
+      extractVariant(new constructor(item, collected))
+    );
+  }
+}

--- a/src/slang-nodes/VersionExpressionSet.ts
+++ b/src/slang-nodes/VersionExpressionSet.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { VersionExpression } from './VersionExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,17 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class VersionExpressionSet extends SlangNode {
+export class VersionExpressionSet extends VariantCollection<
+  ast.VersionExpressionSet,
+  VersionExpression
+> {
   readonly kind = NonterminalKind.VersionExpressionSet;
 
-  items: VersionExpression['variant'][];
-
   constructor(ast: ast.VersionExpressionSet, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new VersionExpression(item, collected))
-    );
+    super(ast, collected, VersionExpression);
   }
 
   print(print: PrintFunction, path: AstPath<VersionExpressionSet>): Doc {

--- a/src/slang-nodes/VersionExpressionSets.ts
+++ b/src/slang-nodes/VersionExpressionSets.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { VersionExpressionSet } from './VersionExpressionSet.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class VersionExpressionSets extends SlangNode {
+export class VersionExpressionSets extends NodeCollection<
+  ast.VersionExpressionSets,
+  VersionExpressionSet
+> {
   readonly kind = NonterminalKind.VersionExpressionSets;
 
-  items: VersionExpressionSet[];
-
   constructor(ast: ast.VersionExpressionSets, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map(
-      (item) => new VersionExpressionSet(item, collected)
-    );
+    super(ast, collected, VersionExpressionSet);
   }
 
   print(print: PrintFunction, path: AstPath<VersionExpressionSets>): Doc {

--- a/src/slang-nodes/YulArguments.ts
+++ b/src/slang-nodes/YulArguments.ts
@@ -1,24 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { YulExpression } from './YulExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class YulArguments extends SlangNode {
+export class YulArguments extends VariantCollection<
+  ast.YulArguments,
+  YulExpression
+> {
   readonly kind = NonterminalKind.YulArguments;
 
-  items: YulExpression['variant'][];
-
   constructor(ast: ast.YulArguments, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new YulExpression(item, collected))
-    );
+    super(ast, collected, YulExpression);
   }
 
   print(print: PrintFunction, path: AstPath<YulArguments>): Doc {

--- a/src/slang-nodes/YulParameters.ts
+++ b/src/slang-nodes/YulParameters.ts
@@ -1,21 +1,20 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class YulParameters extends SlangNode {
+export class YulParameters extends NodeCollection<
+  ast.YulParameters,
+  TerminalNode
+> {
   readonly kind = NonterminalKind.YulParameters;
 
-  items: TerminalNode[];
-
   constructor(ast: ast.YulParameters, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new TerminalNode(item, collected));
+    super(ast, collected, TerminalNode);
   }
 
   print(print: PrintFunction, path: AstPath<YulParameters>): Doc {

--- a/src/slang-nodes/YulPath.ts
+++ b/src/slang-nodes/YulPath.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,11 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class YulPath extends SlangNode {
+export class YulPath extends NodeCollection<ast.YulPath, TerminalNode> {
   readonly kind = NonterminalKind.YulPath;
 
-  items: TerminalNode[];
-
   constructor(ast: ast.YulPath, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new TerminalNode(item, collected));
+    super(ast, collected, TerminalNode);
   }
 
   print(print: PrintFunction, path: AstPath<YulPath>): Doc {

--- a/src/slang-nodes/YulPaths.ts
+++ b/src/slang-nodes/YulPaths.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { YulPath } from './YulPath.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,15 +9,11 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { join } = doc.builders;
 
-export class YulPaths extends SlangNode {
+export class YulPaths extends NodeCollection<ast.YulPaths, YulPath> {
   readonly kind = NonterminalKind.YulPaths;
 
-  items: YulPath[];
-
   constructor(ast: ast.YulPaths, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new YulPath(item, collected));
+    super(ast, collected, YulPath);
   }
 
   print(print: PrintFunction, path: AstPath<YulPaths>): Doc {

--- a/src/slang-nodes/YulStatements.ts
+++ b/src/slang-nodes/YulStatements.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printIndentedPreservingEmptyLines } from '../slang-printers/print-preserving-empty-lines.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { YulStatement } from './YulStatement.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -9,17 +8,14 @@ import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class YulStatements extends SlangNode {
+export class YulStatements extends VariantCollection<
+  ast.YulStatements,
+  YulStatement
+> {
   readonly kind = NonterminalKind.YulStatements;
 
-  items: YulStatement['variant'][];
-
   constructor(ast: ast.YulStatements, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new YulStatement(item, collected))
-    );
+    super(ast, collected, YulStatement);
   }
 
   print(

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -1,7 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { VariantCollection } from './VariantCollection.js';
 import { YulSwitchCase } from './YulSwitchCase.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,17 +9,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { hardline, join } = doc.builders;
 
-export class YulSwitchCases extends SlangNode {
+export class YulSwitchCases extends VariantCollection<
+  ast.YulSwitchCases,
+  YulSwitchCase
+> {
   readonly kind = NonterminalKind.YulSwitchCases;
 
-  items: YulSwitchCase['variant'][];
-
   constructor(ast: ast.YulSwitchCases, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) =>
-      extractVariant(new YulSwitchCase(item, collected))
-    );
+    super(ast, collected, YulSwitchCase);
   }
 
   print(print: PrintFunction, path: AstPath<YulSwitchCases>): Doc {

--- a/src/slang-nodes/YulVariableNames.ts
+++ b/src/slang-nodes/YulVariableNames.ts
@@ -1,7 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
-import { SlangNode } from './SlangNode.js';
+import { NodeCollection } from './NodeCollection.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
@@ -10,15 +10,14 @@ import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
 const { line } = doc.builders;
 
-export class YulVariableNames extends SlangNode {
+export class YulVariableNames extends NodeCollection<
+  ast.YulVariableNames,
+  TerminalNode
+> {
   readonly kind = NonterminalKind.YulVariableNames;
 
-  items: TerminalNode[];
-
   constructor(ast: ast.YulVariableNames, collected: CollectedMetadata) {
-    super(ast, collected, true);
-
-    this.items = ast.items.map((item) => new TerminalNode(item, collected));
+    super(ast, collected, TerminalNode);
   }
 
   print(print: PrintFunction, path: AstPath<YulVariableNames>): Doc {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import type * as ast from '@nomicfoundation/slang/ast';
+import type { TerminalNode as SlangTerminalNode } from '@nomicfoundation/slang/cst';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from './slang-nodes/types.d.ts';
 
@@ -36,3 +37,42 @@ type ValuesOf<E> = E[keyof E];
 
 type SlangAstNode = { [k in KeyOfAst]: ValuesOf<TypeOfAst[k]> }[KeyOfAst];
 type SlangAstNodeClass = { [k in KeyOfAst]: TypeOfAst[k] }[KeyOfAst];
+
+type SlangPolymorphicNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode | SlangTerminalNode }
+>;
+
+type SlangPolymorphicNonterminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode }
+>;
+
+type SlangPolymorphicTerminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangTerminalNode }
+>;
+
+type SlangCollectionNode = Extract<
+  SlangAstNode,
+  { items: readonly (SlangAstNode | SlangTerminalNode)[] }
+>;
+
+type SlangVariantCollection = Extract<
+  SlangCollectionNode,
+  { items: readonly SlangPolymorphicNode[] }
+>;
+
+type SlangBinaryOperation = Extract<
+  SlangAstNode,
+  {
+    leftOperand: ast.Expression;
+    operator: SlangTerminalNode;
+    rightOperand: ast.Expression;
+  }
+>;
+
+type SlangUnaryOperation = Extract<
+  SlangAstNode,
+  { operand: ast.Expression; operator: SlangTerminalNode }
+>;


### PR DESCRIPTION
So all collections, have an `items` attribute. This attribute in some cases is an array of nodes and in others is an array of polymorphic nodes.

by adding a base class for each case we clean up a lot of boilerplate.