### PR TITLE
Polymorphic base classes

### DIFF
--- a/src/slang-nodes/AbicoderVersion.ts
+++ b/src/slang-nodes/AbicoderVersion.ts
@@ -1,22 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class AbicoderVersion extends SlangNode {
+export class AbicoderVersion extends PolymorphicString {
   readonly kind = NonterminalKind.AbicoderVersion;
-
-  variant: string;
 
   constructor(ast: ast.AbicoderVersion, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-  }
-
-  print(): Doc {
-    return this.variant;
   }
 }

--- a/src/slang-nodes/ArgumentsDeclaration.ts
+++ b/src/slang-nodes/ArgumentsDeclaration.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { PositionalArgumentsDeclaration } from './PositionalArgumentsDeclaration.js';
 import { NamedArgumentsDeclaration } from './NamedArgumentsDeclaration.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.NamedArgumentsDeclaration, NamedArgumentsDeclaration]
 ]);
 
-export class ArgumentsDeclaration extends SlangNode {
+export class ArgumentsDeclaration extends PolymorphicNonterminalNode<
+  ast.ArgumentsDeclaration,
+  PositionalArgumentsDeclaration | NamedArgumentsDeclaration
+> {
   readonly kind = NonterminalKind.ArgumentsDeclaration;
 
-  variant: PositionalArgumentsDeclaration | NamedArgumentsDeclaration;
-
   constructor(ast: ast.ArgumentsDeclaration, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ConstructorAttribute.ts
+++ b/src/slang-nodes/ConstructorAttribute.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class ConstructorAttribute extends SlangNode {
+export class ConstructorAttribute extends PolymorphicNode<
+  ast.ConstructorAttribute,
+  ModifierInvocation | TerminalNode
+> {
   readonly kind = NonterminalKind.ConstructorAttribute;
 
-  variant: ModifierInvocation | TerminalNode;
-
   constructor(ast: ast.ConstructorAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new ModifierInvocation(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new ModifierInvocation(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/ContractMember.ts
+++ b/src/slang-nodes/ContractMember.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { UsingDirective } from './UsingDirective.js';
 import { FunctionDefinition } from './FunctionDefinition.js';
 import { ConstructorDefinition } from './ConstructorDefinition.js';
@@ -37,29 +37,25 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.UserDefinedValueTypeDefinition, UserDefinedValueTypeDefinition]
 ]);
 
-export class ContractMember extends SlangNode {
+export class ContractMember extends PolymorphicNonterminalNode<
+  ast.ContractMember,
+  | UsingDirective
+  | FunctionDefinition
+  | ConstructorDefinition
+  | ReceiveFunctionDefinition
+  | FallbackFunctionDefinition
+  | UnnamedFunctionDefinition
+  | ModifierDefinition
+  | StructDefinition
+  | EnumDefinition
+  | EventDefinition
+  | StateVariableDefinition
+  | ErrorDefinition
+  | UserDefinedValueTypeDefinition
+> {
   readonly kind = NonterminalKind.ContractMember;
 
-  variant:
-    | UsingDirective
-    | FunctionDefinition
-    | ConstructorDefinition
-    | ReceiveFunctionDefinition
-    | FallbackFunctionDefinition
-    | UnnamedFunctionDefinition
-    | ModifierDefinition
-    | StructDefinition
-    | EnumDefinition
-    | EventDefinition
-    | StateVariableDefinition
-    | ErrorDefinition
-    | UserDefinedValueTypeDefinition;
-
   constructor(ast: ast.ContractMember, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ContractSpecifier.ts
+++ b/src/slang-nodes/ContractSpecifier.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
 import { StorageLayoutSpecifier } from './StorageLayoutSpecifier.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.StorageLayoutSpecifier, StorageLayoutSpecifier]
 ]);
 
-export class ContractSpecifier extends SlangNode {
+export class ContractSpecifier extends PolymorphicNonterminalNode<
+  ast.ContractSpecifier,
+  InheritanceSpecifier | StorageLayoutSpecifier
+> {
   readonly kind = NonterminalKind.ContractSpecifier;
 
-  variant: InheritanceSpecifier | StorageLayoutSpecifier;
-
   constructor(ast: ast.ContractSpecifier, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ElementaryType.ts
+++ b/src/slang-nodes/ElementaryType.ts
@@ -1,29 +1,18 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { AddressType } from './AddressType.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class ElementaryType extends SlangNode {
+export class ElementaryType extends PolymorphicNode<
+  ast.ElementaryType,
+  AddressType | TerminalNode
+> {
   readonly kind = NonterminalKind.ElementaryType;
 
-  variant: AddressType | TerminalNode;
-
   constructor(ast: ast.ElementaryType, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new AddressType(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) => new AddressType(variant, collected));
   }
 }

--- a/src/slang-nodes/ExperimentalFeature.ts
+++ b/src/slang-nodes/ExperimentalFeature.ts
@@ -1,29 +1,18 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { StringLiteral } from './StringLiteral.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class ExperimentalFeature extends SlangNode {
+export class ExperimentalFeature extends PolymorphicNode<
+  ast.ExperimentalFeature,
+  StringLiteral | TerminalNode
+> {
   readonly kind = NonterminalKind.ExperimentalFeature;
 
-  variant: StringLiteral | TerminalNode;
-
   constructor(ast: ast.ExperimentalFeature, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new StringLiteral(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) => new StringLiteral(variant, collected));
   }
 }

--- a/src/slang-nodes/Expression.ts
+++ b/src/slang-nodes/Expression.ts
@@ -1,10 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { AssignmentExpression } from './AssignmentExpression.js';
 import { ConditionalExpression } from './ConditionalExpression.js';
 import { OrExpression } from './OrExpression.js';
@@ -32,9 +29,9 @@ import { HexNumberExpression } from './HexNumberExpression.js';
 import { DecimalNumberExpression } from './DecimalNumberExpression.js';
 import { StringExpression } from './StringExpression.js';
 import { ElementaryType } from './ElementaryType.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantCreator<
   ast.Expression,
@@ -73,49 +70,42 @@ const createNonterminalVariant = createNonterminalVariantCreator<
   ]
 );
 
-export class Expression extends SlangNode {
+export class Expression extends PolymorphicNode<
+  ast.Expression,
+  | AssignmentExpression
+  | ConditionalExpression
+  | OrExpression
+  | AndExpression
+  | EqualityExpression
+  | InequalityExpression
+  | BitwiseOrExpression
+  | BitwiseXorExpression
+  | BitwiseAndExpression
+  | ShiftExpression
+  | AdditiveExpression
+  | MultiplicativeExpression
+  | ExponentiationExpression
+  | PostfixExpression
+  | PrefixExpression
+  | FunctionCallExpression
+  | CallOptionsExpression
+  | MemberAccessExpression
+  | IndexAccessExpression
+  | NewExpression
+  | TupleExpression
+  | TypeExpression
+  | ArrayExpression
+  | HexNumberExpression
+  | DecimalNumberExpression
+  | StringExpression['variant']
+  | ElementaryType['variant']
+  | TerminalNode
+> {
   readonly kind = NonterminalKind.Expression;
 
-  variant:
-    | AssignmentExpression
-    | ConditionalExpression
-    | OrExpression
-    | AndExpression
-    | EqualityExpression
-    | InequalityExpression
-    | BitwiseOrExpression
-    | BitwiseXorExpression
-    | BitwiseAndExpression
-    | ShiftExpression
-    | AdditiveExpression
-    | MultiplicativeExpression
-    | ExponentiationExpression
-    | PostfixExpression
-    | PrefixExpression
-    | FunctionCallExpression
-    | CallOptionsExpression
-    | MemberAccessExpression
-    | IndexAccessExpression
-    | NewExpression
-    | TupleExpression
-    | TypeExpression
-    | ArrayExpression
-    | HexNumberExpression
-    | DecimalNumberExpression
-    | StringExpression['variant']
-    | ElementaryType['variant']
-    | TerminalNode;
-
   constructor(ast: ast.Expression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) =>
+      createNonterminalVariant(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/FallbackFunctionAttribute.ts
+++ b/src/slang-nodes/FallbackFunctionAttribute.ts
@@ -1,15 +1,12 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.FallbackFunctionAttribute,
@@ -19,24 +16,16 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.OverrideSpecifier, OverrideSpecifier]
 ]);
 
-export class FallbackFunctionAttribute extends SlangNode {
+export class FallbackFunctionAttribute extends PolymorphicNode<
+  ast.FallbackFunctionAttribute,
+  ModifierInvocation | OverrideSpecifier | TerminalNode
+> {
   readonly kind = NonterminalKind.FallbackFunctionAttribute;
-
-  variant: ModifierInvocation | OverrideSpecifier | TerminalNode;
 
   constructor(
     ast: ast.FallbackFunctionAttribute,
     collected: CollectedMetadata
   ) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ForStatementCondition.ts
+++ b/src/slang-nodes/ForStatementCondition.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class ForStatementCondition extends SlangNode {
+export class ForStatementCondition extends PolymorphicNode<
+  ast.ForStatementCondition,
+  ExpressionStatement | TerminalNode
+> {
   readonly kind = NonterminalKind.ForStatementCondition;
 
-  variant: ExpressionStatement | TerminalNode;
-
   constructor(ast: ast.ForStatementCondition, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new ExpressionStatement(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new ExpressionStatement(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/ForStatementInitialization.ts
+++ b/src/slang-nodes/ForStatementInitialization.ts
@@ -1,16 +1,13 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ForStatementInitialization,
@@ -21,28 +18,21 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.TupleDeconstructionStatement, TupleDeconstructionStatement]
 ]);
 
-export class ForStatementInitialization extends SlangNode {
+export class ForStatementInitialization extends PolymorphicNode<
+  ast.ForStatementInitialization,
+  | ExpressionStatement
+  | VariableDeclarationStatement
+  | TupleDeconstructionStatement
+  | TerminalNode
+> {
   readonly kind = NonterminalKind.ForStatementInitialization;
-
-  variant:
-    | ExpressionStatement
-    | VariableDeclarationStatement
-    | TupleDeconstructionStatement
-    | TerminalNode;
 
   constructor(
     ast: ast.ForStatementInitialization,
     collected: CollectedMetadata
   ) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) =>
+      createNonterminalVariant(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/FunctionAttribute.ts
+++ b/src/slang-nodes/FunctionAttribute.ts
@@ -1,15 +1,12 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.FunctionAttribute,
@@ -19,21 +16,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.OverrideSpecifier, OverrideSpecifier]
 ]);
 
-export class FunctionAttribute extends SlangNode {
+export class FunctionAttribute extends PolymorphicNode<
+  ast.FunctionAttribute,
+  ModifierInvocation | OverrideSpecifier | TerminalNode
+> {
   readonly kind = NonterminalKind.FunctionAttribute;
 
-  variant: ModifierInvocation | OverrideSpecifier | TerminalNode;
-
   constructor(ast: ast.FunctionAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/FunctionBody.ts
+++ b/src/slang-nodes/FunctionBody.ts
@@ -1,29 +1,18 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { Block } from './Block.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class FunctionBody extends SlangNode {
+export class FunctionBody extends PolymorphicNode<
+  ast.FunctionBody,
+  Block | TerminalNode
+> {
   readonly kind = NonterminalKind.FunctionBody;
 
-  variant: Block | TerminalNode;
-
   constructor(ast: ast.FunctionBody, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new Block(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) => new Block(variant, collected));
   }
 }

--- a/src/slang-nodes/FunctionName.ts
+++ b/src/slang-nodes/FunctionName.ts
@@ -1,18 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
-import { TerminalNode } from './TerminalNode.js';
+import { PolymorphicTerminalNode } from './PolymorphicTerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class FunctionName extends SlangNode {
+export class FunctionName extends PolymorphicTerminalNode {
   readonly kind = NonterminalKind.FunctionName;
-
-  variant: TerminalNode;
 
   constructor(ast: ast.FunctionName, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = new TerminalNode(ast.variant, collected);
   }
 }

--- a/src/slang-nodes/FunctionTypeAttribute.ts
+++ b/src/slang-nodes/FunctionTypeAttribute.ts
@@ -1,18 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
-import { TerminalNode } from './TerminalNode.js';
+import { PolymorphicTerminalNode } from './PolymorphicTerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class FunctionTypeAttribute extends SlangNode {
+export class FunctionTypeAttribute extends PolymorphicTerminalNode {
   readonly kind = NonterminalKind.FunctionTypeAttribute;
-
-  variant: TerminalNode;
 
   constructor(ast: ast.FunctionTypeAttribute, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = new TerminalNode(ast.variant, collected);
   }
 }

--- a/src/slang-nodes/HexStringLiteral.ts
+++ b/src/slang-nodes/HexStringLiteral.ts
@@ -1,25 +1,18 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printString } from '../slang-printers/print-string.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class HexStringLiteral extends SlangNode {
+export class HexStringLiteral extends PolymorphicString {
   readonly kind = NonterminalKind.HexStringLiteral;
 
-  variant: string;
-
   constructor(ast: ast.HexStringLiteral, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-
-    this.variant = `hex${printString(this.variant.slice(4, -1), collected.options)}`;
-  }
-
-  print(): Doc {
-    return this.variant;
+    super(
+      ast,
+      collected,
+      (raw) => `hex${printString(raw.slice(4, -1), collected.options)}`
+    );
   }
 }

--- a/src/slang-nodes/ImportClause.ts
+++ b/src/slang-nodes/ImportClause.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { PathImport } from './PathImport.js';
 import { NamedImport } from './NamedImport.js';
 import { ImportDeconstruction } from './ImportDeconstruction.js';
@@ -17,16 +17,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.ImportDeconstruction, ImportDeconstruction]
 ]);
 
-export class ImportClause extends SlangNode {
+export class ImportClause extends PolymorphicNonterminalNode<
+  ast.ImportClause,
+  PathImport | NamedImport | ImportDeconstruction
+> {
   readonly kind = NonterminalKind.ImportClause;
 
-  variant: PathImport | NamedImport | ImportDeconstruction;
-
   constructor(ast: ast.ImportClause, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/MappingKeyType.ts
+++ b/src/slang-nodes/MappingKeyType.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { ElementaryType } from './ElementaryType.js';
 import { IdentifierPath } from './IdentifierPath.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantCreator<
   [[ast.ElementaryType, ElementaryType]]
 );
 
-export class MappingKeyType extends SlangNode {
+export class MappingKeyType extends PolymorphicNonterminalNode<
+  ast.MappingKeyType,
+  ElementaryType['variant'] | IdentifierPath
+> {
   readonly kind = NonterminalKind.MappingKeyType;
 
-  variant: ElementaryType['variant'] | IdentifierPath;
-
   constructor(ast: ast.MappingKeyType, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ModifierAttribute.ts
+++ b/src/slang-nodes/ModifierAttribute.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class ModifierAttribute extends SlangNode {
+export class ModifierAttribute extends PolymorphicNode<
+  ast.ModifierAttribute,
+  OverrideSpecifier | TerminalNode
+> {
   readonly kind = NonterminalKind.ModifierAttribute;
 
-  variant: OverrideSpecifier | TerminalNode;
-
   constructor(ast: ast.ModifierAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new OverrideSpecifier(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new OverrideSpecifier(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/NumberUnit.ts
+++ b/src/slang-nodes/NumberUnit.ts
@@ -1,22 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class NumberUnit extends SlangNode {
+export class NumberUnit extends PolymorphicString {
   readonly kind = NonterminalKind.NumberUnit;
-
-  variant: string;
 
   constructor(ast: ast.NumberUnit, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-  }
-
-  print(): Doc {
-    return this.variant;
   }
 }

--- a/src/slang-nodes/PolymorphicNode.ts
+++ b/src/slang-nodes/PolymorphicNode.ts
@@ -1,0 +1,36 @@
+import { TerminalNode as SlangTerminalNode } from '@nomicfoundation/slang/cst';
+import { SlangNode } from './SlangNode.js';
+import { TerminalNode } from './TerminalNode.js';
+
+import type { CollectedMetadata, SlangPolymorphicNode } from '../types.d.ts';
+import type { PrintableNode } from './types.d.ts';
+
+export abstract class PolymorphicNode<
+  A extends SlangPolymorphicNode,
+  V extends PrintableNode | TerminalNode
+> extends SlangNode {
+  variant: V;
+
+  protected constructor(
+    ast: A,
+    collected: CollectedMetadata,
+    createNonterminalVariant: (
+      variant: Exclude<A['variant'], SlangTerminalNode>,
+      collected: CollectedMetadata
+    ) => V
+  ) {
+    super(ast, collected);
+
+    const variant = ast.variant;
+    if (variant instanceof SlangTerminalNode) {
+      this.variant = new TerminalNode(variant, collected) as V;
+      return;
+    }
+    this.variant = createNonterminalVariant(
+      variant as Exclude<A['variant'], SlangTerminalNode>,
+      collected
+    );
+
+    this.updateMetadata(this.variant);
+  }
+}

--- a/src/slang-nodes/PolymorphicNonterminalNode.ts
+++ b/src/slang-nodes/PolymorphicNonterminalNode.ts
@@ -1,0 +1,26 @@
+import { SlangNode } from './SlangNode.js';
+
+import type {
+  CollectedMetadata,
+  SlangPolymorphicNonterminalNode
+} from '../types.d.ts';
+import type { PrintableNode } from './types.d.ts';
+
+export abstract class PolymorphicNonterminalNode<
+  A extends SlangPolymorphicNonterminalNode,
+  V extends PrintableNode
+> extends SlangNode {
+  variant: V;
+
+  protected constructor(
+    ast: A,
+    collected: CollectedMetadata,
+    createVariant: (variant: A['variant'], collected: CollectedMetadata) => V
+  ) {
+    super(ast, collected);
+
+    this.variant = createVariant(ast.variant, collected);
+
+    this.updateMetadata(this.variant);
+  }
+}

--- a/src/slang-nodes/PolymorphicString.ts
+++ b/src/slang-nodes/PolymorphicString.ts
@@ -1,0 +1,25 @@
+import { SlangNode } from './SlangNode.js';
+
+import type { Doc } from 'prettier';
+import type {
+  CollectedMetadata,
+  SlangPolymorphicTerminalNode
+} from '../types.d.ts';
+
+export abstract class PolymorphicString extends SlangNode {
+  variant: string;
+
+  protected constructor(
+    ast: SlangPolymorphicTerminalNode,
+    collected: CollectedMetadata,
+    process?: (raw: string) => string
+  ) {
+    super(ast, collected);
+    const raw = ast.variant.unparse();
+    this.variant = process ? process(raw) : raw;
+  }
+
+  print(): Doc {
+    return this.variant;
+  }
+}

--- a/src/slang-nodes/PolymorphicTerminalNode.ts
+++ b/src/slang-nodes/PolymorphicTerminalNode.ts
@@ -1,0 +1,20 @@
+import { SlangNode } from './SlangNode.js';
+import { TerminalNode } from './TerminalNode.js';
+
+import type {
+  CollectedMetadata,
+  SlangPolymorphicTerminalNode
+} from '../types.d.ts';
+
+export abstract class PolymorphicTerminalNode extends SlangNode {
+  variant: TerminalNode;
+
+  protected constructor(
+    ast: SlangPolymorphicTerminalNode,
+    collected: CollectedMetadata
+  ) {
+    super(ast, collected);
+
+    this.variant = new TerminalNode(ast.variant, collected);
+  }
+}

--- a/src/slang-nodes/Pragma.ts
+++ b/src/slang-nodes/Pragma.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { AbicoderPragma } from './AbicoderPragma.js';
 import { ExperimentalPragma } from './ExperimentalPragma.js';
 import { VersionPragma } from './VersionPragma.js';
@@ -17,16 +17,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.VersionPragma, VersionPragma]
 ]);
 
-export class Pragma extends SlangNode {
+export class Pragma extends PolymorphicNonterminalNode<
+  ast.Pragma,
+  AbicoderPragma | ExperimentalPragma | VersionPragma
+> {
   readonly kind = NonterminalKind.Pragma;
 
-  variant: AbicoderPragma | ExperimentalPragma | VersionPragma;
-
   constructor(ast: ast.Pragma, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/ReceiveFunctionAttribute.ts
+++ b/src/slang-nodes/ReceiveFunctionAttribute.ts
@@ -1,15 +1,12 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.ReceiveFunctionAttribute,
@@ -19,21 +16,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.OverrideSpecifier, OverrideSpecifier]
 ]);
 
-export class ReceiveFunctionAttribute extends SlangNode {
+export class ReceiveFunctionAttribute extends PolymorphicNode<
+  ast.ReceiveFunctionAttribute,
+  ModifierInvocation | OverrideSpecifier | TerminalNode
+> {
   readonly kind = NonterminalKind.ReceiveFunctionAttribute;
 
-  variant: ModifierInvocation | OverrideSpecifier | TerminalNode;
-
   constructor(ast: ast.ReceiveFunctionAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/SourceUnitMember.ts
+++ b/src/slang-nodes/SourceUnitMember.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { PragmaDirective } from './PragmaDirective.js';
 import { ImportDirective } from './ImportDirective.js';
 import { ContractDefinition } from './ContractDefinition.js';
@@ -37,29 +37,25 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.EventDefinition, EventDefinition]
 ]);
 
-export class SourceUnitMember extends SlangNode {
+export class SourceUnitMember extends PolymorphicNonterminalNode<
+  ast.SourceUnitMember,
+  | PragmaDirective
+  | ImportDirective
+  | ContractDefinition
+  | InterfaceDefinition
+  | LibraryDefinition
+  | StructDefinition
+  | EnumDefinition
+  | FunctionDefinition
+  | ConstantDefinition
+  | ErrorDefinition
+  | UserDefinedValueTypeDefinition
+  | UsingDirective
+  | EventDefinition
+> {
   readonly kind = NonterminalKind.SourceUnitMember;
 
-  variant:
-    | PragmaDirective
-    | ImportDirective
-    | ContractDefinition
-    | InterfaceDefinition
-    | LibraryDefinition
-    | StructDefinition
-    | EnumDefinition
-    | FunctionDefinition
-    | ConstantDefinition
-    | ErrorDefinition
-    | UserDefinedValueTypeDefinition
-    | UsingDirective
-    | EventDefinition;
-
   constructor(ast: ast.SourceUnitMember, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/StateVariableAttribute.ts
+++ b/src/slang-nodes/StateVariableAttribute.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { OverrideSpecifier } from './OverrideSpecifier.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class StateVariableAttribute extends SlangNode {
+export class StateVariableAttribute extends PolymorphicNode<
+  ast.StateVariableAttribute,
+  OverrideSpecifier | TerminalNode
+> {
   readonly kind = NonterminalKind.StateVariableAttribute;
 
-  variant: OverrideSpecifier | TerminalNode;
-
   constructor(ast: ast.StateVariableAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new OverrideSpecifier(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new OverrideSpecifier(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/Statement.ts
+++ b/src/slang-nodes/Statement.ts
@@ -1,7 +1,7 @@
 import * as slangAst from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ExpressionStatement } from './ExpressionStatement.js';
 import { VariableDeclarationStatement } from './VariableDeclarationStatement.js';
 import { TupleDeconstructionStatement } from './TupleDeconstructionStatement.js';
@@ -44,37 +44,33 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [slangAst.UncheckedBlock, UncheckedBlock]
 ]);
 
-export class Statement extends SlangNode {
+export class Statement extends PolymorphicNode<
+  slangAst.Statement,
+  | ExpressionStatement
+  | VariableDeclarationStatement
+  | TupleDeconstructionStatement
+  | IfStatement
+  | ForStatement
+  | WhileStatement
+  | DoWhileStatement
+  | ContinueStatement
+  | BreakStatement
+  | ReturnStatement
+  | ThrowStatement
+  | EmitStatement
+  | TryStatement
+  | RevertStatement
+  | AssemblyStatement
+  | Block
+  | UncheckedBlock
+> {
   readonly kind = NonterminalKind.Statement;
 
-  variant:
-    | ExpressionStatement
-    | VariableDeclarationStatement
-    | TupleDeconstructionStatement
-    | IfStatement
-    | ForStatement
-    | WhileStatement
-    | DoWhileStatement
-    | ContinueStatement
-    | BreakStatement
-    | ReturnStatement
-    | ThrowStatement
-    | EmitStatement
-    | TryStatement
-    | RevertStatement
-    | AssemblyStatement
-    | Block
-    | UncheckedBlock;
-
   constructor(ast: slangAst.Statement, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    this.variant =
+    super(ast, collected, (variant) =>
       variant instanceof slangAst.Block
         ? new Block(variant, collected)
-        : createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+        : createNonterminalVariant(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/StorageLocation.ts
+++ b/src/slang-nodes/StorageLocation.ts
@@ -1,22 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class StorageLocation extends SlangNode {
+export class StorageLocation extends PolymorphicString {
   readonly kind = NonterminalKind.StorageLocation;
-
-  variant: string;
 
   constructor(ast: ast.StorageLocation, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-  }
-
-  print(): Doc {
-    return this.variant;
   }
 }

--- a/src/slang-nodes/StringExpression.ts
+++ b/src/slang-nodes/StringExpression.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { StringLiteral } from './StringLiteral.js';
 import { StringLiterals } from './StringLiterals.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
@@ -21,21 +21,17 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.UnicodeStringLiterals, UnicodeStringLiterals]
 ]);
 
-export class StringExpression extends SlangNode {
+export class StringExpression extends PolymorphicNonterminalNode<
+  ast.StringExpression,
+  | StringLiteral
+  | StringLiterals
+  | HexStringLiteral
+  | HexStringLiterals
+  | UnicodeStringLiterals
+> {
   readonly kind = NonterminalKind.StringExpression;
 
-  variant:
-    | StringLiteral
-    | StringLiterals
-    | HexStringLiteral
-    | HexStringLiterals
-    | UnicodeStringLiterals;
-
   constructor(ast: ast.StringExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/StringLiteral.ts
+++ b/src/slang-nodes/StringLiteral.ts
@@ -1,25 +1,16 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printString } from '../slang-printers/print-string.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class StringLiteral extends SlangNode {
+export class StringLiteral extends PolymorphicString {
   readonly kind = NonterminalKind.StringLiteral;
 
-  variant: string;
-
   constructor(ast: ast.StringLiteral, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-
-    this.variant = printString(this.variant.slice(1, -1), collected.options);
-  }
-
-  print(): Doc {
-    return this.variant;
+    super(ast, collected, (raw) =>
+      printString(raw.slice(1, -1), collected.options)
+    );
   }
 }

--- a/src/slang-nodes/TupleMember.ts
+++ b/src/slang-nodes/TupleMember.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypedTupleMember } from './TypedTupleMember.js';
 import { UntypedTupleMember } from './UntypedTupleMember.js';
 
@@ -15,16 +15,15 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.UntypedTupleMember, UntypedTupleMember]
 ]);
 
-export class TupleMember extends SlangNode {
+export class TupleMember extends PolymorphicNode<
+  ast.TupleMember,
+  TypedTupleMember | UntypedTupleMember
+> {
   readonly kind = NonterminalKind.TupleMember;
 
-  variant: TypedTupleMember | UntypedTupleMember;
-
   constructor(ast: ast.TupleMember, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) =>
+      createNonterminalVariant(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/TypeName.ts
+++ b/src/slang-nodes/TypeName.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { ArrayTypeName } from './ArrayTypeName.js';
 import { FunctionType } from './FunctionType.js';
 import { MappingType } from './MappingType.js';
@@ -23,21 +23,17 @@ const createNonterminalVariant = createNonterminalVariantCreator<
   [[ast.ElementaryType, ElementaryType]]
 );
 
-export class TypeName extends SlangNode {
+export class TypeName extends PolymorphicNonterminalNode<
+  ast.TypeName,
+  | ArrayTypeName
+  | FunctionType
+  | MappingType
+  | ElementaryType['variant']
+  | IdentifierPath
+> {
   readonly kind = NonterminalKind.TypeName;
 
-  variant:
-    | ArrayTypeName
-    | FunctionType
-    | MappingType
-    | ElementaryType['variant']
-    | IdentifierPath;
-
   constructor(ast: ast.TypeName, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/UnicodeStringLiteral.ts
+++ b/src/slang-nodes/UnicodeStringLiteral.ts
@@ -1,25 +1,18 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printString } from '../slang-printers/print-string.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class UnicodeStringLiteral extends SlangNode {
+export class UnicodeStringLiteral extends PolymorphicString {
   readonly kind = NonterminalKind.UnicodeStringLiteral;
 
-  variant: string;
-
   constructor(ast: ast.UnicodeStringLiteral, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-
-    this.variant = `unicode${printString(this.variant.slice(8, -1), collected.options)}`;
-  }
-
-  print(): Doc {
-    return this.variant;
+    super(
+      ast,
+      collected,
+      (raw) => `unicode${printString(raw.slice(8, -1), collected.options)}`
+    );
   }
 }

--- a/src/slang-nodes/UnnamedFunctionAttribute.ts
+++ b/src/slang-nodes/UnnamedFunctionAttribute.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { ModifierInvocation } from './ModifierInvocation.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class UnnamedFunctionAttribute extends SlangNode {
+export class UnnamedFunctionAttribute extends PolymorphicNode<
+  ast.UnnamedFunctionAttribute,
+  ModifierInvocation | TerminalNode
+> {
   readonly kind = NonterminalKind.UnnamedFunctionAttribute;
 
-  variant: ModifierInvocation | TerminalNode;
-
   constructor(ast: ast.UnnamedFunctionAttribute, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new ModifierInvocation(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new ModifierInvocation(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/UsingClause.ts
+++ b/src/slang-nodes/UsingClause.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { IdentifierPath } from './IdentifierPath.js';
 import { UsingDeconstruction } from './UsingDeconstruction.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.UsingDeconstruction, UsingDeconstruction]
 ]);
 
-export class UsingClause extends SlangNode {
+export class UsingClause extends PolymorphicNonterminalNode<
+  ast.UsingClause,
+  IdentifierPath | UsingDeconstruction
+> {
   readonly kind = NonterminalKind.UsingClause;
 
-  variant: IdentifierPath | UsingDeconstruction;
-
   constructor(ast: ast.UsingClause, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/UsingOperator.ts
+++ b/src/slang-nodes/UsingOperator.ts
@@ -1,22 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class UsingOperator extends SlangNode {
+export class UsingOperator extends PolymorphicString {
   readonly kind = NonterminalKind.UsingOperator;
-
-  variant: string;
 
   constructor(ast: ast.UsingOperator, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-  }
-
-  print(): Doc {
-    return this.variant;
   }
 }

--- a/src/slang-nodes/UsingTarget.ts
+++ b/src/slang-nodes/UsingTarget.ts
@@ -1,30 +1,21 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypeName } from './TypeName.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class UsingTarget extends SlangNode {
+export class UsingTarget extends PolymorphicNode<
+  ast.UsingTarget,
+  TypeName['variant'] | TerminalNode
+> {
   readonly kind = NonterminalKind.UsingTarget;
 
-  variant: TypeName['variant'] | TerminalNode;
-
   constructor(ast: ast.UsingTarget, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = extractVariant(new TypeName(variant, collected));
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) =>
+      extractVariant(new TypeName(variant, collected))
+    );
   }
 }

--- a/src/slang-nodes/VariableDeclarationType.ts
+++ b/src/slang-nodes/VariableDeclarationType.ts
@@ -1,30 +1,21 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { TypeName } from './TypeName.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class VariableDeclarationType extends SlangNode {
+export class VariableDeclarationType extends PolymorphicNode<
+  ast.VariableDeclarationType,
+  TypeName['variant'] | TerminalNode
+> {
   readonly kind = NonterminalKind.VariableDeclarationType;
 
-  variant: TypeName['variant'] | TerminalNode;
-
   constructor(ast: ast.VariableDeclarationType, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = extractVariant(new TypeName(variant, collected));
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, (variant) =>
+      extractVariant(new TypeName(variant, collected))
+    );
   }
 }

--- a/src/slang-nodes/VersionExpression.ts
+++ b/src/slang-nodes/VersionExpression.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { VersionRange } from './VersionRange.js';
 import { VersionTerm } from './VersionTerm.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.VersionTerm, VersionTerm]
 ]);
 
-export class VersionExpression extends SlangNode {
+export class VersionExpression extends PolymorphicNonterminalNode<
+  ast.VersionExpression,
+  VersionRange | VersionTerm
+> {
   readonly kind = NonterminalKind.VersionExpression;
 
-  variant: VersionRange | VersionTerm;
-
   constructor(ast: ast.VersionExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/VersionLiteral.ts
+++ b/src/slang-nodes/VersionLiteral.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { SimpleVersionLiteral } from './SimpleVersionLiteral.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class VersionLiteral extends SlangNode {
+export class VersionLiteral extends PolymorphicNode<
+  ast.VersionLiteral,
+  SimpleVersionLiteral | TerminalNode
+> {
   readonly kind = NonterminalKind.VersionLiteral;
 
-  variant: SimpleVersionLiteral | TerminalNode;
-
   constructor(ast: ast.VersionLiteral, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new SimpleVersionLiteral(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new SimpleVersionLiteral(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/VersionOperator.ts
+++ b/src/slang-nodes/VersionOperator.ts
@@ -1,22 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicString } from './PolymorphicString.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
-import type { Doc } from 'prettier';
 import type { CollectedMetadata } from '../types.d.ts';
 
-export class VersionOperator extends SlangNode {
+export class VersionOperator extends PolymorphicString {
   readonly kind = NonterminalKind.VersionOperator;
-
-  variant: string;
 
   constructor(ast: ast.VersionOperator, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.variant = ast.variant.unparse();
-  }
-
-  print(): Doc {
-    return this.variant;
   }
 }

--- a/src/slang-nodes/YulAssignmentOperator.ts
+++ b/src/slang-nodes/YulAssignmentOperator.ts
@@ -1,29 +1,22 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulColonAndEqual } from './YulColonAndEqual.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class YulAssignmentOperator extends SlangNode {
+export class YulAssignmentOperator extends PolymorphicNode<
+  ast.YulAssignmentOperator,
+  YulColonAndEqual | TerminalNode
+> {
   readonly kind = NonterminalKind.YulAssignmentOperator;
 
-  variant: YulColonAndEqual | TerminalNode;
-
   constructor(ast: ast.YulAssignmentOperator, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new YulColonAndEqual(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new YulColonAndEqual(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/YulExpression.ts
+++ b/src/slang-nodes/YulExpression.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { YulFunctionCallExpression } from './YulFunctionCallExpression.js';
 import { YulLiteral } from './YulLiteral.js';
 import { YulPath } from './YulPath.js';
@@ -19,16 +19,13 @@ const createNonterminalVariant = createNonterminalVariantCreator<
   [[ast.YulLiteral, YulLiteral]]
 );
 
-export class YulExpression extends SlangNode {
+export class YulExpression extends PolymorphicNonterminalNode<
+  ast.YulExpression,
+  YulFunctionCallExpression | YulLiteral['variant'] | YulPath
+> {
   readonly kind = NonterminalKind.YulExpression;
 
-  variant: YulFunctionCallExpression | YulLiteral['variant'] | YulPath;
-
   constructor(ast: ast.YulExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/YulLiteral.ts
+++ b/src/slang-nodes/YulLiteral.ts
@@ -1,15 +1,12 @@
 import * as ast from '@nomicfoundation/slang/ast';
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 import { StringLiteral } from './StringLiteral.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
 const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   ast.YulLiteral,
@@ -19,21 +16,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.StringLiteral, StringLiteral]
 ]);
 
-export class YulLiteral extends SlangNode {
+export class YulLiteral extends PolymorphicNode<
+  ast.YulLiteral,
+  HexStringLiteral | StringLiteral | TerminalNode
+> {
   readonly kind = NonterminalKind.YulLiteral;
 
-  variant: HexStringLiteral | StringLiteral | TerminalNode;
-
   constructor(ast: ast.YulLiteral, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/slang-nodes/YulStackAssignmentOperator.ts
+++ b/src/slang-nodes/YulStackAssignmentOperator.ts
@@ -1,32 +1,25 @@
-import {
-  NonterminalKind,
-  TerminalNode as SlangTerminalNode
-} from '@nomicfoundation/slang/cst';
-import { SlangNode } from './SlangNode.js';
+import { NonterminalKind } from '@nomicfoundation/slang/cst';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulEqualAndColon } from './YulEqualAndColon.js';
-import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { CollectedMetadata } from '../types.d.ts';
+import type { TerminalNode } from './TerminalNode.ts';
 
-export class YulStackAssignmentOperator extends SlangNode {
+export class YulStackAssignmentOperator extends PolymorphicNode<
+  ast.YulStackAssignmentOperator,
+  YulEqualAndColon | TerminalNode
+> {
   readonly kind = NonterminalKind.YulStackAssignmentOperator;
-
-  variant: YulEqualAndColon | TerminalNode;
 
   constructor(
     ast: ast.YulStackAssignmentOperator,
     collected: CollectedMetadata
   ) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    if (variant instanceof SlangTerminalNode) {
-      this.variant = new TerminalNode(variant, collected);
-      return;
-    }
-    this.variant = new YulEqualAndColon(variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(
+      ast,
+      collected,
+      (variant) => new YulEqualAndColon(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/YulStatement.ts
+++ b/src/slang-nodes/YulStatement.ts
@@ -1,7 +1,7 @@
 import * as slangAst from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNode } from './PolymorphicNode.js';
 import { YulBlock } from './YulBlock.js';
 import { YulFunctionDefinition } from './YulFunctionDefinition.js';
 import { YulVariableDeclarationStatement } from './YulVariableDeclarationStatement.js';
@@ -38,33 +38,29 @@ const createNonterminalVariant = createNonterminalVariantCreator<
   [[slangAst.YulExpression, YulExpression]]
 );
 
-export class YulStatement extends SlangNode {
+export class YulStatement extends PolymorphicNode<
+  slangAst.YulStatement,
+  | YulBlock
+  | YulFunctionDefinition
+  | YulVariableDeclarationStatement
+  | YulVariableAssignmentStatement
+  | YulStackAssignmentStatement
+  | YulIfStatement
+  | YulForStatement
+  | YulSwitchStatement
+  | YulLeaveStatement
+  | YulBreakStatement
+  | YulContinueStatement
+  | YulLabel
+  | YulExpression['variant']
+> {
   readonly kind = NonterminalKind.YulStatement;
 
-  variant:
-    | YulBlock
-    | YulFunctionDefinition
-    | YulVariableDeclarationStatement
-    | YulVariableAssignmentStatement
-    | YulStackAssignmentStatement
-    | YulIfStatement
-    | YulForStatement
-    | YulSwitchStatement
-    | YulLeaveStatement
-    | YulBreakStatement
-    | YulContinueStatement
-    | YulLabel
-    | YulExpression['variant'];
-
   constructor(ast: slangAst.YulStatement, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    const variant = ast.variant;
-    this.variant =
+    super(ast, collected, (variant) =>
       variant instanceof slangAst.YulBlock
         ? new YulBlock(variant, collected)
-        : createNonterminalVariant(variant, collected);
-
-    this.updateMetadata(this.variant);
+        : createNonterminalVariant(variant, collected)
+    );
   }
 }

--- a/src/slang-nodes/YulSwitchCase.ts
+++ b/src/slang-nodes/YulSwitchCase.ts
@@ -1,7 +1,7 @@
 import * as ast from '@nomicfoundation/slang/ast';
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createNonterminalVariantSimpleCreator } from '../slang-utils/create-nonterminal-variant-creator.js';
-import { SlangNode } from './SlangNode.js';
+import { PolymorphicNonterminalNode } from './PolymorphicNonterminalNode.js';
 import { YulDefaultCase } from './YulDefaultCase.js';
 import { YulValueCase } from './YulValueCase.js';
 
@@ -15,16 +15,13 @@ const createNonterminalVariant = createNonterminalVariantSimpleCreator<
   [ast.YulValueCase, YulValueCase]
 ]);
 
-export class YulSwitchCase extends SlangNode {
+export class YulSwitchCase extends PolymorphicNonterminalNode<
+  ast.YulSwitchCase,
+  YulDefaultCase | YulValueCase
+> {
   readonly kind = NonterminalKind.YulSwitchCase;
 
-  variant: YulDefaultCase | YulValueCase;
-
   constructor(ast: ast.YulSwitchCase, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.variant = createNonterminalVariant(ast.variant, collected);
-
-    this.updateMetadata(this.variant);
+    super(ast, collected, createNonterminalVariant);
   }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import type * as ast from '@nomicfoundation/slang/ast';
+import type { TerminalNode as SlangTerminalNode } from '@nomicfoundation/slang/cst';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from './slang-nodes/types.d.ts';
 
@@ -36,3 +37,42 @@ type ValuesOf<E> = E[keyof E];
 
 type SlangAstNode = { [k in KeyOfAst]: ValuesOf<TypeOfAst[k]> }[KeyOfAst];
 type SlangAstNodeClass = { [k in KeyOfAst]: TypeOfAst[k] }[KeyOfAst];
+
+type SlangPolymorphicNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode | SlangTerminalNode }
+>;
+
+type SlangPolymorphicNonterminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode }
+>;
+
+type SlangPolymorphicTerminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangTerminalNode }
+>;
+
+type SlangCollectionNode = Extract<
+  SlangAstNode,
+  { items: readonly (SlangAstNode | SlangTerminalNode)[] }
+>;
+
+type SlangVariantCollection = Extract<
+  SlangCollectionNode,
+  { items: readonly SlangPolymorphicNode[] }
+>;
+
+type SlangBinaryOperation = Extract<
+  SlangAstNode,
+  {
+    leftOperand: ast.Expression;
+    operator: SlangTerminalNode;
+    rightOperand: ast.Expression;
+  }
+>;
+
+type SlangUnaryOperation = Extract<
+  SlangAstNode,
+  { operand: ast.Expression; operator: SlangTerminalNode }
+>;


### PR DESCRIPTION
Similar to #1543

There are 4 types of polymeric nodes.

1. with a `variant` that could be different keywords. These usually are parsed as a `string`.
2. with a `variant` that could be a name given by a developer or a keyword. These are parsed as a `TerminalNode`.
3. with a `variant` that could be an `Expression` or a `Statement`. These are parsed as a `NonterminalNode`.
4. with a `variant` that could be anything. This is more general and has logic for cases 2 and 3.

all of this logic put in 4 different base classes cleans up everything.

I added 4 cases just to be very specific but I'd be willing to merge case 2 and 3 into case 4.