### PR TITLE
Binary operation base class

### DIFF
--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -26,27 +24,11 @@ const printAdditiveExpression = printBinaryOperation(
   ])
 );
 
-export class AdditiveExpression extends SlangNode {
+export class AdditiveExpression extends BinaryOperation {
   readonly kind = NonterminalKind.AdditiveExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AdditiveExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
     this.rightOperand = tryToHug(this.rightOperand);

--- a/src/slang-nodes/AdditiveExpression.ts
+++ b/src/slang-nodes/AdditiveExpression.ts
@@ -28,10 +28,7 @@ export class AdditiveExpression extends BinaryOperation {
   readonly kind = NonterminalKind.AdditiveExpression;
 
   constructor(ast: ast.AdditiveExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
-    this.rightOperand = tryToHug(this.rightOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/AndExpression.ts
+++ b/src/slang-nodes/AndExpression.ts
@@ -1,35 +1,17 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printLogicalOperation } from '../slang-printers/print-logical-operation.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
 
-export class AndExpression extends SlangNode {
+export class AndExpression extends BinaryOperation {
   readonly kind = NonterminalKind.AndExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AndExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
   }
 
   print(

--- a/src/slang-nodes/AssignmentExpression.ts
+++ b/src/slang-nodes/AssignmentExpression.ts
@@ -1,34 +1,16 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { extractVariant } from '../slang-utils/extract-variant.js';
 import { printAssignmentRightSide } from '../slang-printers/print-assignment-right-side.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class AssignmentExpression extends SlangNode {
+export class AssignmentExpression extends BinaryOperation {
   readonly kind = NonterminalKind.AssignmentExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.AssignmentExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
   }
 
   print(print: PrintFunction): Doc {

--- a/src/slang-nodes/BinaryOperation.ts
+++ b/src/slang-nodes/BinaryOperation.ts
@@ -1,0 +1,30 @@
+import { extractVariant } from '../slang-utils/extract-variant.js';
+import { SlangNode } from './SlangNode.js';
+import { Expression } from './Expression.js';
+
+import type { CollectedMetadata, SlangBinaryOperation } from '../types.d.ts';
+
+export abstract class BinaryOperation extends SlangNode {
+  leftOperand: Expression['variant'];
+
+  operator: string;
+
+  rightOperand: Expression['variant'];
+
+  protected constructor(
+    ast: SlangBinaryOperation,
+    collected: CollectedMetadata
+  ) {
+    super(ast, collected);
+
+    this.leftOperand = extractVariant(
+      new Expression(ast.leftOperand, collected)
+    );
+    this.operator = ast.operator.unparse();
+    this.rightOperand = extractVariant(
+      new Expression(ast.rightOperand, collected)
+    );
+
+    this.updateMetadata(this.leftOperand, this.rightOperand);
+  }
+}

--- a/src/slang-nodes/BinaryOperation.ts
+++ b/src/slang-nodes/BinaryOperation.ts
@@ -2,6 +2,7 @@ import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { Expression } from './Expression.js';
 
+import type { HugFunction } from '../slang-utils/types.d.ts';
 import type { CollectedMetadata, SlangBinaryOperation } from '../types.d.ts';
 
 export abstract class BinaryOperation extends SlangNode {
@@ -14,8 +15,8 @@ export abstract class BinaryOperation extends SlangNode {
   protected constructor(
     ast: SlangBinaryOperation,
     collected: CollectedMetadata,
-    hugLeft?: (node: Expression['variant']) => Expression['variant'],
-    hugRight?: (node: Expression['variant']) => Expression['variant']
+    hugLeft?: HugFunction,
+    hugRight?: HugFunction
   ) {
     super(ast, collected);
 

--- a/src/slang-nodes/BinaryOperation.ts
+++ b/src/slang-nodes/BinaryOperation.ts
@@ -13,7 +13,9 @@ export abstract class BinaryOperation extends SlangNode {
 
   protected constructor(
     ast: SlangBinaryOperation,
-    collected: CollectedMetadata
+    collected: CollectedMetadata,
+    hugLeft?: (node: Expression['variant']) => Expression['variant'],
+    hugRight?: (node: Expression['variant']) => Expression['variant']
   ) {
     super(ast, collected);
 
@@ -26,5 +28,12 @@ export abstract class BinaryOperation extends SlangNode {
     );
 
     this.updateMetadata(this.leftOperand, this.rightOperand);
+
+    if (hugLeft) {
+      this.leftOperand = hugLeft(this.leftOperand);
+    }
+    if (hugRight) {
+      this.rightOperand = hugRight(this.rightOperand);
+    }
   }
 }

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -22,27 +20,11 @@ const printBitwiseAndExpression = printBinaryOperation(
   ])
 );
 
-export class BitwiseAndExpression extends SlangNode {
+export class BitwiseAndExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseAndExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseAndExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
     this.rightOperand = tryToHug(this.rightOperand);

--- a/src/slang-nodes/BitwiseAndExpression.ts
+++ b/src/slang-nodes/BitwiseAndExpression.ts
@@ -24,10 +24,7 @@ export class BitwiseAndExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseAndExpression;
 
   constructor(ast: ast.BitwiseAndExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
-    this.rightOperand = tryToHug(this.rightOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -32,27 +30,11 @@ const printBitwiseOrExpression = printBinaryOperation(
   ])
 );
 
-export class BitwiseOrExpression extends SlangNode {
+export class BitwiseOrExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseOrExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseOrExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
     this.rightOperand = tryToHug(this.rightOperand);

--- a/src/slang-nodes/BitwiseOrExpression.ts
+++ b/src/slang-nodes/BitwiseOrExpression.ts
@@ -34,10 +34,7 @@ export class BitwiseOrExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseOrExpression;
 
   constructor(ast: ast.BitwiseOrExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
-    this.rightOperand = tryToHug(this.rightOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -22,27 +20,11 @@ const printBitwiseXorExpression = printBinaryOperation(
   ])
 );
 
-export class BitwiseXorExpression extends SlangNode {
+export class BitwiseXorExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseXorExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.BitwiseXorExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
     this.rightOperand = tryToHug(this.rightOperand);

--- a/src/slang-nodes/BitwiseXorExpression.ts
+++ b/src/slang-nodes/BitwiseXorExpression.ts
@@ -24,10 +24,7 @@ export class BitwiseXorExpression extends BinaryOperation {
   readonly kind = NonterminalKind.BitwiseXorExpression;
 
   constructor(ast: ast.BitwiseXorExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
-    this.rightOperand = tryToHug(this.rightOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -20,27 +18,11 @@ const printEqualityExpression = printBinaryOperation(
   ])
 );
 
-export class EqualityExpression extends SlangNode {
+export class EqualityExpression extends BinaryOperation {
   readonly kind = NonterminalKind.EqualityExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.EqualityExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
   }

--- a/src/slang-nodes/EqualityExpression.ts
+++ b/src/slang-nodes/EqualityExpression.ts
@@ -22,9 +22,7 @@ export class EqualityExpression extends BinaryOperation {
   readonly kind = NonterminalKind.EqualityExpression;
 
   constructor(ast: ast.EqualityExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
+    super(ast, collected, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -4,9 +4,7 @@ import { createBinaryOperationPrinter } from '../slang-printers/create-binary-op
 import { binaryIndentRulesBuilder } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -37,27 +35,11 @@ const printExponentiationExpression = createBinaryOperationPrinter(
   binaryIndentRulesBuilder(shouldIndent) // indent as a binary operation with some exceptions
 );
 
-export class ExponentiationExpression extends SlangNode {
+export class ExponentiationExpression extends BinaryOperation {
   readonly kind = NonterminalKind.ExponentiationExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.ExponentiationExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.rightOperand = tryToHug(this.rightOperand);
     this.leftOperand = tryToHug(this.leftOperand);

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -39,10 +39,7 @@ export class ExponentiationExpression extends BinaryOperation {
   readonly kind = NonterminalKind.ExponentiationExpression;
 
   constructor(ast: ast.ExponentiationExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.rightOperand = tryToHug(this.rightOperand);
-    this.leftOperand = tryToHug(this.leftOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/InequalityExpression.ts
+++ b/src/slang-nodes/InequalityExpression.ts
@@ -1,9 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -18,27 +16,11 @@ const printComparisonExpression = printBinaryOperation(
   ])
 );
 
-export class InequalityExpression extends SlangNode {
+export class InequalityExpression extends BinaryOperation {
   readonly kind = NonterminalKind.InequalityExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.InequalityExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
   }
 
   print(

--- a/src/slang-nodes/MultiplicativeExpression.ts
+++ b/src/slang-nodes/MultiplicativeExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -31,27 +29,11 @@ const printMultiplicativeExpression = printBinaryOperation(
   ])
 );
 
-export class MultiplicativeExpression extends SlangNode {
+export class MultiplicativeExpression extends BinaryOperation {
   readonly kind = NonterminalKind.MultiplicativeExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.MultiplicativeExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     const tryToHug = hugFunctions[this.operator as keyof typeof hugFunctions];
 

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -1,9 +1,7 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printLogicalOperation } from '../slang-printers/print-logical-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -12,27 +10,11 @@ import type { PrintableNode } from './types.d.ts';
 
 const tryToHug = createHugFunction(['&&']);
 
-export class OrExpression extends SlangNode {
+export class OrExpression extends BinaryOperation {
   readonly kind = NonterminalKind.OrExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.OrExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHug(this.leftOperand);
     this.rightOperand = tryToHug(this.rightOperand);

--- a/src/slang-nodes/OrExpression.ts
+++ b/src/slang-nodes/OrExpression.ts
@@ -14,10 +14,7 @@ export class OrExpression extends BinaryOperation {
   readonly kind = NonterminalKind.OrExpression;
 
   constructor(ast: ast.OrExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHug(this.leftOperand);
-    this.rightOperand = tryToHug(this.rightOperand);
+    super(ast, collected, tryToHug, tryToHug);
   }
 
   print(

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -2,9 +2,7 @@ import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { printBinaryOperation } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { BinaryOperation } from './BinaryOperation.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
@@ -34,27 +32,11 @@ const printShiftExpression = printBinaryOperation(
   ])
 );
 
-export class ShiftExpression extends SlangNode {
+export class ShiftExpression extends BinaryOperation {
   readonly kind = NonterminalKind.ShiftExpression;
-
-  leftOperand: Expression['variant'];
-
-  operator: string;
-
-  rightOperand: Expression['variant'];
 
   constructor(ast: ast.ShiftExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.leftOperand = extractVariant(
-      new Expression(ast.leftOperand, collected)
-    );
-    this.operator = ast.operator.unparse();
-    this.rightOperand = extractVariant(
-      new Expression(ast.rightOperand, collected)
-    );
-
-    this.updateMetadata(this.leftOperand, this.rightOperand);
 
     this.leftOperand = tryToHugLeftOperand(this.leftOperand);
     this.rightOperand = tryToHugRightOperand(this.rightOperand);

--- a/src/slang-nodes/ShiftExpression.ts
+++ b/src/slang-nodes/ShiftExpression.ts
@@ -36,10 +36,7 @@ export class ShiftExpression extends BinaryOperation {
   readonly kind = NonterminalKind.ShiftExpression;
 
   constructor(ast: ast.ShiftExpression, collected: CollectedMetadata) {
-    super(ast, collected);
-
-    this.leftOperand = tryToHugLeftOperand(this.leftOperand);
-    this.rightOperand = tryToHugRightOperand(this.rightOperand);
+    super(ast, collected, tryToHugLeftOperand, tryToHugRightOperand);
   }
 
   print(

--- a/src/slang-utils/create-hug-function.ts
+++ b/src/slang-utils/create-hug-function.ts
@@ -5,10 +5,9 @@ import { TupleValue } from '../slang-nodes/TupleValue.js';
 import { isBinaryOperation } from './is-binary-operation.js';
 
 import type { Expression } from '../slang-nodes/Expression.ts';
+import type { HugFunction } from './types.d.ts';
 
-export function createHugFunction(
-  huggableOperators: string[]
-): (node: Expression['variant']) => Expression['variant'] {
+export function createHugFunction(huggableOperators: string[]): HugFunction {
   const operators = new Set(huggableOperators);
   return (node: Expression['variant']): Expression['variant'] => {
     if (isBinaryOperation(node) && operators.has(node.operator)) {

--- a/src/slang-utils/types.d.ts
+++ b/src/slang-utils/types.d.ts
@@ -7,6 +7,7 @@ import type { ModifierAttribute } from '../slang-nodes/ModifierAttribute.ts';
 import type { ReceiveFunctionAttribute } from '../slang-nodes/ReceiveFunctionAttribute.ts';
 import type { StateVariableAttribute } from '../slang-nodes/StateVariableAttribute.ts';
 import type { UnnamedFunctionAttribute } from '../slang-nodes/UnnamedFunctionAttribute.ts';
+import type { Expression } from '../slang-nodes/Expression.ts';
 
 type SortableAttribute =
   | ConstructorAttribute['variant']
@@ -17,3 +18,5 @@ type SortableAttribute =
   | ReceiveFunctionAttribute['variant']
   | StateVariableAttribute['variant']
   | UnnamedFunctionAttribute['variant'];
+
+type HugFunction = (node: Expression['variant']) => Expression['variant'];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import type * as ast from '@nomicfoundation/slang/ast';
+import type { TerminalNode as SlangTerminalNode } from '@nomicfoundation/slang/cst';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from './slang-nodes/types.d.ts';
 
@@ -36,3 +37,42 @@ type ValuesOf<E> = E[keyof E];
 
 type SlangAstNode = { [k in KeyOfAst]: ValuesOf<TypeOfAst[k]> }[KeyOfAst];
 type SlangAstNodeClass = { [k in KeyOfAst]: TypeOfAst[k] }[KeyOfAst];
+
+type SlangPolymorphicNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode | SlangTerminalNode }
+>;
+
+type SlangPolymorphicNonterminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode }
+>;
+
+type SlangPolymorphicTerminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangTerminalNode }
+>;
+
+type SlangCollectionNode = Extract<
+  SlangAstNode,
+  { items: readonly (SlangAstNode | SlangTerminalNode)[] }
+>;
+
+type SlangVariantCollection = Extract<
+  SlangCollectionNode,
+  { items: readonly SlangPolymorphicNode[] }
+>;
+
+type SlangBinaryOperation = Extract<
+  SlangAstNode,
+  {
+    leftOperand: ast.Expression;
+    operator: SlangTerminalNode;
+    rightOperand: ast.Expression;
+  }
+>;
+
+type SlangUnaryOperation = Extract<
+  SlangAstNode,
+  { operand: ast.Expression; operator: SlangTerminalNode }
+>;


### PR DESCRIPTION
All binary operations have a `leftOperand`, `operator`, and a `rightOperand` and most of them have some logic to put parentheses around the `operands`.

Here we get rid of all of this boilerplate.