### PR TITLE
Unary operation base class

### DIFF
--- a/src/slang-nodes/PostfixExpression.ts
+++ b/src/slang-nodes/PostfixExpression.ts
@@ -1,26 +1,15 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { UnaryExpression } from './UnaryExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class PostfixExpression extends SlangNode {
+export class PostfixExpression extends UnaryExpression {
   readonly kind = NonterminalKind.PostfixExpression;
-
-  operand: Expression['variant'];
-
-  operator: string;
 
   constructor(ast: ast.PostfixExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.operand = extractVariant(new Expression(ast.operand, collected));
-    this.operator = ast.operator.unparse();
-
-    this.updateMetadata(this.operand);
   }
 
   print(print: PrintFunction): Doc {

--- a/src/slang-nodes/PrefixExpression.ts
+++ b/src/slang-nodes/PrefixExpression.ts
@@ -1,26 +1,15 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { extractVariant } from '../slang-utils/extract-variant.js';
-import { SlangNode } from './SlangNode.js';
-import { Expression } from './Expression.js';
+import { UnaryExpression } from './UnaryExpression.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 
-export class PrefixExpression extends SlangNode {
+export class PrefixExpression extends UnaryExpression {
   readonly kind = NonterminalKind.PrefixExpression;
-
-  operator: string;
-
-  operand: Expression['variant'];
 
   constructor(ast: ast.PrefixExpression, collected: CollectedMetadata) {
     super(ast, collected);
-
-    this.operator = ast.operator.unparse();
-    this.operand = extractVariant(new Expression(ast.operand, collected));
-
-    this.updateMetadata(this.operand);
 
     if (this.operator === 'delete') {
       this.operator = 'delete ';

--- a/src/slang-nodes/UnaryExpression.ts
+++ b/src/slang-nodes/UnaryExpression.ts
@@ -1,0 +1,30 @@
+import { extractVariant } from '../slang-utils/extract-variant.js';
+import { SlangNode } from './SlangNode.js';
+import { Expression } from './Expression.js';
+
+import type { Doc } from 'prettier';
+import type {
+  CollectedMetadata,
+  PrintFunction,
+  SlangUnaryOperation
+} from '../types.d.ts';
+
+export abstract class UnaryExpression extends SlangNode {
+  operand: Expression['variant'];
+
+  operator: string;
+
+  protected constructor(
+    ast: SlangUnaryOperation,
+    collected: CollectedMetadata
+  ) {
+    super(ast, collected);
+
+    this.operand = extractVariant(new Expression(ast.operand, collected));
+    this.operator = ast.operator.unparse();
+
+    this.updateMetadata(this.operand);
+  }
+
+  abstract print(print: PrintFunction): Doc;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import type * as ast from '@nomicfoundation/slang/ast';
+import type { TerminalNode as SlangTerminalNode } from '@nomicfoundation/slang/cst';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from './slang-nodes/types.d.ts';
 
@@ -36,3 +37,42 @@ type ValuesOf<E> = E[keyof E];
 
 type SlangAstNode = { [k in KeyOfAst]: ValuesOf<TypeOfAst[k]> }[KeyOfAst];
 type SlangAstNodeClass = { [k in KeyOfAst]: TypeOfAst[k] }[KeyOfAst];
+
+type SlangPolymorphicNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode | SlangTerminalNode }
+>;
+
+type SlangPolymorphicNonterminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangAstNode }
+>;
+
+type SlangPolymorphicTerminalNode = Extract<
+  SlangAstNode,
+  { variant: SlangTerminalNode }
+>;
+
+type SlangCollectionNode = Extract<
+  SlangAstNode,
+  { items: readonly (SlangAstNode | SlangTerminalNode)[] }
+>;
+
+type SlangVariantCollection = Extract<
+  SlangCollectionNode,
+  { items: readonly SlangPolymorphicNode[] }
+>;
+
+type SlangBinaryOperation = Extract<
+  SlangAstNode,
+  {
+    leftOperand: ast.Expression;
+    operator: SlangTerminalNode;
+    rightOperand: ast.Expression;
+  }
+>;
+
+type SlangUnaryOperation = Extract<
+  SlangAstNode,
+  { operand: ast.Expression; operator: SlangTerminalNode }
+>;


### PR DESCRIPTION
Similar to #1545 not attached to this one being merged though. Since the benefit is minimal (only 2 classes affected) and it actually adds 18 bytes to the minified file while all others have a huge impact in file size on top of cleaning up the code.
I just wanted to get feedback on this one.