### PR TITLE
avoid-printing a lingering `line` when there is no `iterator`

### DIFF
--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -1,5 +1,5 @@
 import { doc } from 'prettier';
-import { printSeparatedList } from '../common/printer-helpers.js';
+import { printSeparatedItem } from '../common/printer-helpers.js';
 
 const { group, indent, line } = doc.builders;
 
@@ -20,20 +20,21 @@ const printBody = (node, path, print) =>
 export const ForStatement = {
   print: ({ node, path, print }) => [
     'for (',
-    printSeparatedList(
-      [
-        initExpression(node, path, print),
-        conditionExpression(node, path, print),
-        loopExpression(node, path, print)
-      ],
-      {
-        separator:
-          node.initExpression ||
-          node.conditionExpression ||
-          node.loopExpression.expression
-            ? [';', line]
-            : ';'
-      }
+    printSeparatedItem(
+      node.loopExpression.expression
+        ? [
+            initExpression(node, path, print),
+            [';', line],
+            conditionExpression(node, path, print),
+            [';', line],
+            loopExpression(node, path, print)
+          ]
+        : [
+            initExpression(node, path, print),
+            node.initExpression || node.conditionExpression ? [';', line] : ';',
+            conditionExpression(node, path, print),
+            ';'
+          ]
     ),
     ')',
     printBody(node, path, print)

--- a/src/nodes/ForStatement.js
+++ b/src/nodes/ForStatement.js
@@ -3,14 +3,15 @@ import { printSeparatedItem } from '../common/printer-helpers.js';
 
 const { group, indent, line } = doc.builders;
 
-const initExpression = (node, path, print) =>
-  node.initExpression ? path.call(print, 'initExpression') : '';
+const initExpression = (node, path, print) => [
+  node.initExpression ? path.call(print, 'initExpression') : '',
+  ';'
+];
 
-const conditionExpression = (node, path, print) =>
-  node.conditionExpression ? path.call(print, 'conditionExpression') : '';
-
-const loopExpression = (node, path, print) =>
-  node.loopExpression.expression ? path.call(print, 'loopExpression') : '';
+const conditionExpression = (node, path, print) => [
+  node.conditionExpression ? path.call(print, 'conditionExpression') : '',
+  ';'
+];
 
 const printBody = (node, path, print) =>
   node.body.type === 'Block'
@@ -24,16 +25,15 @@ export const ForStatement = {
       node.loopExpression.expression
         ? [
             initExpression(node, path, print),
-            [';', line],
+            line,
             conditionExpression(node, path, print),
-            [';', line],
-            loopExpression(node, path, print)
+            line,
+            path.call(print, 'loopExpression')
           ]
         : [
             initExpression(node, path, print),
-            node.initExpression || node.conditionExpression ? [';', line] : ';',
-            conditionExpression(node, path, print),
-            ';'
+            node.initExpression || node.conditionExpression ? line : '',
+            conditionExpression(node, path, print)
           ]
     ),
     ')',

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
 import { doc } from 'prettier';
-import { printSeparatedList } from '../slang-printers/print-separated-list.js';
+import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -55,12 +55,15 @@ export class ForStatement extends SlangNode {
 
     return [
       'for (',
-      printSeparatedList([initialization, condition, iterator], {
-        separator:
-          initialization !== ';' || condition !== ';' || iterator !== ''
-            ? line
-            : ''
-      }),
+      printSeparatedItem(
+        iterator === ''
+          ? [
+              initialization,
+              initialization === ';' && condition === ';' ? '' : line,
+              condition
+            ]
+          : [initialization, line, condition, line, iterator]
+      ),
       ')',
       printIndentedGroupOrSpacedDocument(
         print('body'),

--- a/tests/format/ForStatements/ForStatements.sol
+++ b/tests/format/ForStatements/ForStatements.sol
@@ -18,6 +18,12 @@ for ((uint i, uint j) = getIndexes(); i < 100; i++) a++;
 
         for (veryLongVariableName = 0; veryLongVariableName < 100; veryLongVariableName++) { a++; }
 
+        for (veryVeryVeryVeryLongVariableName = 0; veryVeryVeryVeryLongVariableName < 100; ) { a++; }
+
+        for (veryVeryVeryVeryLongVariableName = 0; ; veryVeryVeryVeryLongVariableName++) { a++; }
+
+        for (; veryVeryVeryVeryLongVariableName < 100; veryVeryVeryVeryLongVariableName++) { a++; }
+
         for (; ; ) { // #178
         }
 

--- a/tests/format/ForStatements/__snapshots__/format.test.js.snap
+++ b/tests/format/ForStatements/__snapshots__/format.test.js.snap
@@ -25,6 +25,12 @@ for ((uint i, uint j) = getIndexes(); i < 100; i++) a++;
 
         for (veryLongVariableName = 0; veryLongVariableName < 100; veryLongVariableName++) { a++; }
 
+        for (veryVeryVeryVeryLongVariableName = 0; veryVeryVeryVeryLongVariableName < 100; ) { a++; }
+
+        for (veryVeryVeryVeryLongVariableName = 0; ; veryVeryVeryVeryLongVariableName++) { a++; }
+
+        for (; veryVeryVeryVeryLongVariableName < 100; veryVeryVeryVeryLongVariableName++) { a++; }
+
         for (; ; ) { // #178
         }
 
@@ -87,13 +93,36 @@ contract ForStatements {
             a++;
         }
 
+        for (
+            veryVeryVeryVeryLongVariableName = 0;
+            veryVeryVeryVeryLongVariableName < 100;
+        ) {
+            a++;
+        }
+
+        for (
+            veryVeryVeryVeryLongVariableName = 0;
+            ;
+            veryVeryVeryVeryLongVariableName++
+        ) {
+            a++;
+        }
+
+        for (
+            ;
+            veryVeryVeryVeryLongVariableName < 100;
+            veryVeryVeryVeryLongVariableName++
+        ) {
+            a++;
+        }
+
         for (;;) {
             // #178
         }
 
-        for (i = 0; ; ) {}
+        for (i = 0; ;) {}
 
-        for (i = 0; i < 100; ) {}
+        for (i = 0; i < 100;) {}
 
         for (i = 0; ; i++) {}
 
@@ -101,7 +130,7 @@ contract ForStatements {
 
         for (; i < 100; i++) {}
 
-        for (; i < 100; ) {}
+        for (; i < 100;) {}
 
         for (; ; i++) {}
     }

--- a/tests/format/MemberAccess/__snapshots__/format.test.js.snap
+++ b/tests/format/MemberAccess/__snapshots__/format.test.js.snap
@@ -251,7 +251,7 @@ contract MemberAccessIsEndOfChainCases {
         while (b.c) {}
         // break if is a part of a ForStatement
         // for (b.c;;) {}
-        for (; b.c; ) {}
+        for (; b.c;) {}
         // for (;;b.c) {}
         // break if is a part of a VariableDeclarationStatement
         uint a = b.c;


### PR DESCRIPTION
Since prettier release 3.9.0 there was a small [tweak](https://prettier.io/blog/2026/06/27/3.9.0#change-19188) in `for` statements without `iterator` that I believe we should follow.


```Solidity
// Input
for (initialize;;) {}
for (; condition;) {}

// Old format
for (initialize; ; ) {}
for (; condition; ) {}

// New format
for (initialize; ;) {}
for (; condition;) {}
```
