### PR TITLE
destructuring `pretier.doc.builders` and `prettier.util` only once

### DIFF
--- a/src/slang-comments/handlers/add-collection-first-comment.ts
+++ b/src/slang-comments/handlers/add-collection-first-comment.ts
@@ -1,8 +1,9 @@
-import { util } from 'prettier';
+import {
+  addDanglingComment,
+  addLeadingComment
+} from '../../slang-utils/prettier-utils.js';
 
 import type { Comment, StrictCollection } from '../../slang-nodes/types.d.ts';
-
-const { addDanglingComment, addLeadingComment } = util;
 
 export default function addCollectionFirstComment(
   node: StrictCollection,

--- a/src/slang-comments/handlers/add-collection-last-comment.ts
+++ b/src/slang-comments/handlers/add-collection-last-comment.ts
@@ -1,8 +1,9 @@
-import { util } from 'prettier';
+import {
+  addDanglingComment,
+  addTrailingComment
+} from '../../slang-utils/prettier-utils.js';
 
 import type { Comment, StrictCollection } from '../../slang-nodes/types.d.ts';
-
-const { addDanglingComment, addTrailingComment } = util;
 
 export default function addCollectionLastComment(
   node: StrictCollection,

--- a/src/slang-comments/handlers/handle-contract-definition-comments.ts
+++ b/src/slang-comments/handlers/handle-contract-definition-comments.ts
@@ -1,11 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addLeadingComment,
+  addTrailingComment,
+  getNextNonSpaceNonCommentCharacter
+} from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment, addTrailingComment } = util;
 
 export default function handleContractDefinitionComments({
   text,
@@ -18,7 +20,7 @@ export default function handleContractDefinitionComments({
     return false;
   }
 
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-contract-specifiers-comments.ts
+++ b/src/slang-comments/handlers/handle-contract-specifiers-comments.ts
@@ -1,10 +1,8 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import { addTrailingComment } from '../../slang-utils/prettier-utils.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addTrailingComment } = util;
 
 export default function handleContractSpecifiersComments({
   precedingNode,

--- a/src/slang-comments/handlers/handle-else-branch-comments.ts
+++ b/src/slang-comments/handlers/handle-else-branch-comments.ts
@@ -1,10 +1,8 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import { addLeadingComment } from '../../slang-utils/prettier-utils.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment } = util;
 
 export default function handleElseBranchComments({
   enclosingNode,

--- a/src/slang-comments/handlers/handle-if-statement-comments.ts
+++ b/src/slang-comments/handlers/handle-if-statement-comments.ts
@@ -1,11 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addLeadingComment,
+  addTrailingComment,
+  getNextNonSpaceNonCommentCharacter
+} from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment, addTrailingComment } = util;
 
 export default function handleIfStatementComments({
   text,
@@ -23,7 +25,7 @@ export default function handleIfStatementComments({
   //   if (a /* comment */) {}
   // The only workaround I found is to look at the next character to see if
   // it is a ).
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-interface-definition-comments.ts
+++ b/src/slang-comments/handlers/handle-interface-definition-comments.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import { getNextNonSpaceNonCommentCharacter } from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
@@ -17,7 +17,7 @@ export default function handleInterfaceDefinitionComments({
     return false;
   }
 
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-library-definition-comments.ts
+++ b/src/slang-comments/handlers/handle-library-definition-comments.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import { getNextNonSpaceNonCommentCharacter } from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
@@ -17,7 +17,7 @@ export default function handleLibraryDefinitionComments({
     return false;
   }
 
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-member-access-expression-comments.ts
+++ b/src/slang-comments/handlers/handle-member-access-expression-comments.ts
@@ -1,9 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addLeadingComment,
+  addTrailingComment
+} from '../../slang-utils/prettier-utils.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment, addTrailingComment } = util;
 
 export default function handleMemberAccessExpressionComments({
   precedingNode,

--- a/src/slang-comments/handlers/handle-modifier-invocation-comments.ts
+++ b/src/slang-comments/handlers/handle-modifier-invocation-comments.ts
@@ -1,11 +1,12 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addTrailingComment,
+  getNextNonSpaceNonCommentCharacter
+} from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addTrailingComment } = util;
 
 export default function handleModifierInvocationComments({
   text,
@@ -18,7 +19,7 @@ export default function handleModifierInvocationComments({
     return false;
   }
 
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-struct-definition-comments.ts
+++ b/src/slang-comments/handlers/handle-struct-definition-comments.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import { getNextNonSpaceNonCommentCharacter } from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 import addCollectionLastComment from './add-collection-last-comment.js';
@@ -17,7 +17,7 @@ export default function handleStructDefinitionComments({
     return false;
   }
 
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-while-statement-comments.ts
+++ b/src/slang-comments/handlers/handle-while-statement-comments.ts
@@ -1,11 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addLeadingComment,
+  addTrailingComment,
+  getNextNonSpaceNonCommentCharacter
+} from '../../slang-utils/prettier-utils.js';
 import { locEnd } from '../../slang-utils/loc.js';
 import addCollectionFirstComment from './add-collection-first-comment.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment, addTrailingComment } = util;
 
 export default function handleWhileStatementComments({
   text,
@@ -23,7 +25,7 @@ export default function handleWhileStatementComments({
   //   while (a /* comment */) {}
   // The only workaround I found is to look at the next character to see if
   // it is a ).
-  const nextCharacter = util.getNextNonSpaceNonCommentCharacter(
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     locEnd(comment)
   );

--- a/src/slang-comments/handlers/handle-yul-block-comments.ts
+++ b/src/slang-comments/handlers/handle-yul-block-comments.ts
@@ -1,9 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { util } from 'prettier';
+import {
+  addDanglingComment,
+  addLeadingComment
+} from '../../slang-utils/prettier-utils.js';
 
 import type { HandlerParams } from './types.d.ts';
-
-const { addLeadingComment, addDanglingComment } = util;
 
 export default function handleYulBlockComments({
   precedingNode,

--- a/src/slang-nodes/CallOptions.ts
+++ b/src/slang-nodes/CallOptions.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line, softline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { NamedArgument } from './NamedArgument.js';
@@ -8,8 +8,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { line, softline } = doc.builders;
 
 export class CallOptions extends SlangNode {
   readonly kind = NonterminalKind.CallOptions;

--- a/src/slang-nodes/CatchClauseError.ts
+++ b/src/slang-nodes/CatchClauseError.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { group } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
@@ -7,8 +7,6 @@ import { ParametersDeclaration } from './ParametersDeclaration.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group } = doc.builders;
 
 export class CatchClauseError extends SlangNode {
   readonly kind = NonterminalKind.CatchClauseError;

--- a/src/slang-nodes/CatchClauses.ts
+++ b/src/slang-nodes/CatchClauses.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { CatchClause } from './CatchClause.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class CatchClauses extends SlangNode {
   readonly kind = NonterminalKind.CatchClauses;

--- a/src/slang-nodes/ConditionalExpression.ts
+++ b/src/slang-nodes/ConditionalExpression.ts
@@ -1,5 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import {
+  group,
+  hardline,
+  ifBreak,
+  indent,
+  line
+} from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -9,8 +15,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { group, hardline, ifBreak, indent, line } = doc.builders;
 
 function experimentalTernaries(
   node: ConditionalExpression,

--- a/src/slang-nodes/ConstructorAttributes.ts
+++ b/src/slang-nodes/ConstructorAttributes.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
+import { line } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { ConstructorAttribute } from './ConstructorAttribute.js';
@@ -8,8 +8,6 @@ import { ConstructorAttribute } from './ConstructorAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class ConstructorAttributes extends SlangNode {
   readonly kind = NonterminalKind.ConstructorAttributes;

--- a/src/slang-nodes/ContractDefinition.ts
+++ b/src/slang-nodes/ContractDefinition.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { satisfies } from 'semver';
+import { group, line } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { ContractSpecifiers } from './ContractSpecifiers.js';
@@ -9,8 +9,6 @@ import { ContractMembers } from './ContractMembers.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group, line } = doc.builders;
 
 export class ContractDefinition extends SlangNode {
   readonly kind = NonterminalKind.ContractDefinition;

--- a/src/slang-nodes/ContractSpecifiers.ts
+++ b/src/slang-nodes/ContractSpecifiers.ts
@@ -1,5 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import {
+  group,
+  ifBreak,
+  line,
+  softline
+} from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +13,6 @@ import { ContractSpecifier } from './ContractSpecifier.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group, ifBreak, line, softline } = doc.builders;
 
 function sortContractSpecifiers(
   { kind: aKind }: ContractSpecifier['variant'],

--- a/src/slang-nodes/DoWhileStatement.ts
+++ b/src/slang-nodes/DoWhileStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -9,8 +9,6 @@ import { Expression } from './Expression.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class DoWhileStatement extends SlangNode {
   readonly kind = NonterminalKind.DoWhileStatement;

--- a/src/slang-nodes/EnumMembers.ts
+++ b/src/slang-nodes/EnumMembers.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -7,8 +7,6 @@ import { TerminalNode } from './TerminalNode.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { hardline } = doc.builders;
 
 export class EnumMembers extends SlangNode {
   readonly kind = NonterminalKind.EnumMembers;

--- a/src/slang-nodes/ExponentiationExpression.ts
+++ b/src/slang-nodes/ExponentiationExpression.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { group } from '../slang-printers/prettier-builders.js';
 import { createBinaryOperationPrinter } from '../slang-printers/create-binary-operation-printer.js';
 import { binaryIndentRulesBuilder } from '../slang-printers/print-binary-operation.js';
 import { createHugFunction } from '../slang-utils/create-hug-function.js';
@@ -12,8 +12,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { group } = doc.builders;
 
 const tryToHug = createHugFunction(['**']);
 

--- a/src/slang-nodes/FallbackFunctionAttributes.ts
+++ b/src/slang-nodes/FallbackFunctionAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { FallbackFunctionAttribute } from './FallbackFunctionAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class FallbackFunctionAttributes extends SlangNode {
   readonly kind = NonterminalKind.FallbackFunctionAttributes;

--- a/src/slang-nodes/ForStatement.ts
+++ b/src/slang-nodes/ForStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
@@ -12,8 +12,6 @@ import { Statement } from './Statement.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class ForStatement extends SlangNode {
   readonly kind = NonterminalKind.ForStatement;

--- a/src/slang-nodes/FunctionAttributes.ts
+++ b/src/slang-nodes/FunctionAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { FunctionAttribute } from './FunctionAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class FunctionAttributes extends SlangNode {
   readonly kind = NonterminalKind.FunctionAttributes;

--- a/src/slang-nodes/FunctionTypeAttributes.ts
+++ b/src/slang-nodes/FunctionTypeAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { FunctionTypeAttribute } from './FunctionTypeAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class FunctionTypeAttributes extends SlangNode {
   readonly kind = NonterminalKind.FunctionTypeAttributes;

--- a/src/slang-nodes/HexStringLiterals.ts
+++ b/src/slang-nodes/HexStringLiterals.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline, join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { HexStringLiteral } from './HexStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join, hardline } = doc.builders;
 
 export class HexStringLiterals extends SlangNode {
   readonly kind = NonterminalKind.HexStringLiterals;

--- a/src/slang-nodes/IdentifierPath.ts
+++ b/src/slang-nodes/IdentifierPath.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class IdentifierPath extends SlangNode {
   readonly kind = NonterminalKind.IdentifierPath;

--- a/src/slang-nodes/IfStatement.ts
+++ b/src/slang-nodes/IfStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { printIndentedGroupOrSpacedDocument } from '../slang-printers/print-indented-group-or-spaced-document.js';
 import { isBlockComment } from '../slang-utils/is-comment.js';
@@ -12,8 +12,6 @@ import { ElseBranch } from './ElseBranch.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { hardline } = doc.builders;
 
 export class IfStatement extends SlangNode {
   readonly kind = NonterminalKind.IfStatement;

--- a/src/slang-nodes/ImportDeconstructionSymbols.ts
+++ b/src/slang-nodes/ImportDeconstructionSymbols.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { satisfies } from 'semver';
+import { line, softline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { ImportDeconstructionSymbol } from './ImportDeconstructionSymbol.js';
@@ -9,8 +9,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { line, softline } = doc.builders;
 
 export class ImportDeconstructionSymbols extends SlangNode {
   readonly kind = NonterminalKind.ImportDeconstructionSymbols;

--- a/src/slang-nodes/InheritanceTypes.ts
+++ b/src/slang-nodes/InheritanceTypes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { InheritanceType } from './InheritanceType.js';
@@ -7,8 +7,6 @@ import { InheritanceType } from './InheritanceType.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class InheritanceTypes extends SlangNode {
   readonly kind = NonterminalKind.InheritanceTypes;

--- a/src/slang-nodes/InterfaceDefinition.ts
+++ b/src/slang-nodes/InterfaceDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { group, line } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { InheritanceSpecifier } from './InheritanceSpecifier.js';
@@ -8,8 +8,6 @@ import { InterfaceMembers } from './InterfaceMembers.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group, line } = doc.builders;
 
 export class InterfaceDefinition extends SlangNode {
   readonly kind = NonterminalKind.InterfaceDefinition;

--- a/src/slang-nodes/LibraryDefinition.ts
+++ b/src/slang-nodes/LibraryDefinition.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { satisfies } from 'semver';
+import { group, line } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 import { LibraryMembers } from './LibraryMembers.js';
@@ -8,8 +8,6 @@ import { LibraryMembers } from './LibraryMembers.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group, line } = doc.builders;
 
 export class LibraryDefinition extends SlangNode {
   readonly kind = NonterminalKind.LibraryDefinition;

--- a/src/slang-nodes/MemberAccessExpression.ts
+++ b/src/slang-nodes/MemberAccessExpression.ts
@@ -1,5 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import {
+  group,
+  indent,
+  label,
+  softline
+} from '../slang-printers/prettier-builders.js';
 import { isLabel } from '../slang-utils/is-label.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { isChainableExpression } from '../slang-utils/is-chainable-expression.js';
@@ -12,8 +17,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { ChainableExpression, PrintableNode } from './types.d.ts';
-
-const { group, indent, label, softline } = doc.builders;
 
 const separatorLabel = Symbol('separator');
 

--- a/src/slang-nodes/ModifierAttributes.ts
+++ b/src/slang-nodes/ModifierAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { ModifierAttribute } from './ModifierAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class ModifierAttributes extends SlangNode {
   readonly kind = NonterminalKind.ModifierAttributes;

--- a/src/slang-nodes/NamedArguments.ts
+++ b/src/slang-nodes/NamedArguments.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line, softline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { NamedArgument } from './NamedArgument.js';
@@ -8,8 +8,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { line, softline } = doc.builders;
 
 export class NamedArguments extends SlangNode {
   readonly kind = NonterminalKind.NamedArguments;

--- a/src/slang-nodes/Parameter.ts
+++ b/src/slang-nodes/Parameter.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { group } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { TypeName } from './TypeName.js';
@@ -9,8 +9,6 @@ import { TerminalNode } from './TerminalNode.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group } = doc.builders;
 
 export class Parameter extends SlangNode {
   readonly kind = NonterminalKind.Parameter;

--- a/src/slang-nodes/ReceiveFunctionAttributes.ts
+++ b/src/slang-nodes/ReceiveFunctionAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { ReceiveFunctionAttribute } from './ReceiveFunctionAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class ReceiveFunctionAttributes extends SlangNode {
   readonly kind = NonterminalKind.ReceiveFunctionAttributes;

--- a/src/slang-nodes/ReturnsDeclaration.ts
+++ b/src/slang-nodes/ReturnsDeclaration.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { group } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { ParametersDeclaration } from './ParametersDeclaration.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { group } = doc.builders;
 
 export class ReturnsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.ReturnsDeclaration;

--- a/src/slang-nodes/SourceUnit.ts
+++ b/src/slang-nodes/SourceUnit.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { SourceUnitMembers } from './SourceUnitMembers.js';
 
@@ -7,8 +7,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { line } = doc.builders;
 
 export class SourceUnit extends SlangNode {
   readonly kind = NonterminalKind.SourceUnit;

--- a/src/slang-nodes/StateVariableAttributes.ts
+++ b/src/slang-nodes/StateVariableAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { StateVariableAttribute } from './StateVariableAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class StateVariableAttributes extends SlangNode {
   readonly kind = NonterminalKind.StateVariableAttributes;

--- a/src/slang-nodes/StateVariableDefinition.ts
+++ b/src/slang-nodes/StateVariableDefinition.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { indent } from '../slang-printers/prettier-builders.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -11,8 +11,6 @@ import { StateVariableDefinitionValue } from './StateVariableDefinitionValue.js'
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { indent } = doc.builders;
 
 export class StateVariableDefinition extends SlangNode {
   readonly kind = NonterminalKind.StateVariableDefinition;

--- a/src/slang-nodes/StorageLayoutSpecifier.ts
+++ b/src/slang-nodes/StorageLayoutSpecifier.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { Expression } from './Expression.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class StorageLayoutSpecifier extends SlangNode {
   readonly kind = NonterminalKind.StorageLayoutSpecifier;

--- a/src/slang-nodes/StringLiterals.ts
+++ b/src/slang-nodes/StringLiterals.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline, join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { StringLiteral } from './StringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join, hardline } = doc.builders;
 
 export class StringLiterals extends SlangNode {
   readonly kind = NonterminalKind.StringLiterals;

--- a/src/slang-nodes/StructMembers.ts
+++ b/src/slang-nodes/StructMembers.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { StructMember } from './StructMember.js';
@@ -7,8 +7,6 @@ import { StructMember } from './StructMember.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { hardline } = doc.builders;
 
 export class StructMembers extends SlangNode {
   readonly kind = NonterminalKind.StructMembers;

--- a/src/slang-nodes/TryStatement.ts
+++ b/src/slang-nodes/TryStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -11,8 +11,6 @@ import { CatchClauses } from './CatchClauses.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class TryStatement extends SlangNode {
   readonly kind = NonterminalKind.TryStatement;

--- a/src/slang-nodes/UnicodeStringLiterals.ts
+++ b/src/slang-nodes/UnicodeStringLiterals.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline, join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { UnicodeStringLiteral } from './UnicodeStringLiteral.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join, hardline } = doc.builders;
 
 export class UnicodeStringLiterals extends SlangNode {
   readonly kind = NonterminalKind.UnicodeStringLiterals;

--- a/src/slang-nodes/UnnamedFunctionAttributes.ts
+++ b/src/slang-nodes/UnnamedFunctionAttributes.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { sortFunctionAttributes } from '../slang-utils/sort-function-attributes.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -8,8 +8,6 @@ import { UnnamedFunctionAttribute } from './UnnamedFunctionAttribute.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class UnnamedFunctionAttributes extends SlangNode {
   readonly kind = NonterminalKind.UnnamedFunctionAttributes;

--- a/src/slang-nodes/UsingDeconstructionSymbols.ts
+++ b/src/slang-nodes/UsingDeconstructionSymbols.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line, softline } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { UsingDeconstructionSymbol } from './UsingDeconstructionSymbol.js';
@@ -8,8 +8,6 @@ import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
 import type { PrintableNode } from './types.d.ts';
-
-const { line, softline } = doc.builders;
 
 export class UsingDeconstructionSymbols extends SlangNode {
   readonly kind = NonterminalKind.UsingDeconstructionSymbols;

--- a/src/slang-nodes/VariableDeclarationStatement.ts
+++ b/src/slang-nodes/VariableDeclarationStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { indent, line } from '../slang-printers/prettier-builders.js';
 import { printGroupAndIndentIfBreakPair } from '../slang-printers/print-group-and-indent-if-break-pair.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -11,8 +11,6 @@ import { VariableDeclarationValue } from './VariableDeclarationValue.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { indent, line } = doc.builders;
 
 export class VariableDeclarationStatement extends SlangNode {
   readonly kind = NonterminalKind.VariableDeclarationStatement;

--- a/src/slang-nodes/VersionExpressionSet.ts
+++ b/src/slang-nodes/VersionExpressionSet.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { VersionExpression } from './VersionExpression.js';
@@ -7,8 +7,6 @@ import { VersionExpression } from './VersionExpression.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class VersionExpressionSet extends SlangNode {
   readonly kind = NonterminalKind.VersionExpressionSet;

--- a/src/slang-nodes/VersionExpressionSets.ts
+++ b/src/slang-nodes/VersionExpressionSets.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { VersionExpressionSet } from './VersionExpressionSet.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class VersionExpressionSets extends SlangNode {
   readonly kind = NonterminalKind.VersionExpressionSets;

--- a/src/slang-nodes/YulForStatement.ts
+++ b/src/slang-nodes/YulForStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulBlock } from './YulBlock.js';
@@ -8,8 +8,6 @@ import { YulExpression } from './YulExpression.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class YulForStatement extends SlangNode {
   readonly kind = NonterminalKind.YulForStatement;

--- a/src/slang-nodes/YulLabel.ts
+++ b/src/slang-nodes/YulLabel.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { dedent, line } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { dedent, line } = doc.builders;
 
 export class YulLabel extends SlangNode {
   readonly kind = NonterminalKind.YulLabel;

--- a/src/slang-nodes/YulPath.ts
+++ b/src/slang-nodes/YulPath.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class YulPath extends SlangNode {
   readonly kind = NonterminalKind.YulPath;

--- a/src/slang-nodes/YulPaths.ts
+++ b/src/slang-nodes/YulPaths.ts
@@ -1,13 +1,11 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { SlangNode } from './SlangNode.js';
 import { YulPath } from './YulPath.js';
 
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class YulPaths extends SlangNode {
   readonly kind = NonterminalKind.YulPaths;

--- a/src/slang-nodes/YulReturnsDeclaration.ts
+++ b/src/slang-nodes/YulReturnsDeclaration.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { SlangNode } from './SlangNode.js';
 import { YulVariableNames } from './YulVariableNames.js';
@@ -7,8 +7,6 @@ import { YulVariableNames } from './YulVariableNames.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class YulReturnsDeclaration extends SlangNode {
   readonly kind = NonterminalKind.YulReturnsDeclaration;

--- a/src/slang-nodes/YulStackAssignmentStatement.ts
+++ b/src/slang-nodes/YulStackAssignmentStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedItem } from '../slang-printers/print-separated-item.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
@@ -9,8 +9,6 @@ import { TerminalNode } from './TerminalNode.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class YulStackAssignmentStatement extends SlangNode {
   readonly kind = NonterminalKind.YulStackAssignmentStatement;

--- a/src/slang-nodes/YulSwitchCases.ts
+++ b/src/slang-nodes/YulSwitchCases.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline, join } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulSwitchCase } from './YulSwitchCase.js';
@@ -7,8 +7,6 @@ import { YulSwitchCase } from './YulSwitchCase.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { hardline, join } = doc.builders;
 
 export class YulSwitchCases extends SlangNode {
   readonly kind = NonterminalKind.YulSwitchCases;

--- a/src/slang-nodes/YulSwitchStatement.ts
+++ b/src/slang-nodes/YulSwitchStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { hardline } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulExpression } from './YulExpression.js';
@@ -8,8 +8,6 @@ import { YulSwitchCases } from './YulSwitchCases.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { hardline } = doc.builders;
 
 export class YulSwitchStatement extends SlangNode {
   readonly kind = NonterminalKind.YulSwitchStatement;

--- a/src/slang-nodes/YulVariableAssignmentStatement.ts
+++ b/src/slang-nodes/YulVariableAssignmentStatement.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { join } from '../slang-printers/prettier-builders.js';
 import { extractVariant } from '../slang-utils/extract-variant.js';
 import { SlangNode } from './SlangNode.js';
 import { YulPaths } from './YulPaths.js';
@@ -9,8 +9,6 @@ import { YulExpression } from './YulExpression.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { join } = doc.builders;
 
 export class YulVariableAssignmentStatement extends SlangNode {
   readonly kind = NonterminalKind.YulVariableAssignmentStatement;

--- a/src/slang-nodes/YulVariableNames.ts
+++ b/src/slang-nodes/YulVariableNames.ts
@@ -1,5 +1,5 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { line } from '../slang-printers/prettier-builders.js';
 import { printSeparatedList } from '../slang-printers/print-separated-list.js';
 import { SlangNode } from './SlangNode.js';
 import { TerminalNode } from './TerminalNode.js';
@@ -7,8 +7,6 @@ import { TerminalNode } from './TerminalNode.js';
 import type * as ast from '@nomicfoundation/slang/ast';
 import type { AstPath, Doc } from 'prettier';
 import type { CollectedMetadata, PrintFunction } from '../types.d.ts';
-
-const { line } = doc.builders;
 
 export class YulVariableNames extends SlangNode {
   readonly kind = NonterminalKind.YulVariableNames;

--- a/src/slang-printers/create-binary-operation-printer.ts
+++ b/src/slang-printers/create-binary-operation-printer.ts
@@ -1,12 +1,10 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
+import { group, line } from './prettier-builders.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { BinaryOperation, PrintableNode } from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-
-const { group, line } = doc.builders;
 
 function rightOperandPrint(
   { operator, leftOperand }: BinaryOperation,

--- a/src/slang-printers/prettier-builders.ts
+++ b/src/slang-printers/prettier-builders.ts
@@ -1,0 +1,15 @@
+import { doc } from 'prettier';
+
+export const {
+  dedent,
+  group,
+  hardline,
+  ifBreak,
+  indent,
+  indentIfBreak,
+  join,
+  label,
+  line,
+  literalline,
+  softline
+} = doc.builders;

--- a/src/slang-printers/print-binary-operation.ts
+++ b/src/slang-printers/print-binary-operation.ts
@@ -1,14 +1,12 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { createKindCheckFunction } from '../slang-utils/create-kind-check-function.js';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
+import { group, indent } from './prettier-builders.js';
 import { createBinaryOperationPrinter } from './create-binary-operation-printer.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { BinaryOperation, PrintableNode } from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-
-const { group, indent } = doc.builders;
 
 export const binaryGroupRulesBuilder =
   (shouldGroup: (node: BinaryOperation) => boolean) =>

--- a/src/slang-printers/print-block-comment.ts
+++ b/src/slang-printers/print-block-comment.ts
@@ -1,9 +1,7 @@
-import { doc } from 'prettier';
+import { hardline, join, literalline } from './prettier-builders.js';
 
 import type { Doc } from 'prettier';
 import type { BlockComment } from '../slang-nodes/types.d.ts';
-
-const { hardline, join, literalline } = doc.builders;
 
 function trimmedIndentableLines(lines: string[]): string[] | undefined {
   // If the comment has multiple lines and every line starts with a star

--- a/src/slang-printers/print-comments.ts
+++ b/src/slang-printers/print-comments.ts
@@ -1,11 +1,10 @@
-import { doc, util } from 'prettier';
 import { printComment } from '../slang-comments/printer.js';
+import { isNextLineEmpty } from '../slang-utils/prettier-utils.js';
 import { locEnd } from '../slang-utils/loc.js';
+import { hardline } from './prettier-builders.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { Comment, PrintableNode } from '../slang-nodes/types.d.ts';
-
-const { hardline } = doc.builders;
 
 function isPrintable(comment: Comment): boolean {
   return !comment.trailing && !comment.leading && !comment.printed;
@@ -30,7 +29,7 @@ export function printComments(
       index !== lastPrintableIndex
         ? [
             hardline,
-            util.isNextLineEmpty(options.originalText, locEnd(comment))
+            isNextLineEmpty(options.originalText, locEnd(comment))
               ? hardline
               : ''
           ]

--- a/src/slang-printers/print-function.ts
+++ b/src/slang-printers/print-function.ts
@@ -1,11 +1,9 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
+import { dedent, group, indent, line } from './prettier-builders.js';
 
 import type { Doc } from 'prettier';
 import type { FunctionLike, FunctionWithBody } from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-
-const { dedent, group, indent, line } = doc.builders;
 
 export function printFunction(
   functionName: Doc,

--- a/src/slang-printers/print-group-and-indent-if-break-pair.ts
+++ b/src/slang-printers/print-group-and-indent-if-break-pair.ts
@@ -1,8 +1,6 @@
-import { doc } from 'prettier';
+import { group, indentIfBreak } from './prettier-builders.js';
 
-import type { Doc } from 'prettier';
-
-const { group, indentIfBreak } = doc.builders;
+import type { Doc, doc } from 'prettier';
 
 export function printGroupAndIndentIfBreakPair(
   groupDoc: Doc,

--- a/src/slang-printers/print-indented-group-or-spaced-document.ts
+++ b/src/slang-printers/print-indented-group-or-spaced-document.ts
@@ -1,8 +1,6 @@
-import { doc } from 'prettier';
+import { group, indent, line } from './prettier-builders.js';
 
-import type { Doc } from 'prettier';
-
-const { group, indent, line } = doc.builders;
+import type { Doc, doc } from 'prettier';
 
 export function printIndentedGroupOrSpacedDocument(
   document: Doc,

--- a/src/slang-printers/print-logical-operation.ts
+++ b/src/slang-printers/print-logical-operation.ts
@@ -1,6 +1,6 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc } from 'prettier';
 import { isBinaryOperation } from '../slang-utils/is-binary-operation.js';
+import { indent } from './prettier-builders.js';
 import { createBinaryOperationPrinter } from './create-binary-operation-printer.js';
 import {
   binaryGroupRulesBuilder,
@@ -9,8 +9,6 @@ import {
 
 import type { AstPath, Doc } from 'prettier';
 import type { BinaryOperation, PrintableNode } from '../slang-nodes/types.d.ts';
-
-const { indent } = doc.builders;
 
 const logicalGroupRulesBuilder = binaryGroupRulesBuilder(() => false);
 

--- a/src/slang-printers/print-preserving-empty-lines.ts
+++ b/src/slang-printers/print-preserving-empty-lines.ts
@@ -1,14 +1,13 @@
 import { NonterminalKind } from '@nomicfoundation/slang/cst';
-import { doc, util } from 'prettier';
+import { isNextLineEmpty } from '../slang-utils/prettier-utils.js';
 import { locEnd } from '../slang-utils/loc.js';
+import { hardline } from './prettier-builders.js';
 import { printComments } from './print-comments.js';
 import { printSeparatedItem } from './print-separated-item.js';
 
 import type { AstPath, Doc, ParserOptions } from 'prettier';
 import type { LineCollection, PrintableNode } from '../slang-nodes/types.d.ts';
 import type { PrintFunction } from '../types.d.ts';
-
-const { hardline } = doc.builders;
 
 export function printPreservingEmptyLines(
   node: LineCollection,
@@ -30,7 +29,7 @@ export function printPreservingEmptyLines(
           !isLast &&
           // Append an empty line if the original text already had an one after the
           // current `node`
-          util.isNextLineEmpty(options.originalText, locEnd(node))
+          isNextLineEmpty(options.originalText, locEnd(node))
             ? hardline
             : ''
         ];

--- a/src/slang-printers/print-separated-item.ts
+++ b/src/slang-printers/print-separated-item.ts
@@ -1,9 +1,7 @@
-import { doc } from 'prettier';
+import { group, hardline, indent, softline } from './prettier-builders.js';
 
-import type { Doc } from 'prettier';
+import type { Doc, doc } from 'prettier';
 import type { PrintSeparatedOptions } from './types.d.ts';
-
-const { group, hardline, indent, softline } = doc.builders;
 
 // This function will add an indentation to the `item` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/slang-printers/print-separated-list.ts
+++ b/src/slang-printers/print-separated-list.ts
@@ -1,10 +1,8 @@
-import { doc } from 'prettier';
+import { join, line } from './prettier-builders.js';
 import { printSeparatedItem } from './print-separated-item.js';
 
-import type { Doc } from 'prettier';
+import type { Doc, doc } from 'prettier';
 import type { PrintSeparatedOptions } from './types.d.ts';
-
-const { join, line } = doc.builders;
 
 // This function will add an indentation to the `list` and separate it from the
 // rest of the `doc` in most cases by a `softline`.

--- a/src/slang-printers/print-string.ts
+++ b/src/slang-printers/print-string.ts
@@ -1,6 +1,6 @@
-import { util } from 'prettier';
+import { makeString } from '../slang-utils/prettier-utils.js';
 
-import type { ParserOptions } from 'prettier';
+import type { ParserOptions, util } from 'prettier';
 import type { PrintableNode } from '../slang-nodes/types.d.ts';
 
 const SINGLE_QUOTE: util.Quote = "'";
@@ -30,5 +30,5 @@ export function printString(
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain
   // unnecessary escapes (such as in `"\'"`). Always using `makeString` makes
   // sure that we consistently output the minimum amount of escaped quotes.
-  return util.makeString(rawContent, enclosingQuote);
+  return makeString(rawContent, enclosingQuote);
 }

--- a/src/slang-utils/prettier-utils.ts
+++ b/src/slang-utils/prettier-utils.ts
@@ -1,0 +1,10 @@
+import { util } from 'prettier';
+
+export const {
+  addDanglingComment,
+  addLeadingComment,
+  addTrailingComment,
+  getNextNonSpaceNonCommentCharacter,
+  isNextLineEmpty,
+  makeString
+} = util;


### PR DESCRIPTION
slight performance improvement at the beginning of the runtime and smaller file size since every time we destructure an object, we have to name the attribute and we can't minimize that.