### PR TITLE
Removing GitPOAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/prettier-solidity/prettier-plugin-solidity/actions/workflows/CI.yml/badge.svg)](https://github.com/prettier-solidity/prettier-plugin-solidity/actions)
 [![Telegram](/assets/telegram-badge.svg)](https://t.me/+kgTgkFgIwJkwMjcx)
 [![Twitter Follow](https://img.shields.io/twitter/follow/PrettierSol.svg?style=social)](https://x.com/PrettierSol)
-[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/prettier-solidity/prettier-plugin-solidity/badge)](https://www.gitpoap.io/gh/prettier-solidity/prettier-plugin-solidity)
 
 <p align="center">
   <img width="375" height="375" src="https://user-images.githubusercontent.com/1022054/59317198-f1149b80-8d15-11e9-9b0f-0c5e7d4b8b81.png">


### PR DESCRIPTION
GitPOAP closed on [04 of August 2026](https://www.kucoin.com/news/flash/poap-announces-official-shutdown-after-over-five-years-of-operations)