### PR TITLE
bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prettier-plugin-solidity",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@nomicfoundation/slang": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-plugin-solidity",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A Prettier Plugin for automatically formatting your Solidity code.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The latest slang  has a [valid format case](https://github.com/prettier-solidity/prettier-plugin-solidity/pull/1666/changes) that wasn't supported before by the parser so we need to publish a patch with this case.