### PR TITLE
updating the format test framework to mirror prettier

### DIFF
--- a/tests/config/constants.js
+++ b/tests/config/constants.js
@@ -4,7 +4,7 @@ import { normalizeDirectory } from "./utilities.js";
 
 const { __dirname } = createEsmUtils(import.meta);
 
-export const FORMAT_SCRIPT_FILENAME = "format.test.js";
+export const FORMAT_TEST_SCRIPT_FILENAME = "format.test.js";
 
 export const FORMAT_TEST_DIRECTORY = normalizeDirectory(
   path.join(__dirname, "../format/"),

--- a/tests/config/get-fixtures.js
+++ b/tests/config/get-fixtures.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { FORMAT_SCRIPT_FILENAME } from "./constants.js";
+import { FORMAT_TEST_SCRIPT_FILENAME } from "./constants.js";
 import visualizeEndOfLine from "./visualize-end-of-line.js";
 
 /**
@@ -23,18 +23,18 @@ function* getFiles(context) {
   const { dirname } = context;
   for (const file of fs.readdirSync(dirname, { withFileTypes: true })) {
     const filename = file.name;
-    const filepath = path.join(dirname, filename);
     if (
       !file.isFile() ||
       filename[0] === "." ||
-      filename === FORMAT_SCRIPT_FILENAME ||
-      // VSCode creates this file sometime https://github.com/microsoft/vscode/issues/105191
+      filename === FORMAT_TEST_SCRIPT_FILENAME ||
+      // VS Code creates this file sometime https://github.com/microsoft/vscode/issues/105191
       filename === "debug.log" ||
       path.extname(filename) === ".snap"
     ) {
       continue;
     }
 
+    const filepath = path.join(dirname, filename);
     const text = fs.readFileSync(filepath, "utf8");
 
     yield {

--- a/tests/config/run-format-test.js
+++ b/tests/config/run-format-test.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import url from "node:url";
-import { FORMAT_SCRIPT_FILENAME } from "./constants.js";
+import { FORMAT_TEST_SCRIPT_FILENAME } from "./constants.js";
 import { getFixtures } from "./get-fixtures.js";
 import { testFixture } from "./run-test.js";
 import { stringifyOptionsForTitle } from "./stringify-options-for-title.js";
@@ -39,9 +39,9 @@ function runFormatTest(rawFixtures, explicitParsers, rawOptions) {
     : { importMeta: rawFixtures };
 
   const filename = path.basename(new URL(importMeta.url).pathname);
-  if (filename !== FORMAT_SCRIPT_FILENAME) {
+  if (filename !== FORMAT_TEST_SCRIPT_FILENAME) {
     throw new Error(
-      `Format test should run in file named '${FORMAT_SCRIPT_FILENAME}'.`,
+      `Format test should run in file named '${FORMAT_TEST_SCRIPT_FILENAME}'.`,
     );
   }
 

--- a/tests/config/visualize-range.js
+++ b/tests/config/visualize-range.js
@@ -1,5 +1,6 @@
 import indexToPosition from "index-to-position";
 import { codeFrameColumns } from "@babel/code-frame";
+
 const codeFrameColumnsOptions = {
   linesAbove: Number.POSITIVE_INFINITY,
   linesBelow: Number.POSITIVE_INFINITY,
@@ -8,11 +9,7 @@ const codeFrameColumnsOptions = {
 const locationForRange = (text, range) => {
   const [start, end] = [...range]
     .sort((indexA, indexB) => indexA - indexB)
-    .map((index) => indexToPosition(text, index, { oneBased: true }));
-
-  if (start.line !== end.line) {
-    end.column -= 1;
-  }
+    .map((index) => indexToPosition(text, index, { oneBasedLine: true }));
 
   return { start, end };
 };


### PR DESCRIPTION
small changes that have happened in the prettier's test config:


- `FORMAT_SCRIPT_FILENAME` renamed to `FORMAT_TEST_SCRIPT_FILENAME` https://github.com/prettier/prettier/pull/19285
- move unneeded variable declarations after a possible `continue`  https://github.com/prettier/prettier/pull/19371
- cleaner calculation for range (we are not using this yet but better keep up for when it's available) https://github.com/prettier/prettier/pull/19340